### PR TITLE
Elastic changes

### DIFF
--- a/natlas-server/README.md
+++ b/natlas-server/README.md
@@ -1,24 +1,25 @@
 # natlas-server
 
-Installing Elasticsearch
-------------------------
+## Installing Elasticsearch
+
 Natlas uses Elasticsearch 6.6 to store all of the scan results. If you want to run Elasticsearch locally on your natlas-server, simply run the `./setup-elastic.sh` script.
 
 Alternatively, if you already have an elastic cluster that you'd like to use, you can add it to the `.env` file with the name `ELASTICSEARCH_URL`.
 
 
-The Setup
-------------------
+## The Setup
+
 The setup script has been tested on Ubuntu 18.10:
 
 ```
 $ sudo ./setup-server.sh
 ```
 
-If you would like to run this in docker, you can modify the desired environment variables and run ` docker-compose up -d natla-server `. You can also run the complete stack by running ` docker-compose up -d `. Note: This method is only suggested for a Development Environment. Future updates will allow for this to be ran as a production stack.
+If you would like to run this in docker, you can modify the desired environment variables and run ` docker-compose up -d natlas-server `. You can also run the complete stack by running ` docker-compose up -d `. Note: This method is only suggested for a Development Environment.
 
-The Config
-------------------
+
+## The Config
+
 There are a number of config options that you can specify in a file called `.env` before initializing the database and launching the application. These options break down into two categories:
 
 Can't be changed via the web interface (only `.env`):
@@ -53,8 +54,8 @@ Can be changed via the web interface:
 For most installations, the defaults will probably be fine (with the exception of `SECRET_KEY`, but this should get generated automatically by `setup-server.sh`), however user invitations won't work without a valid mail server.
 
 
-Initializing the Database
-------------------
+## Initializing the Database
+
 The database should be initialized automatically during the `./setup-server` script, but if it is not for whatever reason, this is the manual steps required to intiialize or upgrade the database.
 
 ```
@@ -65,8 +66,8 @@ $ deactivate
 ```
 
 
-Setting the Scope
-------------------
+## Setting the Scope
+
 The scope and blacklist can be set server side without using the admin interface by running the `./add-scope.py` script from within the natlas `venv` with the `--scope` and `--blacklist` arguments, respectively. These each take a file name to read scope from. You may optionally specify `--verbose` to see exactly which scope items succeeded to import, failed to import, or already existed in the scope. A scope is **REQUIRED** for agents to do any work, however a blacklist is optional.
 
 ```
@@ -77,8 +78,8 @@ $ python3 add-scope.py --blacklist myblacklist.txt
 ```
 
 
-Giving a User Admin Privilege
-------------------
+## Giving a User Admin Privilege
+
 In order to get started interacting with Natlas, you'll need an administrator account. Admins are allowed to make changes to the following via the web interface:
 
 - application config
@@ -95,15 +96,15 @@ $ python3 add-user.py --admin user@example.com
 ```
 
 
-Starting the Server
-------------------
+## Starting the Server
+
 Starting the server is easy and can pretty much be handled entirely by the `run-server.sh` script. Simply navigate to the natlas-server folder (where this readme is) and `./run-server.sh`. This will start the flask application in your terminal, listening on localhost on port 5000. If you really want, you could change this to listen on a specific IP address on another port, but it is encouraged that you add nginx in front of your flask application.
 
 Furthermore, you might think it's mighty inconvenient that the flask application is running in your terminal and now you can't close the terminal without shutting down the server. You can remediate this with a systemd unit (an example one is provided), or by simply launching the server inside a `screen` session.
 
 
-NGINX as a Reverse Proxy
-------------------
+## NGINX as a Reverse Proxy
+
 As mentioned above, it is not really advisable to run the flask application directly on the internet (or even on your local network). The flask application is just that, an application. It doesn't account for things like SSL certificates, and modifying application logic to add in potential routes for things like Let's Encrypt should be avoided. Luckily, it's very easy to setup a reverse proxy so that all of this stuff can be handled by a proper web server and leave your application to do exactly what it's supposed to do.
 
 To install nginx, you can simply `sudo apt-get install nginx`. Once it's installed, let's make a copy of provided nginx config:
@@ -115,8 +116,8 @@ $ sudo cp natlas/natlas-server/deployment/nginx /etc/nginx/sites-available/natla
 This nginx config expects that you'll be using TLS for your connections to the server. If you're hosting on the internet, letsencrypt makes this really easy. If you're not, you'll want to remove the TLS redirects. You should really be using a TLS certificate, though, even if it's only self-signed. All communications between both the users and the server, and the agents and the server will happen over this connection.  Go ahead and modify the lines that say `server_name <host>` and change `<host>` to whatever hostname your server will be listening on. Then, in the second server block, you'll want to set the `ssl_certificate` and `ssl_certificate_key` values to point to the correct SSL certificate and key. The final `location /` block is where the reverse proxying actually happens, specifically line `proxy_pass http://127.0.0.1:5000;`.
 
 
-Example Systemd Unit
-------------------
+## Example Systemd Unit
+
 An example systemd unit file is provided in `deployment/natlas-server.service`. It can be installed by copying it to `/etc/systemd/system/` and reloading the systemctl daemon.
 
 ```

--- a/natlas-server/README.md
+++ b/natlas-server/README.md
@@ -15,7 +15,7 @@ The setup script has been tested on Ubuntu 18.10:
 $ sudo ./setup-server.sh
 ```
 
-If you would like to run this in docker, you can modify the desired environment variables and run ` docker-compose up -d natla-server `. You can also run the complete stack by running ` docker-compose up -d `. Note: This method is only suggested for a Development Environment. Future updates will allow for this to be ran as a production stack. 
+If you would like to run this in docker, you can modify the desired environment variables and run ` docker-compose up -d natla-server `. You can also run the complete stack by running ` docker-compose up -d `. Note: This method is only suggested for a Development Environment. Future updates will allow for this to be ran as a production stack.
 
 The Config
 ------------------
@@ -27,6 +27,7 @@ Can't be changed via the web interface (only `.env`):
 |---|---|---|
 | `SECRET_KEY` | `you-should-set-a-secret-key` | Used for CSRF tokens and sessions. The `setup-server.sh` script will generate a random value for you if you don't have an existing `SECRET_KEY` set. |
 | `SQLALCHEMY_DATABASE_URI` | `sqlite:///metadata.db` | A SQLALCHEMY URI that points to the database to store natlas metadata in |
+| `ELASTICSEARCH_URL` | `http://localhost:9200` | A URL that points to the elasticsearch cluster to store natlas scan data in |
 | `FLASK_ENV` | `production` | Used to tell flask which environment to run. Only change this if you are debugging or developing, and never leave your server running in anything but `production`.  |
 | `FLASK_APP` | `natlas-server.py` | The file name that launches the flask application. This should not be changed as it allows commands like `flask run`, `flask db upgrade`, and `flask shell` to run.|
 | `MEDIA_DIRECTORY` | `$BASEDIR/media/` | If you want to store media (screenshots) in a larger mounted storage volume, set this value to an absolute path. If you change this value, be sure to copy the contents of the previous media directory to the new location, otherwise old media will not render.|
@@ -39,7 +40,6 @@ Can be changed via the web interface:
 |---|---|---|
 | `LOGIN_REQUIRED` | `False` | Require login to browse results |
 | `REGISTER_ALLOWED` | `False` | Permit open registration (requires defined `MAIL_*` settings below) for new users |
-| `ELASTICSEARCH_URL` | `http://localhost:9200` | Location of an elasticsearch node that we can store and fetch scan data from |
 | `MAIL_SERVER` | `localhost` | Mail server to use for invitations, registrations, and password resets |
 | `MAIL_PORT` | `25` | Port that `MAIL_SERVER` is listening on |
 | `MAIL_USE_TLS` | `False` | Whether or not to connect to `MAIL_SERVER` with TLS|

--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -5,7 +5,7 @@ from flask_login import LoginManager, AnonymousUserMixin, current_user
 from flask_mail import Mail
 from flask_wtf.csrf import CSRFProtect
 from config import Config, populate_defaults, get_defaults
-from app.elastic import Elastic
+from app.elastic import ElasticInterface
 from app.scope import ScopeManager
 from urllib.parse import urlparse
 import os
@@ -143,7 +143,7 @@ def create_app(config_class=Config, load_config=False):
 
 		# Grungy thing so we can use flask db and flask shell before the config items are initially populated
 		if "ELASTICSEARCH_URL" in app.config:
-			app.elastic = Elastic(app.config['ELASTICSEARCH_URL'])
+			app.elastic = ElasticInterface(app.config['ELASTICSEARCH_URL'])
 
 	app.ScopeManager = ScopeManager()
 

--- a/natlas-server/app/admin/forms.py
+++ b/natlas-server/app/admin/forms.py
@@ -4,7 +4,6 @@ from wtforms import StringField, BooleanField, SubmitField, TextAreaField, Passw
 from wtforms.validators import DataRequired, ValidationError, Email, Optional
 from app.models import User, ScopeItem, AgentScript
 import ipaddress
-from app.elastic import Elastic
 
 
 class ConfigForm(FlaskForm):
@@ -13,7 +12,6 @@ class ConfigForm(FlaskForm):
 	agent_authentication = BooleanField('Agent Authentication Required')
 	local_subresources = BooleanField('Use Local Subresources (instead of CDN)')
 	custom_brand = StringField('Custom Branding')
-	elasticsearch_url = StringField("Elastic URL")
 	mail_from = StringField("From Address", validators=[Email(), Optional()])
 	mail_server = StringField("Mail Server")
 	mail_port = StringField("Mail Port")
@@ -21,11 +19,6 @@ class ConfigForm(FlaskForm):
 	mail_username = StringField("Mail username")
 	mail_password = PasswordField("Mail password")
 	submit = SubmitField("Save Changes")
