### PR TITLE
Merge a handful of features in support of v0.5

### DIFF
--- a/natlas-agent/natlas-agent.py
+++ b/natlas-agent/natlas-agent.py
@@ -59,6 +59,7 @@ def scan():
     # print(out)
 
     result = {}
+    result['scan_id'] = rand
     for ext in 'nmap', 'gnmap', 'xml':
         result[ext+"_data"] = open("data/natlas."+rand+"."+ext).read()
         os.remove("data/natlas."+rand+"."+ext)

--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -25,7 +25,7 @@ db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 ScopeManager = ScopeManager()
 
-from app import routes, models
+from app import routes, models, filters
 
 # super gross hack that enables flask db operations when the databse doesn't already exist
 try:

--- a/natlas-server/app/elastic.py
+++ b/natlas-server/app/elastic.py
@@ -51,6 +51,14 @@ class Elastic:
 
         return result['hits']['total'], results
 
+    def gethost_scan_id(self, ip, scan_id):
+        result = self.es.search(index='nmap_history', doc_type='_doc', body={"size": 1, "query": {
+                                "query_string": {'query': scan_id, "fields": ["scan_id"], "default_operator": "AND"}}, "sort": {"ctime": {"order": "desc"}}})
+
+        if result['hits']['total'] == 0:
+            return 0, None
+        return result['hits']['total'], result['hits']['hits'][0]['_source']
+
     def getwork_mass(self):  # getwork when masscan data is loaded
 
         # get random ip

--- a/natlas-server/app/filters.py
+++ b/natlas-server/app/filters.py
@@ -1,0 +1,6 @@
+from app import app
+from datetime import datetime
+
+@app.template_filter('ctime')
+def ctime(s):
+    return datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f').strftime("%Y-%m-%d")

--- a/natlas-server/app/routes.py
+++ b/natlas-server/app/routes.py
@@ -459,6 +459,15 @@ def host_history(ip):
 
     return render_template("host/history.html", ip=ip, info=info, page=page, hosts=context, next_url=next_url, prev_url=prev_url)
 
+@app.route('/host/<ip>/history/<scan_id>')
+@isAuthenticated
+def host_historical_result(ip, scan_id):
+    info, context = hostinfo(ip)
+    
+    count, context = elastic.gethost_scan_id(
+        ip, scan_id)
+
+    return render_template("host/summary.html", info=info, **context)
 
 @app.route('/host/<ip>/headshots')
 @isAuthenticated

--- a/natlas-server/app/routes.py
+++ b/natlas-server/app/routes.py
@@ -1,5 +1,5 @@
 import flask
-from flask import render_template, request, Flask, g, url_for, flash, redirect, abort
+from flask import render_template, request, Flask, g, url_for, flash, redirect, abort, Response
 from flask_login import current_user, login_user, logout_user
 from werkzeug.urls import url_parse
 from netaddr import *
@@ -428,7 +428,10 @@ def search():
 
     # what kind of output are we looking for?
     if format == 'hostlist':
-        return render_template("hostlist.html", query=query, numresults=count, page=page, hosts=context)
+        hostlist = []
+        for host in context:
+            hostlist.append(str(host['ip']))
+        return Response('\n'.join(hostlist), mimetype='text/plain')
     else:
         return render_template("search.html", query=query, numresults=count, page=page, hosts=context, next_url=next_url, prev_url=prev_url)
 

--- a/natlas-server/app/routes.py
+++ b/natlas-server/app/routes.py
@@ -438,6 +438,7 @@ def search():
 
 # Create your views here.
 @app.route('/host/<ip>')
+@app.route('/host/<ip>/')
 @isAuthenticated
 def host(ip):
     info, context = hostinfo(ip)
@@ -445,6 +446,7 @@ def host(ip):
 
 
 @app.route('/host/<ip>/history')
+@app.route('/host/<ip>/history/')
 @isAuthenticated
 def host_history(ip):
     info, context = hostinfo(ip)
@@ -462,19 +464,44 @@ def host_history(ip):
 
     return render_template("host/history.html", ip=ip, info=info, page=page, hosts=context, next_url=next_url, prev_url=prev_url)
 
