### PR TITLE
Fix add scope when no tags are defined for a scope item.

### DIFF
--- a/natlas-server/app/models.py
+++ b/natlas-server/app/models.py
@@ -135,6 +135,7 @@ class ScopeItem(db.Model):
 			tags = line.split(',')[1:]
 		else:
 			ip = line
+			tags = []
 
 		if '/' not in ip:
 			ip = ip + '/32'


### PR DESCRIPTION
Closes #196. Accidentally referenced a variable that wasn't always assigned.