-
-	def validate_elasticsearch_url(self, elasticsearch_url):
-		tmpElasticInstance = Elastic(elasticsearch_url.data)
-		if not tmpElasticInstance.status:
-			raise ValidationError("%s : %s" % (tmpElasticInstance.errorinfo, elasticsearch_url.data))
 
 
 class InviteUserForm(FlaskForm):

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -2,7 +2,6 @@ from flask import render_template, redirect, url_for, current_app, flash, Respon
 from flask_login import current_user
 from app import db
 from app.admin import bp
-from app.elastic import Elastic
 from app.admin import forms
 from app.models import User, ScopeItem, ConfigItem, NatlasServices, AgentConfig, AgentScript, Tag
 from app.auth.email import send_user_invite_email
@@ -21,9 +20,6 @@ def admin():
 		for fieldname, fieldvalue in configForm.data.items():
 			if fieldname.upper() in ["SUBMIT", "CSRF_TOKEN"]:
 				continue
-			# if we've got a new elasticsearch address, update our current handle to elastic
-			if fieldname.upper() == "ELASTICSEARCH_URL" and fieldvalue != current_app.config["ELASTICSEARCH_URL"]:
-				current_app.elastic = Elastic(fieldvalue)
 			current_app.config[fieldname.upper()] = fieldvalue
 			confitem = ConfigItem.query.filter_by(name=fieldname.upper()).first()
 			confitem.value = str(fieldvalue)

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -408,11 +408,11 @@ def deleteScan(scan_id):
 				else:
 					redirectLoc = request.referrer
 			else:
-				redirectLoc = url_for('main.search')
+				redirectLoc = url_for('main.browse')
 			return redirect(redirectLoc)
 		else:
 			flash("Could not delete scan %s." % scan_id, "danger")
-			return redirect(request.referrer or url_for('main.search'))
+			return redirect(request.referrer or url_for('main.browse'))
 	else:
 		flash("Couldn't validate form!")
 		return redirect(request.referrer)
@@ -428,7 +428,7 @@ def deleteHost(ip):
 		deleted = current_app.elastic.delete_host(ip)
 		if deleted > 0:
 			flash("Successfully deleted host %s" % ip, "success")
-			return redirect(url_for('main.search'))
+			return redirect(url_for('main.browse'))
 		else:
 			flash("Couldn't delete host: %s" % ip, "danger")
 	else:

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -396,6 +396,7 @@ def deleteScript(name):
 @isAuthenticated
 @isAdmin
 def deleteScan(scan_id):
+	# TODO - This function redirects you to the deleted scan, which temporarily works because it's an async delete call.
 	delForm = forms.DeleteForm()
 
 	if delForm.validate_on_submit():
@@ -427,10 +428,10 @@ def deleteHost(ip):
 	if delForm.validate_on_submit():
 		deleted = current_app.elastic.delete_host(ip)
 		if deleted > 0:
-			flash("Successfully deleted host %s" % ip, "success")
+			flash(f"Successfully deleted {deleted - 1 if deleted > 1 else deleted} scans for {ip}", "success")
 			return redirect(url_for('main.browse'))
 		else:
-			flash("Couldn't delete host: %s" % ip, "danger")
+			flash(f"Couldn't delete host: {ip}", "danger")
 	else:
 		flash("Couldn't validate form!")
 		return redirect(request.referrer)

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -392,7 +392,6 @@ def deleteScript(name):
 @isAuthenticated
 @isAdmin
 def deleteScan(scan_id):
-	# TODO - This function redirects you to the deleted scan, which temporarily works because it's an async delete call.
 	delForm = forms.DeleteForm()
 
 	if delForm.validate_on_submit():

--- a/natlas-server/app/api/prepare_work.py
+++ b/natlas-server/app/api/prepare_work.py
@@ -20,7 +20,7 @@ def get_unique_scan_id():
 	scan_id = ''
 	while scan_id == '':
 		rand = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
-		count, context = current_app.elastic.gethost_scan_id(rand)
+		count, context = current_app.elastic.get_host_by_scan_id(rand)
 		if count == 0:
 			scan_id = rand
 	return scan_id

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -97,7 +97,7 @@ def submit():
 
 		# If there's no further processing to do, store the host and prepare the response
 		elif not newhost["is_up"] or (newhost["is_up"] and newhost["port_count"] == 0):
-			current_app.elastic.newhost(newhost)
+			current_app.elastic.new_result(newhost)
 			status_code = 200
 			response_body = json.dumps({"status": status_code, "message": "Received: " + newhost['ip']})
 	except NmapParserException:
@@ -147,7 +147,7 @@ def submit():
 		response_body = json.dumps({"status": status_code, "message": "More than 500 ports found, throwing data out"})
 	else:
 		status_code = 200
-		current_app.elastic.newhost(newhost)
+		current_app.elastic.new_result(newhost)
 		response_body = json.dumps({"status": status_code, "message": "Received %s ports for %s" % (len(newhost['ports']), newhost['ip'])})
 
 	response = Response(response=response_body, status=status_code, content_type=json_content)

--- a/natlas-server/app/elastic.py
+++ b/natlas-server/app/elastic.py
@@ -4,58 +4,64 @@ import sys
 from datetime import datetime
 from config import Config
 import logging
+import random
 
 
 class Elastic:
 	es = None
 	status = False
-	errrorinfo = ''
 	natlasIndices = ["nmap", "nmap_history"]
 	mapping = {}
-	lastReconnectAttempt = datetime.utcnow()
+	lastReconnectAttempt = None
 	logger = logging.getLogger('elasticsearch')
 	logger.setLevel('ERROR')
 
 	def __init__(self, elasticURL):
+		# Elastic is initialized outside an application context so we have to instatiate Config ourselves to get BASEDIR
 		with open(Config().BASEDIR + '/defaults/elastic/mapping.json') as mapfile:
 			self.mapping = json.loads(mapfile.read())
 		try:
 			self.es = elasticsearch.Elasticsearch(elasticURL, timeout=5, max_retries=1)
-			self.status = self.ping()
+			self.status = self._ping()
 			if self.status:
-				self.initialize_indices()
-		except Exception as e:
-			self.errorinfo = e
+				self._initialize_indices()
+		except Exception:
 			self.status = False
 			return
+		finally:
+			# Set the lastReconnectAttempt to the timestamp after initialization
+			self.lastReconnectAttempt = datetime.utcnow()
 
-	def initialize_indices(self):
+	def _initialize_indices(self):
 		''' Check each required index and make sure it exists, if it doesn't then create it '''
-		for index in self.natlasIndicies:
+		for index in self.natlasIndices:
 			if not self.es.indices.exists(index):
 				self.es.indices.create(index, body=self.mapping)
 
-	def ping(self):
+	def _ping(self):
 		''' Returns True if the cluster is up, False otherwise'''
 		return self.es.ping()
 
-	def attempt_reconnect(self):
+	def _attempt_reconnect(self):
+		''' Attempt to reconnect if we haven't tried to reconnect too recently '''
 		now = datetime.utcnow()
 		delta = now - self.lastReconnectAttempt
-		if delta.seconds < 5:
+		if delta.seconds < 30:
 			return self.status
 		else:
-			self.status = self.ping()
+			self.status = self._ping()
 			return self.status
 
-	def check_status(self):
+	def _check_status(self):
+		''' If we're in a known bad state, try to reconnect '''
 		if not self.status:
-			if not self.attempt_reconnect():
+			if not self._attempt_reconnect():
 				raise elasticsearch.ConnectionError
 		return self.status
 
-	def execute_raw_query(self, func, **kargs):
-		self.check_status()
+	def _execute_raw_query(self, func, **kargs):
+		''' Wraps the es client to make sure that ConnectionErrors are handled uniformly '''
+		self._check_status()
 		try:
 			results = func(**kargs)
 			return results
@@ -65,14 +71,31 @@ class Elastic:
 		except Exception:
 			return None
 
-	def execute_search(self, **kargs):
+	def _execute_search(self, **kargs):
 		''' Execute an arbitrary search. This is where we should instrument things specific to es.search '''
-		results = self.execute_raw_query(self.es.search, doc_type='_doc', **kargs)
+		results = self._execute_raw_query(self.es.search, doc_type='_doc', **kargs)
 		return results
 
-	def get_collection(self, **kargs):
+	def _execute_count(self, **kargs):
+		''' Executes an arbitrary count. This is where we should instrument things specific to es.count '''
+		results = self._execute_raw_query(self.es.count, doc_type='_doc', **kargs)
+		if not results:
+			return 0
+		return results
+
+	def _execute_delete_by_query(self, **kargs):
+		''' Executes an arbitrary delete_by_query. This is where we should instrument things specific to es.delete_by_query '''
+		results = self._execute_raw_query(self.es.delete_by_query, doc_type='_doc', **kargs)
+		return results
+
+	def _execute_index(self, **kargs):
+		''' Executes an arbitrary index. This is where we should instrument things specific to es.index '''
+		results = self._execute_raw_query(self.es.index, doc_type='_doc', **kargs)
+		return results
+
+	def _get_collection(self, **kargs):
 		''' Execute a search and return a collection of results '''
-		results = self.execute_search(**kargs)
+		results = self._execute_search(**kargs)
 		if not results:
 			return 0, []
 		docsources = []
@@ -80,19 +103,12 @@ class Elastic:
 			docsources.append(result['_source'])
 		return results['hits']['total'], docsources
 
-	def get_single_host(self, **kargs):
+	def _get_single_host(self, **kargs):
 		''' Execute a search and return a single result '''
-		results = self.execute_search(**kargs)
+		results = self._execute_search(**kargs)
 		if not results or results['hits']['total'] == 0:
 			return 0, None
 		return results['hits']['total'], results['hits']['hits'][0]['_source']
-
-	def execute_count(self, **kargs):
-		''' Executes an arbitrary count. This is where we should instrument things specific to es.count '''
-		results = self.execute_raw_query(self.es.count, doc_type='_doc', **kargs)
-		if not results:
-			return 0
-		return results
 
 	def search(self, limit, offset, query='nmap', searchIndex="nmap"):
 		''' Execute a user supplied search and return the results '''