-@app.route('/host/<ip>/history/<scan_id>')
+@app.route('/host/<ip>/<scan_id>')
 @isAuthenticated
 def host_historical_result(ip, scan_id):
+
     info, context = hostinfo(ip)
+    count, context = elastic.gethost_scan_id(
+        ip, scan_id)
+    return render_template("host/summary.html", info=info, **context)
+
+@app.route('/host/<ip>/<scan_id>.xml')
+@isAuthenticated
+def export_scan_xml(ip, scan_id):
     
     count, context = elastic.gethost_scan_id(
         ip, scan_id)
+    return Response(context['xml_data'], mimetype="text/plain")
 
-    return render_template("host/summary.html", info=info, **context)
+@app.route('/host/<ip>/<scan_id>.nmap')
+@isAuthenticated
+def export_scan_nmap(ip, scan_id):
+    
+    count, context = elastic.gethost_scan_id(
+        ip, scan_id)
+    return Response(context['nmap_data'], mimetype="text/plain")
+
+@app.route('/host/<ip>/<scan_id>.gnmap')
+@isAuthenticated
+def export_scan_gnmap(ip, scan_id):
+    
+    count, context = elastic.gethost_scan_id(
+        ip, scan_id)
+    return Response(context['gnmap_data'], mimetype="text/plain")
 
 @app.route('/host/<ip>/headshots')
+@app.route('/host/<ip>/headshots/')
 @isAuthenticated
 def host_headshots(ip):
+
     info, context = hostinfo(ip)
     return render_template("host/headshots.html", **context, info=info)
 

--- a/natlas-server/app/templates/admin/scope.html
+++ b/natlas-server/app/templates/admin/scope.html
@@ -35,8 +35,8 @@
         <tr>
           <th scope="row">{{ item.id }}</th>
           <td>{{ item.target }}</td>
-          <td><form method="POST" action="{{ url_for('deleteScopeItem', id=item.id) }}">{{ delForm.hidden_tag() }} {{ delForm.deleteScopeItem(class="btn btn-danger") }}</form></td>
-          <td><form method="POST" action="{{ url_for('toggleScopeItem', id=item.id) }}">{{ editForm.hidden_tag() }}{{ editForm.toggleScopeItem(class="btn btn-warning") }}</form></td>
+          <td><form method="POST" action="{{ url_for('deleteScopeItem', id=item.id) }}">{{ delForm.hidden_tag() }} {{ delForm.deleteScopeItem(class="btn btn-danger", onclick="return confirm('Are you sure you want to delete this scope item?')") }}</form></td>
+          <td><form method="POST" action="{{ url_for('toggleScopeItem', id=item.id) }}">{{ editForm.hidden_tag() }}{{ editForm.toggleScopeItem(class="btn btn-warning", onclick="return confirm('Are you sure you want to toggle the blacklist status for this scope item?')") }}</form></td>
         </tr>
         {% endfor %}
       </tbody>

--- a/natlas-server/app/templates/admin/users.html
+++ b/natlas-server/app/templates/admin/users.html
@@ -37,8 +37,8 @@
         <tr>
           <th scope="row">{{ user.id }}</th>
           <td>{{ user.email }}{% if user.is_admin %} <span class="badge">admin</span>{% endif %}</td>
-          <td><form method="POST" action="{{ url_for('deleteUser', id=user.id) }}">{{ delForm.hidden_tag() }} {{ delForm.deleteUser(class="btn btn-danger") }}</form></td>
-          <td><form method="POST" action="{{ url_for('toggleUser', id=user.id) }}">{{ editForm.hidden_tag() }}{{ editForm.editUser(class="btn btn-warning") }}</form></td>
+          <td><form method="POST" action="{{ url_for('deleteUser', id=user.id) }}">{{ delForm.hidden_tag() }} {{ delForm.deleteUser(class="btn btn-danger", onclick="return confirm('Are you sure you want to delete this user?')") }}</form></td>
+          <td><form method="POST" action="{{ url_for('toggleUser', id=user.id) }}">{{ editForm.hidden_tag() }}{{ editForm.editUser(class="btn btn-warning", onclick="return confirm('Are you sure you want to make this user an admin?')") }}</form></td>
         </tr>
         {% endfor %}
       </tbody>

