### PR TITLE
Enable CircleCI and enforce flake8 for agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2.1
+orbs:
+  flake8: arrai/flake8@5.0.0
+jobs:
+  general-analysis:
+    docker:
+      - image: circleci/python:3.6.1
+    working_directory: ~/repo
+    steps:
+      - checkout:
+          path: ~/repo
+
+      - flake8/setup_flake8:
+          wd: ~/repo/natlas-agent
+      - flake8/flake8_errors:
+          wd: ~/repo/natlas-agent
+workflows:
+  version: 2
+  normal-build:
+    jobs:
+      - general-analysis

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# W191 - Tabs over spaces
+# E261 - Two spaces before comments
+# E117 - Indention levels
+
+ignore = W191, E261, E117
+max-line-length = 160

--- a/natlas-agent/config.py
+++ b/natlas-agent/config.py
@@ -1,10 +1,11 @@
 import os
 from dotenv import load_dotenv
 
+
 class Config:
 
 	# Current Version
-	NATLAS_VERSION="0.6.7"
+	NATLAS_VERSION = "0.6.7"
 
 	BASEDIR = os.path.abspath(os.path.dirname(__file__))
 	load_dotenv(os.path.join(BASEDIR, '.env'))

--- a/natlas-agent/natlas-agent.py
+++ b/natlas-agent/natlas-agent.py
@@ -13,13 +13,14 @@ from config import Config
 from natlas.threadscan import ThreadScan
 from natlas.net import NatlasNetworkServices
 
-ERR = {"INVALIDTARGET":1,"SCANTIMEOUT":2, "DATANOTFOUND":3, "INVALIDDATA": 4}
+ERR = {"INVALIDTARGET": 1, "SCANTIMEOUT": 2, "DATANOTFOUND": 3, "INVALIDDATA": 4}
 
 config = Config()
 MAX_QUEUE_SIZE = int(config.max_threads) # only queue enough work for each of our active threads
 
 global_logger = logging.get_logger("MainThread")
 netsrv = NatlasNetworkServices(config)
+
 
 def add_targets_to_queue(target, q):
 	targetNetwork = ipaddress.ip_interface(target.strip())

--- a/natlas-agent/natlas/logging.py
+++ b/natlas-agent/natlas/logging.py
@@ -7,20 +7,24 @@ from logging.handlers import RotatingFileHandler
 FORMATTER = logging.Formatter("%(asctime)s — %(name)s — %(levelname)s — %(message)s")
 logging.Formatter.converter = time.gmtime # Always log in GMT
 
+
 def setup_logging_dir():
 	if not os.path.isdir("logs"):
 		os.mkdir("logs")
 	return True
+
 
 def get_console_handler():
 	console_handler = logging.StreamHandler(sys.stdout)
 	console_handler.setFormatter(FORMATTER)
 	return console_handler
 
+
 def get_file_handler():
-	file_handler = RotatingFileHandler("logs/agent.log", maxBytes=1024*1024, backupCount=5)
+	file_handler = RotatingFileHandler("logs/agent.log", maxBytes=1024 * 1024, backupCount=5)
 	file_handler.setFormatter(FORMATTER)
 	return file_handler
+
 
 def get_logger(name):
 	setup_logging_dir()

--- a/natlas-agent/natlas/scanresult.py
+++ b/natlas-agent/natlas/scanresult.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+
 class ScanResult:
 
 	def __init__(self, target_data, config):

--- a/natlas-agent/natlas/screenshots.py
+++ b/natlas-agent/natlas/screenshots.py
@@ -9,6 +9,7 @@ from natlas import utils
 
 logger = logging.get_logger("ScreenshotUtils")
 
+
 def get_web_screenshots(target, scan_id, services, proctimeout):
 	data_dir = utils.get_data_dir(scan_id)
 	outFiles = f"{data_dir}/aquatone.{scan_id}"
@@ -19,15 +20,15 @@ def get_web_screenshots(target, scan_id, services, proctimeout):
 	if inputstring:
 		inputstring = inputstring[:-1] # trim trailing newline because otherwise chrome spits garbage into localhost for some reason
 
-	logger.info("Attempting to take %s screenshot(s) for %s" % (', '.join(services).upper(),target))
+	logger.info("Attempting to take %s screenshot(s) for %s" % (', '.join(services).upper(), target))
 
 	p1 = subprocess.Popen(["echo", inputstring], stdout=subprocess.PIPE) # nosec
 	process = subprocess.Popen(["aquatone", "-scan-timeout", "2500", "-out", outFiles], stdin=p1.stdout, stdout=subprocess.DEVNULL) # nosec
 	p1.stdout.close()
 
 	try:
-		out,err = process.communicate(timeout=proctimeout)
-		if process.returncode is 0:
+		out, err = process.communicate(timeout=proctimeout)
+		if process.returncode == 0:
 			time.sleep(0.5) # a small sleep to make sure all file handles are closed so that the agent can read them
 			return True
 	except subprocess.TimeoutExpired:
@@ -35,6 +36,7 @@ def get_web_screenshots(target, scan_id, services, proctimeout):
 		process.kill()
 
 	return False
+
 
 def get_vnc_screenshots(target, scan_id, proctimeout):
 	if "DISPLAY" not in os.environ:
@@ -48,7 +50,7 @@ def get_vnc_screenshots(target, scan_id, proctimeout):
 	process = subprocess.Popen(["xvfb-run", "vncsnapshot", "-quality", "50", target, outFile], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) # nosec
 	try:
 		out, err = process.communicate(timeout=proctimeout)
-		if process.returncode is 0:
+		if process.returncode == 0:
 			return True
 	except Exception:
 		try:

--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -15,6 +15,7 @@ from natlas import utils
 
 logger = logging.get_logger("AgentThread")
 
+
 def command_builder(scan_id, agentConfig, target):
 	outFiles = utils.get_data_dir(scan_id) + f"/nmap.{scan_id}"
 	command = ["nmap", "--privileged", "-oA", outFiles, "--servicedb", "./tmp/natlas-services"]
@@ -31,7 +32,7 @@ def command_builder(scan_id, agentConfig, target):
 		"hostTimeout": "--host-timeout={hostTimeout}"
 	}
 
-	for k,v in agentConfig.items():
+	for k, v in agentConfig.items():
 		if agentConfig[k] and k in commandDict:
 			command.append(commandDict[k].format(**agentConfig))
 
@@ -56,7 +57,7 @@ def scan(target_data, config):
 	result = ScanResult(target_data, config)
 
 	try:
-		process = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=int(agentConfig["scanTimeout"])) # nosec
+		subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=int(agentConfig["scanTimeout"])) # nosec
 	except subprocess.TimeoutExpired:
 		result.add_item('timed_out', True)
 		logger.warning("TIMEOUT: Nmap against %s (%s)" % (target, scan_id))
@@ -67,7 +68,7 @@ def scan(target_data, config):
 	for ext in 'nmap', 'gnmap', 'xml':
 		path = f"{data_dir}/nmap.{scan_id}.{ext}"
 		try:
-			result.add_item(ext+"_data", open(path).read())
+			result.add_item(ext + "_data", open(path).read())
 		except Exception:
 			logger.warning(f"Couldn't read {path}")
 			return False
@@ -98,9 +99,8 @@ def scan(target_data, config):
 		result.is_up(nmap_report.hosts[0].is_up())
 		result.add_item('port_count', len(nmap_report.hosts[0].get_ports()))
 
-
 	if agentConfig["webScreenshots"] and shutil.which("aquatone") is not None:
-		targetServices=[]
+		targetServices = []
 		if "80/tcp" in result.result['nmap_data']:
 			targetServices.append("http")
 		if "443/tcp" in result.result['nmap_data']:
@@ -167,7 +167,7 @@ class ThreadScan(threading.Thread):
 				if target_data and target_data["services_hash"] != self.servicesSha:
 					self.servicesSha = self.netsrv.get_services_file()
 					if not self.servicesSha:
-						logger.warning("Failed to get updated services from %s" % config.server)
+						logger.warning("Failed to get updated services from %s" % self.config.server)
 
 				utils.create_data_dir(target_data['scan_id'])
 				result = scan(target_data, self.config)
@@ -183,7 +183,7 @@ class ThreadScan(threading.Thread):
 					utils.cleanup_files(target_data['scan_id'])
 
 		else:
-			#If we're not in auto mode, then the queue is populated with work from local data
+			# If we're not in auto mode, then the queue is populated with work from local data
 			while True:
 				logger.info("Fetching work from queue")
 				target_data = self.queue.get()

--- a/natlas-agent/natlas/utils.py
+++ b/natlas-agent/natlas/utils.py
@@ -1,9 +1,6 @@
 import ipaddress
-import string
-import random
 import os
 import shutil
-import glob
 
 from natlas import logging
 

--- a/natlas-server/elastic-snapshot.py
+++ b/natlas-server/elastic-snapshot.py
@@ -4,6 +4,7 @@ from elasticsearch import Elasticsearch, exceptions
 from datetime import datetime
 import argparse
 
+
 def main():
 	parser_desc = "Server-side utility for creating and restoring elastic snapshots. NOTE: Be sure to set path.repo in elasticsearch.yml before attempting to use this tool."
 	parser_epil = "Be sure that you're running this from within the virtual environment for the server."


### PR DESCRIPTION
Let's improve code quality and standardize code conventions of all new code. This enables CircleCI and enforces that **the natlas-agent/*** code must follow flake8 (with a few ignored rules.) Why not natlas-server you ask? Good question, there's too many issues for now in natlas-server and I'd prefer to fix that in a phase 2.

After this PR is approved and merged, I'll enable CircleCI for this repository. We'll then get green checks or red x's for any failing code.