@@ -130,27 +146,23 @@ class Elastic:
 				}
 			}
 		}
-		result = self.get_collection(index=searchIndex, body=searchBody)
+		result = self._get_collection(index=searchIndex, body=searchBody)
 		return result
 
 	def total_hosts(self):
 		''' Count the number of documents in nmap and return the count '''
-		result = self.execute_count(index="nmap")
+		result = self._execute_count(index="nmap")
 		return result["count"]
 
-	def newhost(self, host):
-		self.checkStatus()
+	def new_result(self, host):
+		''' Create new elastic documents in both indices for a new scan result '''
 		ip = str(host['ip'])
 
-		try:
-			self.es.index(index='nmap_history', doc_type='_doc', body=host)
-			self.es.index(index='nmap', doc_type='_doc', id=ip, body=host)
-			return True
-		except elasticsearch.ElasticsearchException:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		self._execute_index(index='nmap_history', body=host)
+		self._execute_index(index='nmap', id=ip, body=host)
+		return True
 
-	def gethost(self, ip):
+	def get_host(self, ip):
 		''' Gets the most recent result for a host, but by querying the nmap_history it also gives us the total number of historical results '''
 		searchBody = {
 			"size": 1,
@@ -168,11 +180,10 @@ class Elastic:
 				}
 			}
 		}
-		result = self.get_single_host(index='nmap_history', body=searchBody)
+		result = self._get_single_host(index='nmap_history', body=searchBody)
 		return result
 
-
-	def gethost_history(self, ip, limit, offset):
+	def get_host_history(self, ip, limit, offset):
 		''' Gets a collection of historical results for a specific ip address '''
 		searchBody = {
 			"size": limit,
@@ -190,7 +201,7 @@ class Elastic:
 				}
 			}
 		}
-		result = self.get_collection(index='nmap_history', body=searchBody)
+		result = self._get_collection(index='nmap_history', body=searchBody)
 		return result
 
 	def count_host_screenshots(self, ip):
@@ -209,7 +220,7 @@ class Elastic:
 			}
 		}
 		# By setting size to 0, _source to False, and track_scores to False, we're able to optimize this query to give us only what we care about
-		result = self.execute_search(index="nmap_history", body=searchBody, size=0, _source=False, track_scores=False)
+		result = self._execute_search(index="nmap_history", body=searchBody, size=0, _source=False, track_scores=False)
 		num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
 		return num_screenshots
 
@@ -243,10 +254,10 @@ class Elastic:
 			}
 		}
 		source_fields = ['screenshots', 'ctime', 'scan_id']
-		result = self.get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
+		result = self._get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
 		return result
 
-	def gethost_scan_id(self, scan_id):
+	def get_host_by_scan_id(self, scan_id):
 		''' Get a specific historical result based on scan_id, which should be unique '''
 		searchBody = {
 			"size": 1,
@@ -263,75 +274,37 @@ class Elastic:
 				}
 			}
 		}
-		result = self.get_single_host(index='nmap_history', body=searchBody)
+		result = self._get_single_host(index='nmap_history', body=searchBody)
 		return result
 
 	def delete_scan(self, scan_id):
-		self.check_status()
-
+		''' Delete a specific scan, if it's the most recent then try to migrate the next oldest back into the nmap index '''
 		migrate = False
-		try:
-			searchBody = {
-				"size": 1,
-				"query": {
-					"query_string": {
-						"query": scan_id,
-						"fields": ["scan_id"]
-					}
+		searchBody = {
+			"size": 1,
+			"query": {
+				"query_string": {
+					"query": scan_id,
+					"fields": ["scan_id"]
+				}
+			},
+			"sort": {
+				"ctime": {
+					"order": "desc"
 				}
 			}
-			hostResult = self.es.search(index='nmap', doc_type='_doc', body=searchBody)
-			if hostResult['hits']['total'] != 0:
-				# we're deleting the most recent scan result and need to pull the next most recent into the nmap index
-				# otherwise you won't find the host when doing searches or browsing
-				ipaddr = hostResult['hits']['hits'][0]['_source']['ip']
-				secondBody = {
-					"size": 2,
-					"query": {
-						"query_string": {
-							"query": ipaddr,
-							"fields": ["ip"]
-						}
-					},
-					"sort": {
-						"ctime": {
-							"order": "desc"
-						}
-					}
-				}
-				twoscans = self.es.search(index="nmap_history", doc_type="_doc", body=secondBody)
-
-				if len(twoscans['hits']['hits']) != 2:
-					# we're deleting the only scan for this host so we don't need to migrate old scan data into the nmap index
-					migrate = False
-				else:
-					migrate = True
-			deleteBody = {
+		}
+		count, host = self._get_single_host(index='nmap', body=searchBody)
+		if count != 0:
+			# we're deleting the most recent scan result and need to pull the next most recent into the nmap index
+			# otherwise you won't find the host when doing searches or browsing
+			ipaddr = host['ip']
+			secondBody = {
+				"size": 2,
 				"query": {
 					"query_string": {
-						"query": scan_id,
-						"fields": ["scan_id"],
-						"default_operator": "AND"
-					}
-				}
-			}
-			result = self.es.delete_by_query(index="nmap,nmap_history", doc_type="_doc", body=deleteBody)
-			if migrate:
-				self.es.index(index='nmap', doc_type='_doc', id=ipaddr, body=twoscans['hits']['hits'][1]['_source'])
-			return result["deleted"]
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
-
-	def delete_host(self, ip):
-		self.check_status()
-		try:
-			searchBody = {
-				"query": {
-					"query_string": {
-						"query": ip,
-						"fields": ["ip", "id"],
-						"default_operator": "AND"
+						"query": ipaddr,
+						"fields": ["ip"]
 					}
 				},
 				"sort": {
@@ -340,15 +313,42 @@ class Elastic:
 					}
 				}
 			}
-			deleted = self.es.delete_by_query(index="nmap,nmap_history", doc_type="_doc", body=searchBody)
-			return deleted["deleted"]
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+
+			count, twoscans = self._get_collection(index="nmap_history", body=secondBody)
+			# If count is one then there's only one result in history so we can just delete it.
+			# If count is > 1 then we need to migrate the next oldest scan data
+			if count > 1:
+				migrate = True
+		deleteBody = {
+			"query": {
+				"query_string": {
+					"query": scan_id,
+					"fields": ["scan_id"],
+					"default_operator": "AND"
+				}
+			}
+		}
+		result = self._execute_delete_by_query(index="nmap,nmap_history", body=deleteBody)
+		if migrate:
+			self._execute_index(index='nmap', id=ipaddr, body=twoscans[1])
+		return result["deleted"]
+
+	def delete_host(self, ip):
+		''' Delete all occurrences of a given ip address '''
+		searchBody = {
+			"query": {
+				"query_string": {
+					"query": ip,
+					"fields": ["ip", "id"],
+					"default_operator": "AND"
+				}
+			}
+		}
+		deleted = self._execute_delete_by_query(index="nmap,nmap_history", body=searchBody)
+		return deleted["deleted"]
 
 	def random_host(self):
-		self.check_status()
-		import random
+		''' Get a random single host and return it '''
 		seed = random.randrange(sys.maxsize)
 		searchBody = {
 			"from": 0,
@@ -380,16 +380,11 @@ class Elastic:
 				}
 			}
 		}
-		try:
-
-			random = self.es.search(index="nmap", doc_type="_doc", body=searchBody)
-			return random
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		count, host = self._get_single_host(index="nmap", body=searchBody)
+		return host
 
 	def get_current_screenshots(self, limit, offset):
-		self.check_status()
+		''' Get all current screenshots '''
 		searchBody = {
 			"size": limit,
 			"from": offset,
@@ -414,14 +409,11 @@ class Elastic:
 			}
 		}
 		source_fields = ["screenshots", "ctime", "scan_id", "ip"]
-		try:
-			result = self.es.search(index="nmap", doc_type='_doc', body=searchBody, _source=source_fields, track_scores=False)
-			num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
-			results = []  # collate results
-			for thing in result['hits']['hits']:
-				results.append(thing['_source'])
+		# We need to execute_search instead of get_collection here because we also need the aggregation information
+		result = self._execute_search(index="nmap", body=searchBody, _source=source_fields, track_scores=False)
+		num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
+		results = []  # collate results
+		for thing in result['hits']['hits']:
+			results.append(thing['_source'])
 
-			return result['hits']['total'], num_screenshots, results
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		return result['hits']['total'], num_screenshots, results

--- a/natlas-server/app/elastic.py
+++ b/natlas-server/app/elastic.py
@@ -21,99 +21,122 @@ class Elastic:
 			self.mapping = json.loads(mapfile.read())
 		try:
 			self.es = elasticsearch.Elasticsearch(elasticURL, timeout=5, max_retries=1)
-			self.status = self.healthCheck()
+			self.status = self.ping()
 			if self.status:
-				self.initializeIndices()
+				self.initialize_indices()
 		except Exception as e:
 			self.errorinfo = e
 			self.status = False
 			return
 
-	def initializeIndices(self):
+	def initialize_indices(self):
+		''' Check each required index and make sure it exists, if it doesn't then create it '''
 		for index in self.natlasIndicies:
 			if not self.es.indices.exists(index):
 				self.es.indices.create(index, body=self.mapping)
 
-	def healthCheck(self):
-		try:
-			self.es.cluster.health()
-		except elasticsearch.ConnectionError:
-			return False
-		return True
+	def ping(self):
+		''' Returns True if the cluster is up, False otherwise'''
+		return self.es.ping()
 
-	def attemptReconnect(self):
+	def attempt_reconnect(self):
 		now = datetime.utcnow()
 		delta = now - self.lastReconnectAttempt
 		if delta.seconds < 5:
 			return self.status
 		else:
-			self.status = self.healthCheck()
+			self.status = self.ping()
 			return self.status
 
-	def checkStatus(self):
+	def check_status(self):
 		if not self.status:
-			if not self.attemptReconnect():
+			if not self.attempt_reconnect():
 				raise elasticsearch.ConnectionError
 		return self.status
 
-	def search(self, query, limit, offset, searchIndex="nmap"):
-		self.checkStatus()
-
-		if query == '':
-			query = 'nmap'
+	def execute_raw_query(self, func, **kargs):
+		self.check_status()
 		try:
-			searchBody = {
-				"size": limit,
-				"from": offset,
-				"query": {
-					"bool": {
-						"must": [
-							{
-								"query_string": {
-									"query": query,
-									"fields": ["nmap_data"],
-									"default_operator": "AND"
-								}
-							},
-							{
-								"term": {
-									"is_up": True
-								}
-							},
-							{
-								"range": {
-									"port_count": {
-										"gt": 0
-									}
+			results = func(**kargs)
+			return results
+		except elasticsearch.ConnectionError:
+			self.status = False
+			raise elasticsearch.ConnectionError
+		except Exception:
+			return None
+
+	def execute_search(self, **kargs):
+		''' Execute an arbitrary search. This is where we should instrument things specific to es.search '''
+		results = self.execute_raw_query(self.es.search, doc_type='_doc', **kargs)
+		return results
+
+	def get_collection(self, **kargs):
+		''' Execute a search and return a collection of results '''
+		results = self.execute_search(**kargs)
+		if not results:
+			return 0, []
+		docsources = []
+		for result in results['hits']['hits']:
+			docsources.append(result['_source'])
+		return results['hits']['total'], docsources
+
+	def get_single_host(self, **kargs):
+		''' Execute a search and return a single result '''
+		results = self.execute_search(**kargs)
+		if not results or results['hits']['total'] == 0:
+			return 0, None
+		return results['hits']['total'], results['hits']['hits'][0]['_source']
+
+	def execute_count(self, **kargs):
+		''' Executes an arbitrary count. This is where we should instrument things specific to es.count '''
+		results = self.execute_raw_query(self.es.count, doc_type='_doc', **kargs)
+		if not results:
+			return 0
+		return results
+
+	def search(self, limit, offset, query='nmap', searchIndex="nmap"):
+		''' Execute a user supplied search and return the results '''
+		searchBody = {
+			"size": limit,
+			"from": offset,
+			"query": {
+				"bool": {
+					"must": [
+						{
+							"query_string": {
+								"query": query,
+								"fields": ["nmap_data"],
+								"default_operator": "AND"
+							}
+						},
+						{
+							"term": {
+								"is_up": True
+							}
+						},
+						{
+							"range": {
+								"port_count": {
+									"gt": 0
 								}
 							}
-						]
-					}
-				},
-				"sort": {
-					"ctime": {
-						"order": "desc"
-					}
+						}
+					]
+				}
+			},
+			"sort": {
+				"ctime": {
+					"order": "desc"
 				}
 			}
-			result = self.es.search(index=searchIndex, doc_type="_doc", body=searchBody)
-			results = []  # collate results
-			for thing in result['hits']['hits']:
-				results.append(thing['_source'])
+		}
+		result = self.get_collection(index=searchIndex, body=searchBody)
+		return result
 
-			return result['hits']['total'], results
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
-
-	def totalHosts(self):
-		self.checkStatus()
-		try:
-			result = self.es.count(index="nmap", doc_type="_doc")
-			return result["count"]
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+	def total_hosts(self):
+		''' Count the number of documents in nmap and return the count '''
+		result = self.execute_count(index="nmap")
+		return result["count"]
 
 	def newhost(self, host):
 		self.checkStatus()
@@ -128,65 +151,50 @@ class Elastic:
 			raise elasticsearch.ConnectionError
 
 	def gethost(self, ip):
-		self.checkStatus()
-		try:
-			searchBody = {
-				"size": 1,
-				"query": {
-					"query_string": {
-						"query": ip,
-						"fields": ["ip"],
-						"default_operator":
-						"AND"
-					}
-				},
-				"sort": {
-					"ctime": {
-						"order": "desc"
-					}
+		''' Gets the most recent result for a host, but by querying the nmap_history it also gives us the total number of historical results '''
+		searchBody = {
+			"size": 1,
+			"query": {
+				"query_string": {
+					"query": ip,
+					"fields": ["ip"],
+					"default_operator":
+					"AND"
+				}
+			},
+			"sort": {
+				"ctime": {
+					"order": "desc"
 				}
 			}
-			result = self.es.search(index='nmap_history', doc_type='_doc', body=searchBody)
-			if result['hits']['total'] == 0:
-				return 0, None
-			return result['hits']['total'], result['hits']['hits'][0]['_source']
+		}
+		result = self.get_single_host(index='nmap_history', body=searchBody)
+		return result
 
-		except elasticsearch.ElasticsearchException:
-			self.status = False
-			raise elasticsearch.ConnectionError
 
 	def gethost_history(self, ip, limit, offset):
-		self.checkStatus()
-		try:
-			searchBody = {
-				"size": limit,
-				"from": offset,
-				"query": {
-					"query_string": {
-						"query": ip,
-						"fields": ["ip"],
-						"default_operator": "AND"
-					}
-				},
-				"sort": {
-					"ctime": {
-						"order": "desc"
-					}
+		''' Gets a collection of historical results for a specific ip address '''
+		searchBody = {
+			"size": limit,
+			"from": offset,
+			"query": {
+				"query_string": {
+					"query": ip,
+					"fields": ["ip"],
+					"default_operator": "AND"
+				}
+			},
+			"sort": {
+				"ctime": {
+					"order": "desc"
 				}
 			}
-			result = self.es.search(index='nmap_history', doc_type='_doc', body=searchBody)
-			results = []  # collate results
-			for thing in result['hits']['hits']:
-				results.append(thing['_source'])
-
-			return result['hits']['total'], results
-
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		}
+		result = self.get_collection(index='nmap_history', body=searchBody)
+		return result
 
 	def count_host_screenshots(self, ip):
-		self.checkStatus()
+		''' Search history for an ip address and returns the number of historical screenshots '''
 		searchBody = {
 			"query": {
 				"term": {
@@ -200,16 +208,13 @@ class Elastic:
 				}
 			}
 		}
-		try:
-			result = self.es.search(index="nmap_history", doc_type='_doc', body=searchBody, size=0, _source=False, track_scores=False,)
-			num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
-			return num_screenshots
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		# By setting size to 0, _source to False, and track_scores to False, we're able to optimize this query to give us only what we care about
+		result = self.execute_search(index="nmap_history", body=searchBody, size=0, _source=False, track_scores=False)
+		num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
+		return num_screenshots
 
 	def get_host_screenshots(self, ip, limit, offset):
-		self.checkStatus()
+		''' Gets screenshots and minimal context for a given host '''
 		searchBody = {
 			"size": limit,
 			"from": offset,
@@ -237,49 +242,32 @@ class Elastic:
 				}
 			}
 		}
-
-		try:
-			result = self.es.search(index="nmap_history", doc_type='_doc', body=searchBody, _source=["screenshots", "ctime", "scan_id"], track_scores=False,)
-
-			results = []  # collate results
-			for thing in result['hits']['hits']:
-				results.append(thing['_source'])
-
-			return result['hits']['total'], results
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		source_fields = ['screenshots', 'ctime', 'scan_id']
+		result = self.get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
+		return result
 
 	def gethost_scan_id(self, scan_id):
-		self.checkStatus()
-
-		try:
-			searchBody = {
-				"size": 1,
-				"query": {
-					"query_string": {
-						"query": scan_id,
-						"fields": ["scan_id"],
-						"default_operator": "AND"
-					}
-				},
-				"sort": {
-					"ctime": {
-						"order": "desc"
-					}
+		''' Get a specific historical result based on scan_id, which should be unique '''
+		searchBody = {
+			"size": 1,
+			"query": {
+				"query_string": {
+					"query": scan_id,
+					"fields": ["scan_id"],
+					"default_operator": "AND"
+				}
+			},
+			"sort": {
+				"ctime": {
+					"order": "desc"
 				}
 			}
-			result = self.es.search(index='nmap_history', doc_type='_doc', body=searchBody)
-			if result['hits']['total'] == 0:
-				return 0, None
-			return result['hits']['total'], result['hits']['hits'][0]['_source']
-
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
+		}
+		result = self.get_single_host(index='nmap_history', body=searchBody)
+		return result
 
 	def delete_scan(self, scan_id):
-		self.checkStatus()
+		self.check_status()
 
 		migrate = False
 		try:
@@ -336,7 +324,7 @@ class Elastic:
 			raise elasticsearch.ConnectionError
 
 	def delete_host(self, ip):
-		self.checkStatus()
+		self.check_status()
 		try:
 			searchBody = {
 				"query": {
@@ -359,7 +347,7 @@ class Elastic:
 			raise elasticsearch.ConnectionError
 
 	def random_host(self):
-		self.checkStatus()
+		self.check_status()
 		import random
 		seed = random.randrange(sys.maxsize)
 		searchBody = {
@@ -401,7 +389,7 @@ class Elastic:
 			raise elasticsearch.ConnectionError
 
 	def get_current_screenshots(self, limit, offset):
-		self.checkStatus()
+		self.check_status()
 		searchBody = {
 			"size": limit,
 			"from": offset,

--- a/natlas-server/app/elastic/__init__.py
+++ b/natlas-server/app/elastic/__init__.py
@@ -1,0 +1,3 @@
+# importing these here allows for "from app.elastic import ElasticInterface" instead of "from app.elastic.interface import ElasticInterface"
+from app.elastic.client import ElasticClient # noqa: F401
+from app.elastic.interface import ElasticInterface # noqa: F401

--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -1,0 +1,113 @@
+import json
+from config import Config
+import elasticsearch
+from datetime import datetime
+import logging
+
+
+class ElasticClient:
+	es = None
+	lastReconnectAttempt = None
+	mapping = {}
+	natlasIndices = ["nmap", "nmap_history"]
+	status = False
+	# Quiets the elasticsearch logger because otherwise connection errors print tracebacks to the WARNING level, even when the exception is handled.
+	logger = logging.getLogger('elasticsearch')
+	logger.setLevel('ERROR')
+
+	def __init__(self, elasticURL):
+		# Elastic is initialized outside an application context so we have to instatiate Config ourselves to get BASEDIR
+		with open(Config().BASEDIR + '/defaults/elastic/mapping.json') as mapfile:
+			self.mapping = json.loads(mapfile.read())
+		try:
+			self.es = elasticsearch.Elasticsearch(elasticURL, timeout=5, max_retries=1)
+			self.status = self._ping()
+			if self.status:
+				self._initialize_indices()
+		except Exception:
+			self.status = False
+		finally:
+			# Set the lastReconnectAttempt to the timestamp after initialization
+			self.lastReconnectAttempt = datetime.utcnow()
+		return
+
+	def _initialize_indices(self):
+		''' Check each required index and make sure it exists, if it doesn't then create it '''
+		for index in self.natlasIndices:
+			if not self.es.indices.exists(index):
+				self.es.indices.create(index, body=self.mapping)
+
+	def _ping(self):
+		''' Returns True if the cluster is up, False otherwise'''
+		return self.es.ping()
+
+	def _attempt_reconnect(self):
+		''' Attempt to reconnect if we haven't tried to reconnect too recently '''
+		now = datetime.utcnow()
+		delta = now - self.lastReconnectAttempt
+		if delta.seconds < 30:
+			return self.status
+		else:
+			self.status = self._ping()
+			return self.status
+
+	def _check_status(self):
+		''' If we're in a known bad state, try to reconnect '''
+		if not self.status and not self._attempt_reconnect():
+			raise elasticsearch.ConnectionError
+		return self.status
+
+	def _execute_raw_query(self, func, **kargs):
+		''' Wraps the es client to make sure that ConnectionErrors are handled uniformly '''
+		self._check_status()
+		try:
+			results = func(**kargs)
+			return results
+		except elasticsearch.ConnectionError:
+			self.status = False
+			raise elasticsearch.ConnectionError
+		except Exception:
+			return None
+
+	def execute_search(self, **kargs):
+		''' Execute an arbitrary search. This is where we should instrument things specific to es.search '''
+		results = self._execute_raw_query(self.es.search, doc_type='_doc', **kargs)
+		return results
+
+	def execute_count(self, **kargs):
+		''' Executes an arbitrary count. This is where we should instrument things specific to es.count '''
+		results = self._execute_raw_query(self.es.count, doc_type='_doc', **kargs)
+		if not results:
+			return 0
+		return results
+
+	def execute_delete_by_query(self, **kargs):
+		''' Executes an arbitrary delete_by_query. This is where we should instrument things specific to es.delete_by_query '''
+		results = self._execute_raw_query(self.es.delete_by_query, doc_type='_doc', **kargs)
+		return results
+
+	def execute_index(self, **kargs):
+		''' Executes an arbitrary index. This is where we should instrument things specific to es.index '''
+		results = self._execute_raw_query(self.es.index, doc_type='_doc', **kargs)
+		return results
+
+	def get_collection(self, **kargs):
+		''' Execute a search and return a collection of results '''
+		results = self.execute_search(**kargs)
+		if not results:
+			return 0, []
+		docsources = self.collate_source(results['hits']['hits'])
+		return results['hits']['total'], docsources
+
+	def get_single_host(self, **kargs):
+		''' Execute a search and return a single result '''
+		results = self.execute_search(**kargs)
+		if not results or results['hits']['total'] == 0:
+			return 0, None
+		return results['hits']['total'], results['hits']['hits'][0]['_source']
+
+	def collate_source(self, documents):
+		results = []
+		for doc in documents:
+			results.append(doc['_source'])
+		return results

--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -26,6 +26,7 @@ class ElasticClient:
 				self._initialize_indices()
 		except Exception:
 			self.status = False
+			raise
 		finally:
 			# Set the lastReconnectAttempt to the timestamp after initialization
 			self.lastReconnectAttempt = datetime.utcnow()
@@ -66,8 +67,6 @@ class ElasticClient:
 		except elasticsearch.ConnectionError:
 			self.status = False
 			raise elasticsearch.ConnectionError
-		except Exception:
-			return None
 
 	def execute_search(self, **kargs):
 		''' Execute an arbitrary search. This is where we should instrument things specific to es.search '''
@@ -107,7 +106,4 @@ class ElasticClient:
 		return results['hits']['total'], results['hits']['hits'][0]['_source']
 
 	def collate_source(self, documents):
-		results = []
-		for doc in documents:
-			results.append(doc['_source'])
-		return results
+		return map(lambda doc: doc['_source'], documents)

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -45,8 +45,7 @@ class ElasticInterface:
 				}
 			}
 		}
-		result = self.client.get_collection(index=searchIndex, body=searchBody)
-		return result
+		return self.client.get_collection(index=searchIndex, body=searchBody)
 
 	def total_hosts(self):
 		''' Count the number of documents in nmap and return the count '''
@@ -79,8 +78,7 @@ class ElasticInterface:
 				}
 			}
 		}
-		result = self.client.get_single_host(index='nmap_history', body=searchBody)
-		return result
+		return self.client.get_single_host(index='nmap_history', body=searchBody)
 
 	def get_host_history(self, ip, limit, offset):
 		''' Gets a collection of historical results for a specific ip address '''
@@ -100,8 +98,7 @@ class ElasticInterface:
 				}
 			}
 		}
-		result = self.client.get_collection(index='nmap_history', body=searchBody)
-		return result
+		return self.client.get_collection(index='nmap_history', body=searchBody)
 
 	def count_host_screenshots(self, ip):
 		''' Search history for an ip address and returns the number of historical screenshots '''
@@ -119,7 +116,7 @@ class ElasticInterface:
 			}
 		}
 		# By setting size to 0, _source to False, and track_scores to False, we're able to optimize this query to give us only what we care about
-		result = self.client.execute_search(index="nmap_history", body=searchBody, size=0, _source=False, track_scores=False)
+		result = self.client.execute_search(index="nmap_history", body=searchBody, size=0, track_scores=False)
 		num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
 		return num_screenshots
 
@@ -153,8 +150,7 @@ class ElasticInterface:
 			}
 		}
 		source_fields = ['screenshots', 'ctime', 'scan_id']
