### PR TITLE
Update getRandom to better iterate on small values, closes #215

### DIFF
--- a/natlas-server/app/cyclicprng.py
+++ b/natlas-server/app/cyclicprng.py
@@ -90,8 +90,13 @@ class CyclicPRNG:
 		self.current = self.start
 
 	def getRandom(self):
+		# PRNG can't iterate on small values
 		if self.N <= 2:
-			return random.randint(1, self.N)
+			if self.current == 0 or self.N == 1:
+				self.current = random.randint(1, self.N)
+				return self.current
+			else:
+				return (self.current % 2) + 1
 		mutex.acquire()
 		value = self.current
 		self.current = (self.current * self.G) % self.Modulus

--- a/natlas-server/app/cyclicprng.py
+++ b/natlas-server/app/cyclicprng.py
@@ -92,11 +92,17 @@ class CyclicPRNG:
 	def getRandom(self):
 		# PRNG can't iterate on small values
 		if self.N <= 2:
-			if self.current == 0 or self.N == 1:
-				self.current = random.randint(1, self.N)
-				return self.current
+			if self.G == 0 or self.N == 1:
+				self.G = random.randint(1, self.N)
+				value = self.G
+				self.current = self.current + 1
 			else:
-				return (self.current % 2) + 1
+				self.current = self.current + 1
+				value = (self.G % 2) + 1
+			if self.current >= self.N:
+				self.current = 0
+				self.G = 0
+			return value
 		mutex.acquire()
 		value = self.current
 		self.current = (self.current * self.G) % self.Modulus


### PR DESCRIPTION
Repeatedly calling randint() on small values will generate large runs of the same digit. This PR suppresses them.

Old:
```
22212111212121112211221222221111112122112121222221
22122112122221112121121111112222221221112122122221
22111121222122121112211221111111121121112112212121
```

New:
```
21122121122112211212212112121221212112212112121221 
12212112122112122121122112122121212121212121211221
12212121211212122121211212122121211221211221121221
```