--- a/natlas-server/app/templates/host/history.html
+++ b/natlas-server/app/templates/host/history.html
@@ -20,9 +20,9 @@
                 <h4>Scan ID</h4> 
                 <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a>
                 <h4>Export</h4>
-                <a href="{{ url_for('export_scan_xml', ip=host.ip, scan_id=host.scan_id) }}">XML</a> - 
-                <a href="{{ url_for('export_scan_nmap', ip=host.ip, scan_id=host.scan_id) }}">nmap</a> -
-                <a href="{{ url_for('export_scan_gnmap', ip=host.ip, scan_id=host.scan_id) }}">gnmap</a>
+                <a class="btn btn-primary" href="{{ url_for('export_scan_xml', ip=host.ip, scan_id=host.scan_id) }}">XML</a>
+                <a class="btn btn-primary" href="{{ url_for('export_scan_nmap', ip=host.ip, scan_id=host.scan_id) }}">nmap</a>
+                <a class="btn btn-primary" href="{{ url_for('export_scan_gnmap', ip=host.ip, scan_id=host.scan_id) }}">gnmap</a>
                 {% endif %}
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>

--- a/natlas-server/app/templates/host/history.html
+++ b/natlas-server/app/templates/host/history.html
@@ -12,13 +12,17 @@
               <td>
                 <h4>Open Ports</h4>
                 {{ host.ports }}<br>
-                {% if host.scan_id %}
-                <h4>Scan ID</h4> 
-                <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a><br>
-                {% endif %}
                 {% if host.ctime %}
                 <h4>Date Added</h4>
                 {{ host.ctime | ctime }}
+                {% endif %}
+                {% if host.scan_id %}
+                <h4>Scan ID</h4> 
+                <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a>
+                <h4>Export</h4>
+                <a href="{{ url_for('export_scan_xml', ip=host.ip, scan_id=host.scan_id) }}">XML</a> - 
+                <a href="{{ url_for('export_scan_nmap', ip=host.ip, scan_id=host.scan_id) }}">nmap</a> -
+                <a href="{{ url_for('export_scan_gnmap', ip=host.ip, scan_id=host.scan_id) }}">gnmap</a>
                 {% endif %}
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>

--- a/natlas-server/app/templates/host/history.html
+++ b/natlas-server/app/templates/host/history.html
@@ -10,12 +10,16 @@
           {% for host in hosts %}
             <tr>
               <td>
-                <h3>{{ host.ip }}</h3><br>
-                <h5>hostname: {{ host.hostname }}<br>
-                open ports: {{ host.ports }}<br>
+                <h4>Open Ports</h4>
+                {{ host.ports }}<br>
                 {% if host.scan_id %}
-                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a>
-                {% endif %}</h5>
+                <h4>Scan ID</h4> 
+                <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a><br>
+                {% endif %}
+                {% if host.ctime %}
+                <h4>Date Added</h4>
+                {{ host.ctime | ctime }}
+                {% endif %}
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>
                   <img width=200 src="data:image/jpeg;base64,{{ host.headshot }}"></br>

--- a/natlas-server/app/templates/host/history.html
+++ b/natlas-server/app/templates/host/history.html
@@ -12,7 +12,10 @@
               <td>
                 <h3>{{ host.ip }}</h3><br>
                 <h5>hostname: {{ host.hostname }}<br>
-                open ports: {{ host.ports }}</h5>
+                open ports: {{ host.ports }}<br>
+                {% if host.scan_id %}
+                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a>
+                {% endif %}</h5>
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>
                   <img width=200 src="data:image/jpeg;base64,{{ host.headshot }}"></br>
@@ -40,7 +43,7 @@
                       {% endif %}
                     {% endfor %}
                     <pre class="nmap_data">{{ nmap_preview|join('\n') }}</pre>
-                    <a class="preview_link" href="host?h={{ host.ip }}"><div class="preview_nmap">Click here to see the complete results for {{ host.ip }}</div></a>
+                    <a class="preview_link" href="host/{{ host.ip }}"><div class="preview_nmap">Click here to see the complete results for {{ host.ip }}</div></a>
                   {% else %}
                     <pre class="nmap_data">{{ host.nmap_data }}</pre>
                   {% endif %}