-		result = self.client.get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
-		return result
+		return self.client.get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
 
 	def get_host_by_scan_id(self, scan_id):
 		''' Get a specific historical result based on scan_id, which should be unique '''
@@ -173,8 +169,7 @@ class ElasticInterface:
 				}
 			}
 		}
-		result = self.client.get_single_host(index='nmap_history', body=searchBody)
-		return result
+		return self.client.get_single_host(index='nmap_history', body=searchBody)
 
 	def delete_scan(self, scan_id):
 		''' Delete a specific scan, if it's the most recent then try to migrate the next oldest back into the nmap index '''

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -1,117 +1,13 @@
-import json
-import elasticsearch
-import sys
-from datetime import datetime
-from config import Config
-import logging
+from app.elastic import ElasticClient
 import random
+import sys
 
 
-class Elastic:
-	es = None
-	status = False
-	natlasIndices = ["nmap", "nmap_history"]
-	mapping = {}
-	lastReconnectAttempt = None
-	logger = logging.getLogger('elasticsearch')
-	logger.setLevel('ERROR')
+class ElasticInterface:
+	client = None
 
-	def __init__(self, elasticURL):
-		# Elastic is initialized outside an application context so we have to instatiate Config ourselves to get BASEDIR
-		with open(Config().BASEDIR + '/defaults/elastic/mapping.json') as mapfile:
-			self.mapping = json.loads(mapfile.read())
-		try:
-			self.es = elasticsearch.Elasticsearch(elasticURL, timeout=5, max_retries=1)
-			self.status = self._ping()
-			if self.status:
-				self._initialize_indices()
-		except Exception:
-			self.status = False
-			return
-		finally:
-			# Set the lastReconnectAttempt to the timestamp after initialization
-			self.lastReconnectAttempt = datetime.utcnow()
-
-	def _initialize_indices(self):
-		''' Check each required index and make sure it exists, if it doesn't then create it '''
-		for index in self.natlasIndices:
-			if not self.es.indices.exists(index):
-				self.es.indices.create(index, body=self.mapping)
-
-	def _ping(self):
-		''' Returns True if the cluster is up, False otherwise'''
-		return self.es.ping()
-
-	def _attempt_reconnect(self):
-		''' Attempt to reconnect if we haven't tried to reconnect too recently '''
-		now = datetime.utcnow()
-		delta = now - self.lastReconnectAttempt
-		if delta.seconds < 30:
-			return self.status
-		else:
-			self.status = self._ping()
-			return self.status
-
-	def _check_status(self):
-		''' If we're in a known bad state, try to reconnect '''
-		if not self.status and not self._attempt_reconnect():
-			raise elasticsearch.ConnectionError
-		return self.status
-
-	def _execute_raw_query(self, func, **kargs):
-		''' Wraps the es client to make sure that ConnectionErrors are handled uniformly '''
-		self._check_status()
-		try:
-			results = func(**kargs)
-			return results
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
-		except Exception:
-			return None
-
-	def _execute_search(self, **kargs):
-		''' Execute an arbitrary search. This is where we should instrument things specific to es.search '''
-		results = self._execute_raw_query(self.es.search, doc_type='_doc', **kargs)
-		return results
-
-	def _execute_count(self, **kargs):
-		''' Executes an arbitrary count. This is where we should instrument things specific to es.count '''
-		results = self._execute_raw_query(self.es.count, doc_type='_doc', **kargs)
-		if not results:
-			return 0
-		return results
-
-	def _execute_delete_by_query(self, **kargs):
-		''' Executes an arbitrary delete_by_query. This is where we should instrument things specific to es.delete_by_query '''
-		results = self._execute_raw_query(self.es.delete_by_query, doc_type='_doc', **kargs)
-		return results
-
-	def _execute_index(self, **kargs):
-		''' Executes an arbitrary index. This is where we should instrument things specific to es.index '''
-		results = self._execute_raw_query(self.es.index, doc_type='_doc', **kargs)
-		return results
-
-	def _get_collection(self, **kargs):
-		''' Execute a search and return a collection of results '''
-		results = self._execute_search(**kargs)
-		if not results:
-			return 0, []
-		docsources = self._collate_source(results['hits']['hits'])
-		return results['hits']['total'], docsources
-
-	def _get_single_host(self, **kargs):
-		''' Execute a search and return a single result '''
-		results = self._execute_search(**kargs)
-		if not results or results['hits']['total'] == 0:
-			return 0, None
-		return results['hits']['total'], results['hits']['hits'][0]['_source']
-
-	def _collate_source(self, documents):
-		results = []
-		for doc in documents:
-			results.append(doc['_source'])
-		return results
+	def __init__(self, elasticUrl):
+		self.client = ElasticClient(elasticUrl)
 
 	def search(self, limit, offset, query='nmap', searchIndex="nmap"):
 		''' Execute a user supplied search and return the results '''
@@ -149,20 +45,20 @@ class Elastic:
 				}
 			}
 		}
-		result = self._get_collection(index=searchIndex, body=searchBody)
+		result = self.client.get_collection(index=searchIndex, body=searchBody)
 		return result
 
 	def total_hosts(self):
 		''' Count the number of documents in nmap and return the count '''
-		result = self._execute_count(index="nmap")
+		result = self.client.execute_count(index="nmap")
 		return result["count"]
 
 	def new_result(self, host):
 		''' Create new elastic documents in both indices for a new scan result '''
 		ip = str(host['ip'])
 
-		self._execute_index(index='nmap_history', body=host)
-		self._execute_index(index='nmap', id=ip, body=host)
+		self.client.execute_index(index='nmap_history', body=host)
+		self.client.execute_index(index='nmap', id=ip, body=host)
 		return True
 
 	def get_host(self, ip):
@@ -183,7 +79,7 @@ class Elastic:
 				}
 			}
 		}
-		result = self._get_single_host(index='nmap_history', body=searchBody)
+		result = self.client.get_single_host(index='nmap_history', body=searchBody)
 		return result
 
 	def get_host_history(self, ip, limit, offset):
@@ -204,7 +100,7 @@ class Elastic:
 				}
 			}
 		}
-		result = self._get_collection(index='nmap_history', body=searchBody)
+		result = self.client.get_collection(index='nmap_history', body=searchBody)
 		return result
 
 	def count_host_screenshots(self, ip):
@@ -223,7 +119,7 @@ class Elastic:
 			}
 		}
 		# By setting size to 0, _source to False, and track_scores to False, we're able to optimize this query to give us only what we care about
-		result = self._execute_search(index="nmap_history", body=searchBody, size=0, _source=False, track_scores=False)
+		result = self.client.execute_search(index="nmap_history", body=searchBody, size=0, _source=False, track_scores=False)
 		num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
 		return num_screenshots
 
@@ -257,7 +153,7 @@ class Elastic:
 			}
 		}
 		source_fields = ['screenshots', 'ctime', 'scan_id']
-		result = self._get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
+		result = self.client.get_collection(index="nmap_history", body=searchBody, _source=source_fields, track_scores=False)
 		return result
 
 	def get_host_by_scan_id(self, scan_id):
@@ -277,7 +173,7 @@ class Elastic:
 				}
 			}
 		}
-		result = self._get_single_host(index='nmap_history', body=searchBody)
+		result = self.client.get_single_host(index='nmap_history', body=searchBody)
 		return result
 
 	def delete_scan(self, scan_id):
@@ -297,7 +193,7 @@ class Elastic:
 				}
 			}
 		}
-		count, host = self._get_single_host(index='nmap', body=searchBody)
+		count, host = self.client.get_single_host(index='nmap', body=searchBody)
 		if count != 0:
 			# we're deleting the most recent scan result and need to pull the next most recent into the nmap index
 			# otherwise you won't find the host when doing searches or browsing
@@ -317,7 +213,7 @@ class Elastic:
 				}
 			}
 
-			count, twoscans = self._get_collection(index="nmap_history", body=secondBody)
+			count, twoscans = self.client.get_collection(index="nmap_history", body=secondBody)
 			# If count is one then there's only one result in history so we can just delete it.
 			# If count is > 1 then we need to migrate the next oldest scan data
 			if count > 1:
@@ -331,9 +227,9 @@ class Elastic:
 				}
 			}
 		}
-		result = self._execute_delete_by_query(index="nmap,nmap_history", body=deleteBody)
+		result = self.client.execute_delete_by_query(index="nmap,nmap_history", body=deleteBody)
 		if migrate:
-			self._execute_index(index='nmap', id=ipaddr, body=twoscans[1])
+			self.client.execute_index(index='nmap', id=ipaddr, body=twoscans[1])
 		return result["deleted"]
 
 	def delete_host(self, ip):
@@ -347,7 +243,7 @@ class Elastic:
 				}
 			}
 		}
-		deleted = self._execute_delete_by_query(index="nmap,nmap_history", body=searchBody)
+		deleted = self.client.execute_delete_by_query(index="nmap,nmap_history", body=searchBody)
 		return deleted["deleted"]
 
 	def random_host(self):
@@ -383,7 +279,7 @@ class Elastic:
 				}
 			}
 		}
-		count, host = self._get_single_host(index="nmap", body=searchBody)
+		count, host = self.client.get_single_host(index="nmap", body=searchBody)
 		return host
 
 	def get_current_screenshots(self, limit, offset):
@@ -413,8 +309,8 @@ class Elastic:
 		}
 		source_fields = ["screenshots", "ctime", "scan_id", "ip"]
 		# We need to execute_search instead of get_collection here because we also need the aggregation information
-		result = self._execute_search(index="nmap", body=searchBody, _source=source_fields, track_scores=False)
+		result = self.client.execute_search(index="nmap", body=searchBody, _source=source_fields, track_scores=False)
 		num_screenshots = int(result['aggregations']["screenshot_count"]["value"])
-		results = self._collate_source(result['hits']['hits'])
+		results = self.client.collate_source(result['hits']['hits'])
 
 		return result['hits']['total'], num_screenshots, results

--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -1,6 +1,8 @@
 from flask import render_template
 from app.errors import bp
 from app import db
+import elasticsearch
+import sentry_sdk
 
 
 @bp.app_errorhandler(404)
@@ -17,3 +19,9 @@ def method_not_allowed(e):
 def internal_server_error(e):
 	db.session.rollback()
 	return render_template('errors/500.html'), 500
+
+
+@bp.app_errorhandler(elasticsearch.TransportError)
+def elastic_unavailable(e):
+	sentry_sdk.capture_exception(e)
+	return render_template('errors/503.html'), 503

--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -21,7 +21,7 @@ def internal_server_error(e):
 	return render_template('errors/500.html'), 500
 
 
-@bp.app_errorhandler(elasticsearch.TransportError)
+@bp.app_errorhandler(elasticsearch.ConnectionError)
 def elastic_unavailable(e):
 	sentry_sdk.capture_exception(e)
 	return render_template('errors/503.html'), 503

--- a/natlas-server/app/host/routes.py
+++ b/natlas-server/app/host/routes.py
@@ -45,7 +45,7 @@ def host_history(ip):
 	delHostForm = DeleteForm()
 	rescanForm = RescanForm()
 