--- a/natlas-server/app/templates/host/summary.html
+++ b/natlas-server/app/templates/host/summary.html
@@ -19,9 +19,9 @@
                 <h4>Scan ID</h4> 
                 <a href="{{ url_for('host_historical_result', ip=ip, scan_id=scan_id) }}">{{ scan_id }}</a>
                 <h4>Export</h4>
-                <a href="{{ url_for('export_scan_xml', ip=ip, scan_id=scan_id) }}">XML</a> - 
-                <a href="{{ url_for('export_scan_nmap', ip=ip, scan_id=scan_id) }}">nmap</a> -
-                <a href="{{ url_for('export_scan_gnmap', ip=ip, scan_id=scan_id) }}">gnmap</a>
+                <a class="btn btn-primary" href="{{ url_for('export_scan_xml', ip=ip, scan_id=scan_id) }}">XML</a>
+                <a class="btn btn-primary" href="{{ url_for('export_scan_nmap', ip=ip, scan_id=scan_id) }}">nmap</a>
+                <a class="btn btn-primary" href="{{ url_for('export_scan_gnmap', ip=ip, scan_id=scan_id) }}">gnmap</a>
                 {% endif %}
                 {% if headshot %}
                   <h5>Unknown Headshot</h5>

--- a/natlas-server/app/templates/host/summary.html
+++ b/natlas-server/app/templates/host/summary.html
@@ -11,13 +11,17 @@
               <td>
                 <h4>Open Ports</h4>
                 {{ ports }}<br>
-                {% if scan_id %}
-                <h4>Scan ID</h4> 
-                <a href="{{ url_for('host_historical_result', ip=ip, scan_id=scan_id) }}">{{ scan_id }}</a><br>
-                {% endif %}
                 {% if ctime %}
                 <h4>Date Added</h4>
                 {{ ctime | ctime }}
+                {% endif %}
+                {% if scan_id %}
+                <h4>Scan ID</h4> 
+                <a href="{{ url_for('host_historical_result', ip=ip, scan_id=scan_id) }}">{{ scan_id }}</a>
+                <h4>Export</h4>
+                <a href="{{ url_for('export_scan_xml', ip=ip, scan_id=scan_id) }}">XML</a> - 
+                <a href="{{ url_for('export_scan_nmap', ip=ip, scan_id=scan_id) }}">nmap</a> -
+                <a href="{{ url_for('export_scan_gnmap', ip=ip, scan_id=scan_id) }}">gnmap</a>
                 {% endif %}
                 {% if headshot %}
                   <h5>Unknown Headshot</h5>

--- a/natlas-server/app/templates/host/summary.html
+++ b/natlas-server/app/templates/host/summary.html
@@ -4,8 +4,46 @@
 {% block content %}
   <div class="row">
     {% include 'includes/host_header.html' %}
-    {% if nmap_data|length > 0 %}
-    <pre class="nmap_data">{{ nmap_data }}</pre>
-    {% endif %}
-  </div>
+	<div class="table-responsive">
+      <table class="table table-striped">
+        <tbody>
+            <tr>
+              <td>
+                <h4>Open Ports</h4>
+                {{ ports }}<br>
+                {% if scan_id %}
+                <h4>Scan ID</h4> 
+                <a href="{{ url_for('host_historical_result', ip=ip, scan_id=scan_id) }}">{{ scan_id }}</a><br>
+                {% endif %}
+                {% if ctime %}
+                <h4>Date Added</h4>
+                {{ ctime | ctime }}
+                {% endif %}
+                {% if headshot %}
+                  <h5>Unknown Headshot</h5>
+                  <img width=200 src="data:image/jpeg;base64,{{ headshot }}"></br>
+                {% endif %}
+                {% if vncheadshot %}
+                  <h5>VNC</h5>
+                  <img width=200 src="data:image/jpeg;base64,{{ vncheadshot }}"></br>
+                {% endif %}
+                {% if httpheadshot %}
+                  <h5>HTTP</h5>
+                  <img width=200 src="data:image/jpeg;base64,{{ httpheadshot }}"></br>
+                {% endif %}
+                {% if httpsheadshot %}
+                  <h5>HTTPS</h5>
+                  <img width=200 src="data:image/jpeg;base64,{{ httpsheadshot }}"></br>
+                {% endif %}
+              </td>
+              <td>
+              	{% if nmap_data|length > 0 %}
+    			<pre class="nmap_data">{{ nmap_data }}</pre>
+    			{% endif %}
+              </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+</div>
 {% endblock %}

--- a/natlas-server/app/templates/hostlist.html
+++ b/natlas-server/app/templates/hostlist.html
@@ -1,5 +1,0 @@
-<pre>
-{% for host in hosts %}
-{{host.ip}}
-{% endfor %}
-</pre>

--- a/natlas-server/app/templates/search.html
+++ b/natlas-server/app/templates/search.html
@@ -25,7 +25,10 @@
                 <h5>hostname: {{ host.hostname }}<br>
                 open ports: {{ host.ports }}<br>
                 {% if host.scan_id %}
-                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a>
+                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a><br/>
+                {% endif %}
+                {% if host.ctime %}
+                Added: {{ host.ctime | ctime }}
                 {% endif %}</h5>
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>

--- a/natlas-server/app/templates/search.html
+++ b/natlas-server/app/templates/search.html
@@ -21,15 +21,19 @@
           {% for host in hosts %}
             <tr>
               <td>
-                <h3><a href="{{ url_for('host', ip=host.ip) }}">{{ host.ip }}</a></h3><br>
+                <h3><a href="{{ url_for('host', ip=host.ip) }}">{{ host.ip }}</a></h3>
                 <h5>hostname: {{ host.hostname }}<br>
                 open ports: {{ host.ports }}<br>
-                {% if host.scan_id %}
-                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a><br/>
-                {% endif %}
                 {% if host.ctime %}
-                Added: {{ host.ctime | ctime }}
-                {% endif %}</h5>
+                Added: {{ host.ctime | ctime }}<br>
+                {% endif %}
+                {% if host.scan_id %}
+                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a><br>
+                Export: <a href="{{ url_for('export_scan_xml', ip=host.ip, scan_id=host.scan_id) }}">XML</a> - 
+                <a href="{{ url_for('export_scan_nmap', ip=host.ip, scan_id=host.scan_id) }}">nmap</a> -
+                <a href="{{ url_for('export_scan_gnmap', ip=host.ip, scan_id=host.scan_id) }}">gnmap</a>
+                {% endif %}
+                </h5>
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>
                   <img width=200 src="data:image/jpeg;base64,{{ host.headshot }}"></br>

--- a/natlas-server/app/templates/search.html
+++ b/natlas-server/app/templates/search.html
@@ -23,7 +23,10 @@
               <td>
                 <h3><a href="{{ url_for('host', ip=host.ip) }}">{{ host.ip }}</a></h3><br>
                 <h5>hostname: {{ host.hostname }}<br>
-                open ports: {{ host.ports }}</h5>
+                open ports: {{ host.ports }}<br>
+                {% if host.scan_id %}
+                Scan ID: <a href="{{ url_for('host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">{{ host.scan_id }}</a>
+                {% endif %}</h5>
                 {% if host.headshot %}
                   <h5>Unknown Headshot</h5>
                   <img width=200 src="data:image/jpeg;base64,{{ host.headshot }}"></br>
@@ -51,7 +54,7 @@
                       {% endif %}
                     {% endfor %}
                     <pre class="nmap_data">{{ nmap_preview|join('\n') }}</pre>
-                    <a class="preview_link" href="host?h={{ host.ip }}"><div class="preview_nmap">Click here to see the complete results for {{ host.ip }}</div></a>
+                    <a class="preview_link" href="host/{{ host.ip }}"><div class="preview_nmap">Click here to see the complete results for {{ host.ip }}</div></a>
                   {% else %}
                     <pre class="nmap_data">{{ host.nmap_data }}</pre>
                   {% endif %}


### PR DESCRIPTION
Implemented functionality to address scans individually, which enabled individual scan exporting. Cleaned up mimetype for exporting hostlists from search queries so that scripts can more easily automate this and it still appears correct in the browser.