-	count, context = current_app.elastic.gethost_history(
+	count, context = current_app.elastic.get_host_history(
 		ip, current_user.results_per_page, searchOffset)
 	if count == 0:
 		abort(404)
@@ -75,7 +75,7 @@ def host_historical_result(ip, scan_id):
 	delHostForm = DeleteForm()
 	rescanForm = RescanForm()
 	info, context = hostinfo(ip)
-	count, context = current_app.elastic.gethost_scan_id(scan_id)
+	count, context = current_app.elastic.get_host_by_scan_id(scan_id)
 
 	version = determine_data_version(context)
 	template_str = f"host/versions/{version}/summary.html"
@@ -103,7 +103,7 @@ def export_scan(ip, scan_id, ext):
 	else:
 		mime = "text/plain"
 
-	count, context = current_app.elastic.gethost_scan_id(scan_id)
+	count, context = current_app.elastic.get_host_by_scan_id(scan_id)
 	if ext == 'json' and count > 0:
 		return Response(json.dumps(context), mimetype=mime)
 	elif count > 0 and export_field in context:
@@ -197,9 +197,10 @@ def rescan_host(ip):
 @bp.route("/random/")
 def random_host():
 	random_host = current_app.elastic.random_host()
+	# This would most likely occur when there are no hosts up in the index, so just throw a 404
 	if not random_host:
 		abort(404)
-	ip = random_host['hits']['hits'][0]['_source']['ip']
+	ip = random_host['ip']
 	info, context = hostinfo(ip)
 	delForm = DeleteForm()
 	delHostForm = DeleteForm()

--- a/natlas-server/app/host/routes.py
+++ b/natlas-server/app/host/routes.py
@@ -195,6 +195,7 @@ def rescan_host(ip):
 
 @bp.route("/random")
 @bp.route("/random/")
+@isAuthenticated
 def random_host():
 	random_host = current_app.elastic.random_host()
 	# This would most likely occur when there are no hosts up in the index, so just throw a 404

--- a/natlas-server/app/host/summarizers.py
+++ b/natlas-server/app/host/summarizers.py
@@ -3,7 +3,7 @@ from flask import current_app, abort
 
 def hostinfo(ip):
 	hostinfo = {}
-	count, context = current_app.elastic.gethost(ip)
+	count, context = current_app.elastic.get_host(ip)
 	if count == 0:
 		return abort(404)
 	hostinfo['history'] = count

--- a/natlas-server/app/main/pagination.py
+++ b/natlas-server/app/main/pagination.py
@@ -1,0 +1,16 @@
+from flask_login import current_user
+from flask import url_for
+
+
+def build_pagination_urls(route, page, count, **kargs):
+	next_url = url_for(route, page=page + 1, **kargs) \
+		if count > page * current_user.results_per_page else None
+	prev_url = url_for(route, page=page - 1, **kargs) \
+		if page > 1 else None
+	return next_url, prev_url
+
+
+def results_offset(page):
+	results_per_page = current_user.results_per_page
+	search_offset = results_per_page * (page - 1)
+	return results_per_page, search_offset

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -1,7 +1,7 @@
 from flask import redirect, url_for, render_template, \
 	Response, current_app, request, send_from_directory
-from flask_login import current_user
 from app.main import bp
+from app.main.pagination import build_pagination_urls, results_offset
 from app.auth.wrappers import isAuthenticated
 
 
@@ -26,9 +26,7 @@ def browse():
 	page = int(request.args.get('page', 1))
 	includeHistory = request.args.get('includeHistory', False)
 
-	results_per_page = current_user.results_per_page
-	search_offset = results_per_page * (page - 1)
-
+	results_per_page, search_offset = results_offset(page)
 
 	searchIndex = "nmap_history" if includeHistory else "nmap"
 
@@ -36,16 +34,11 @@ def browse():
 	totalHosts = current_app.elastic.total_hosts()
 
 	if includeHistory:
-		next_url = url_for('main.browse', page=page + 1, includeHistory=includeHistory) \
-			if count > page * results_per_page else None
-		prev_url = url_for('main.browse', page=page - 1, includeHistory=includeHistory) \
-			if page > 1 else None
+		next_url, prev_url = build_pagination_urls('main.browse', page, count, includeHistory=includeHistory)
 	else:
 		# By using the if/else we can avoid putting includeHistory=False into the url that gets constructed
-		next_url = url_for('main.browse', page=page + 1) \
-			if count > page * results_per_page else None
-		prev_url = url_for('main.browse', page=page - 1) \
-			if page > 1 else None
+		next_url, prev_url = build_pagination_urls('main.browse', page, count)
+
 	return render_template("main/browse.html", numresults=count, totalHosts=totalHosts, page=page, hosts=hostdata, next_url=next_url, prev_url=prev_url)
 
 
@@ -59,23 +52,17 @@ def search():
 	scan_ids = request.args.get('includeScanIDs', '')
 	includeHistory = request.args.get('includeHistory', False)
 
-	results_per_page = current_user.results_per_page
-	search_offset = results_per_page * (page - 1)
+	results_per_page, search_offset = results_offset(page)
+
 	searchIndex = "nmap_history" if includeHistory else "nmap"
 
 	count, context = current_app.elastic.search(results_per_page, search_offset, query=query, searchIndex=searchIndex)
 	totalHosts = current_app.elastic.total_hosts()
 
 	if includeHistory:
-		next_url = url_for('main.search', query=query, page=page + 1, includeHistory=includeHistory) \
-			if count > page * results_per_page else None
-		prev_url = url_for('main.search', query=query, page=page - 1, includeHistory=includeHistory) \
-			if page > 1 else None
+		next_url, prev_url = build_pagination_urls('main.search', page, count, query=query, includeHistory=includeHistory)
 	else:
-		next_url = url_for('main.search', query=query, page=page + 1) \
-			if count > page * results_per_page else None
-		prev_url = url_for('main.search', query=query, page=page - 1) \
-			if page > 1 else None
+		next_url, prev_url = build_pagination_urls('main.search', page, count, query=query)
 
 	# what kind of output are we looking for?
 	if format == 'hostlist':
@@ -87,7 +74,16 @@ def search():
 				hostlist.append(str(host['ip']))
 		return Response('\n'.join(hostlist), mimetype='text/plain')
 	else:
-		return render_template("main/search.html", query=query, numresults=count, totalHosts=totalHosts, page=page, hosts=context, next_url=next_url, prev_url=prev_url)
+		return render_template(
+			"main/search.html",
+			query=query,
+			numresults=count,
+			totalHosts=totalHosts,
+			page=page,
+			hosts=context,
+			next_url=next_url,
+			prev_url=prev_url
+		)
 
 
 @bp.route('/searchmodal')
@@ -97,16 +93,20 @@ def search_modal():
 
 
 @bp.route("/screenshots")
-@bp.route("/screenshots/")
 def browseScreenshots():
-	page = int(request.args.get('p', 1))
-	searchOffset = current_user.results_per_page * (page - 1)
+	page = int(request.args.get('page', 1))
 
-	total_hosts, total_screenshots, hosts = current_app.elastic.get_current_screenshots(current_user.results_per_page, searchOffset)
+	results_per_page, search_offset = results_offset(page)
 
-	next_url = url_for('main.browseScreenshots', p=page + 1) \
-		if total_hosts > page * current_user.results_per_page else None
-	prev_url = url_for('main.browseScreenshots', p=page - 1) \
-		if page > 1 else None
+	total_hosts, total_screenshots, hosts = current_app.elastic.get_current_screenshots(results_per_page, search_offset)
 
-	return render_template("main/screenshots.html", total_hosts=total_hosts, total_screenshots=total_screenshots, hosts=hosts, next_url=next_url, prev_url=prev_url)
+	next_url, prev_url = build_pagination_urls('main.browseScreenshots', page, total_hosts)
+
+	return render_template(
+		"main/screenshots.html",
+		total_hosts=total_hosts,
+		total_screenshots=total_screenshots,
+		hosts=hosts,
+		next_url=next_url,
+		prev_url=prev_url
+	)

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -13,6 +13,7 @@ def index():
 
 # Serve media files in case the front-end proxy doesn't do it
 @bp.route('/media/<path:filename>')
+@isAuthenticated
 def send_media(filename):
 	# If you're looking at this function, wondering why your files aren't sending...
 	# It's probably because current_app.config['MEDIA_DIRECTORY'] isn't pointing to an absolute file path
@@ -93,6 +94,7 @@ def search_modal():
 
 
 @bp.route("/screenshots")
+@isAuthenticated
 def screenshots():
 	page = int(request.args.get('page', 1))
 

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -93,14 +93,14 @@ def search_modal():
 
 
 @bp.route("/screenshots")
-def browseScreenshots():
+def screenshots():
 	page = int(request.args.get('page', 1))
 
 	results_per_page, search_offset = results_offset(page)
 
 	total_hosts, total_screenshots, hosts = current_app.elastic.get_current_screenshots(results_per_page, search_offset)
 
-	next_url, prev_url = build_pagination_urls('main.browseScreenshots', page, total_hosts)
+	next_url, prev_url = build_pagination_urls('main.screenshots', page, total_hosts)
 
 	return render_template(
 		"main/screenshots.html",

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -8,7 +8,7 @@ from app.auth.wrappers import isAuthenticated
 @bp.route('/')
 @isAuthenticated
 def index():
-	return redirect(url_for('main.search'))
+	return redirect(url_for('main.browse'))
 
 
 # Serve media files in case the front-end proxy doesn't do it
@@ -19,9 +19,40 @@ def send_media(filename):
 	return send_from_directory(current_app.config['MEDIA_DIRECTORY'], filename)
 
 
+@bp.route('/browse')
+@isAuthenticated
+def browse():
+	''' A simple browser that doesn't deal with queries at all '''
+	page = int(request.args.get('page', 1))
+	includeHistory = request.args.get('includeHistory', False)
+
+	results_per_page = current_user.results_per_page
+	search_offset = results_per_page * (page - 1)
+
+
+	searchIndex = "nmap_history" if includeHistory else "nmap"
+
+	count, hostdata = current_app.elastic.search(results_per_page, search_offset, searchIndex=searchIndex)
+	totalHosts = current_app.elastic.total_hosts()
+
+	if includeHistory:
+		next_url = url_for('main.browse', page=page + 1, includeHistory=includeHistory) \
+			if count > page * results_per_page else None
+		prev_url = url_for('main.browse', page=page - 1, includeHistory=includeHistory) \
+			if page > 1 else None
+	else:
+		# By using the if/else we can avoid putting includeHistory=False into the url that gets constructed
+		next_url = url_for('main.browse', page=page + 1) \
+			if count > page * results_per_page else None
+		prev_url = url_for('main.browse', page=page - 1) \
+			if page > 1 else None
+	return render_template("main/browse.html", numresults=count, totalHosts=totalHosts, page=page, hosts=hostdata, next_url=next_url, prev_url=prev_url)
+
+
 @bp.route('/search')
 @isAuthenticated
 def search():
+	''' Return search results for a given query '''
 	query = request.args.get('query', '')
 	page = int(request.args.get('page', 1))
 	format = request.args.get('format', '')
@@ -29,14 +60,11 @@ def search():
 	includeHistory = request.args.get('includeHistory', False)
 
 	results_per_page = current_user.results_per_page
-	if includeHistory:
-		searchIndex = "nmap_history"
-	else:
-		searchIndex = "nmap"
+	search_offset = results_per_page * (page - 1)
+	searchIndex = "nmap_history" if includeHistory else "nmap"
 
-	searchOffset = results_per_page * (page - 1)
-	count, context = current_app.elastic.search(query, results_per_page, searchOffset, searchIndex=searchIndex)
-	totalHosts = current_app.elastic.totalHosts()
+	count, context = current_app.elastic.search(results_per_page, search_offset, query=query, searchIndex=searchIndex)
+	totalHosts = current_app.elastic.total_hosts()
 
 	if includeHistory:
 		next_url = url_for('main.search', query=query, page=page + 1, includeHistory=includeHistory) \
@@ -59,7 +87,7 @@ def search():
 				hostlist.append(str(host['ip']))
 		return Response('\n'.join(hostlist), mimetype='text/plain')
 	else:
-		return render_template("search.html", query=query, numresults=count, totalHosts=totalHosts, page=page, hosts=context, next_url=next_url, prev_url=prev_url)
+		return render_template("main/search.html", query=query, numresults=count, totalHosts=totalHosts, page=page, hosts=context, next_url=next_url, prev_url=prev_url)
 
 
 @bp.route('/searchmodal')
@@ -81,4 +109,4 @@ def browseScreenshots():
 	prev_url = url_for('main.browseScreenshots', p=page - 1) \
 		if page > 1 else None
 
-	return render_template("screenshots.html", numresults=total_screenshots, hosts=hosts, next_url=next_url, prev_url=prev_url)
+	return render_template("main/screenshots.html", total_hosts=total_hosts, total_screenshots=total_screenshots, hosts=hosts, next_url=next_url, prev_url=prev_url)

--- a/natlas-server/app/templates/admin/index.html
+++ b/natlas-server/app/templates/admin/index.html
@@ -28,13 +28,6 @@
             {{ configForm.custom_brand.label(class="control-label") }}
             {{ configForm.custom_brand(value=configItems["CUSTOM_BRAND"], class="form-control", placeholder="Natlas Internal") }}
         </div>
-    	<div class="form-group">
-    		{{ configForm.elasticsearch_url.label(class="control-label") }}
-    		{{ configForm.elasticsearch_url(value=configItems["ELASTICSEARCH_URL"], class="form-control", placeholder="http://localhost:9200") }}
-            {% for error in configForm.elasticsearch_url.errors %}
-                <span style="color: red;">{{ error }}</span>
-            {% endfor %}
-    	</div>
     	<h3>Mail Settings</h3>
     	<small id="mailSettingsHelp" class="form-text text-muted">Mail settings are used to send invitation emails and password resets.</small>
     	<div class="form-group">

--- a/natlas-server/app/templates/errors/500.html
+++ b/natlas-server/app/templates/errors/500.html
@@ -2,8 +2,14 @@
 {% set title = "500 - Internal Server Error" %}
 {% block content %}
   <div class="row">
-  	<h2 class="sub-header">500: Internal Server Error</h2>
-    <p>You can try to return to <a href="{{ url_for('main.index') }}">browse</a></p>
-    <p>If you continue to see this message, please contact the administrator.</p>
+  	<div class="col">
+  		<h2 class="sub-header">500: Internal Server Error</h2>
+  	</div>
   </div>
+  <div class="row">
+  	<div class="col">
+    	<p>You can try to return to <a href="{{ url_for('main.index') }}">browse</a></p>
+    	<p>If you continue to see this message, please contact the administrator.</p>
+    </div>
+   </div>
 {% endblock %}

--- a/natlas-server/app/templates/errors/503.html
+++ b/natlas-server/app/templates/errors/503.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% set title = "503 - Service Unavailable" %}
+{% block content %}
+  <div class="row">
+  	<div class="col">
+  		<h2 class="sub-header">503: Service Unavailable</h2>
+  	</div>
+  </div>
+  <div class="row">
+  	<div class="col">
+    	<p>Please try again in a few minutes.</a></p>
+    </div>
+   </div>
+{% endblock %}

--- a/natlas-server/app/templates/includes/nav.html
+++ b/natlas-server/app/templates/includes/nav.html
@@ -11,7 +11,7 @@
               <a class="nav-link" href="{{ url_for('main.browse') }}">Browse</a>
             </li>
             <li>
-              <a class="nav-link" href="{{ url_for('main.browseScreenshots') }}">Screenshots</a>
+              <a class="nav-link" href="{{ url_for('main.screenshots') }}">Screenshots</a>
             </li>
             <li>
               <a class="nav-link" href="{{ url_for('host.random_host') }}">Random</a>

--- a/natlas-server/app/templates/includes/nav.html
+++ b/natlas-server/app/templates/includes/nav.html
@@ -8,7 +8,7 @@
 
           <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
             <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('main.search') }}">Browse</a>
+              <a class="nav-link" href="{{ url_for('main.browse') }}">Browse</a>
             </li>
             <li>
               <a class="nav-link" href="{{ url_for('main.browseScreenshots') }}">Screenshots</a>

--- a/natlas-server/app/templates/main/_host_collection.html
+++ b/natlas-server/app/templates/main/_host_collection.html
@@ -1,0 +1,12 @@
+{% for host in hosts %}
+  {% if host['agent_version'] %}
+    {% set version_list = host['agent_version'].split('.') %}
+    {% if version_list[0] == 0 and version_list[1]|int <= 6 and version_list[2]|int <= 4 %}
+      {% include 'host/versions/0.6.4/_host-row.html' %}
+    {% else %}
+      {% include 'host/versions/'+host["agent_version"]+'/_host-row.html' %}
+    {% endif %}
+  {% else %}
+    {% include 'host/versions/0.6.4/_host-row.html' %}
+  {% endif %}
+{% endfor %}

--- a/natlas-server/app/templates/main/browse.html
+++ b/natlas-server/app/templates/main/browse.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% set pagetype = 'search' %}
+{% set title = "Browse | Page " ~ page %}
+
+{% block content %}
+  <div class="row search-header mb-3">
+    <div class="col">
+      {% if request.args.get('includeHistory') %}
+      <h2 class="sub-header">{{ numresults }} results across {{ totalHosts }} hosts <small>(including history)</small></h2>
+      {% else %}
+      <h2 class="sub-header">{{ numresults }} results across {{ totalHosts }} hosts</h2>
+      {% endif %}
+    </div>
+    {% if numresults > current_user.results_per_page %}
+      <div class="col-xs-12 col-sm-1">
+        {% include 'includes/pagination.html' %}
+      </div>
+    {% endif %}
+  </div>
+  <div class="host-rows">
+    {% include 'main/_host_collection.html' %}
+  </div>
+  {% include 'host/_imagemodal.html' %}
+  {% if numresults > current_user.results_per_page %}
+    <div class="row">
+      <div class="col text-center my-2">
+        {% include 'includes/pagination.html' %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/natlas-server/app/templates/main/screenshots.html
+++ b/natlas-server/app/templates/main/screenshots.html
@@ -3,9 +3,9 @@
 {% block content %}
 	<div class="row search-header">
 		<div class="col">
-			<h2 class="sub-header">{{numresults}} screenshots</h2>
+			<h2 class="sub-header">{{total_screenshots}} screenshots across {{total_hosts}} hosts</h2>
 		</div>
-		{% if numresults > current_user.results_per_page %}
+		{% if total_hosts > current_user.results_per_page %}
 		<div class="col-xs-12 col-sm-1 text-center">
 		{% include 'includes/pagination.html' %}
 		</div>
@@ -30,7 +30,7 @@
 			{% endfor %}
 		</div>
 
-	{% if numresults > current_user.results_per_page %}
+	{% if total_hosts > current_user.results_per_page %}
     <div class="row">
       <div class="col text-center my-2">
       {% include 'includes/pagination.html' %}

--- a/natlas-server/app/templates/main/search.html
+++ b/natlas-server/app/templates/main/search.html
@@ -29,18 +29,7 @@
     {% endif %}
   </div>
   <div class="host-rows">
-  {% for host in hosts %}
-    {% if host['agent_version'] %}
-      {% set version_list = host['agent_version'].split('.') %}
-      {% if version_list[0] == 0 and version_list[1]|int <= 6 and version_list[2]|int <= 4 %}
-        {% include 'host/versions/0.6.4/_host-row.html' %}
-      {% else %}
-        {% include 'host/versions/'+host["agent_version"]+'/_host-row.html' %}
-      {% endif %}
-    {% else %}
-      {% include 'host/versions/0.6.4/_host-row.html' %}
-    {% endif %}
-  {% endfor %}
+    {% include 'main/_host_collection.html' %}
   </div>
   {% include 'host/_imagemodal.html' %}
   {% if numresults > current_user.results_per_page %}

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -29,6 +29,9 @@ class Config(object):
 	# Also make sure that you're using an absolute path if you're serving your app directly via flask
 	MEDIA_DIRECTORY = os.environ.get('MEDIA_DIRECTORY') or os.path.join(BASEDIR, 'media/')
 
+	# Elasticsearch only gets loaded from environment
+	ELASTICSEARCH_URL = os.environ.get('ELASTICSEARCH_URL') or 'http://localhost:9200'
+
 	# Allow version overrides for local development
 	# Necessary to test versioned host data templates before release
 	version_override = os.environ.get("NATLAS_VERSION_OVERRIDE") or None
@@ -44,7 +47,6 @@ defaultConfig = [
 	("LOGIN_REQUIRED", "bool", "False"),
 	("REGISTER_ALLOWED", "bool", "False"),
 	("AGENT_AUTHENTICATION", "bool", "False"),
-	("ELASTICSEARCH_URL", "string", os.getenv("ELASTICSEARCH_URL", "http://localhost:9200")),
 	("MAIL_SERVER", "string", "localhost"),
 	("MAIL_PORT", "int", "25"),
 	("MAIL_USE_TLS", "bool", "False"),


### PR DESCRIPTION
A bunch of changes to support improved elasticsearch interfacing. This set of changes should enable #219 to be done more easily as the types of queries we execute are separated out into their own functions. This also uses a base function called `execute_raw_query` through which all of the elastic interfacing happens. This means that we can have our status check and exception handling in a single function instead of in all of our functions. 

Also introduced some changes to routing, via `/browse` endpoint becoming separate from the `/search` endpoint. This occurs in this PR because I was making changes to the elastic.py `search` function and realized that a default argument made more sense than checking if the argument was empty and then setting a default value based on that. But that introduced some other issues with the way queries worked for "browse" versus "search" capability. By separating them, we'll get simpler functions, simpler templates, and move closer towards single-purpose routes.

It also includes a fix for #221 and many similar failures that were related to it.

@ajacques Let me know if this set of changes to the elastic class makes it easier to implement the performance tracing stuff we talked about. I tried to follow your design pattern a bit, but also took a couple liberties in what I think are improvements (i.e. not doing tracing at the raw query level but rather at the `execute_<query type>` level, so that you can augment the data according to the type of results we expect to get from that type of query.