### PR TITLE
Adding Nginx as Reverse Proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,16 +15,16 @@ services:
         hard: -1
     volumes:
       - elastic:/usr/share/elasticsearch/data
-    ports:
-      - 9200:9200
+    # ports:
+    #   - 9200:9200
     networks:
       - backend
     restart: on-failure
 
   natlas-server:
     build: natlas-server
-    ports:
-      - 5000:5000
+    # ports:
+    #   - 5000:5000
     networks:
       - backend
     environment:
@@ -48,7 +48,25 @@ services:
     links:
       - natlas-server
 
+  nginx: 
+    build: 
+      context: .
+      dockerfile: docker-nginx/Dockerfile.dev
+    container_name: nginx_fe
+    restart: on-failure
+    volumes:
+      - ns-data:/data
+    networks:
+      - backend
+      - frontend
+    ports:
+      - 80:80
+      - 443:443
+    links:
+      - natlas-server
+
 networks:
+  frontend:
   backend:
 
 volumes:

--- a/docker-nginx/Dockerfile.dev
+++ b/docker-nginx/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM ubuntu:latest as cert_gen
+
+RUN apt update && apt install -y openssl && \
+  	openssl ecparam -name secp384r1 -genkey -noout -out /tmp/dev.key && \
+  	openssl req -new -batch -x509 -days 30 -key /tmp/dev.key -out /tmp/dev.crt
+
+
+FROM nginx:latest
+
+RUN mkdir -p {/etc/ssl/certs/,/etc/ssl/private/dev.key,/opt/natlas/natlas-server/app/static/}
+
+COPY ./docker-nginx/nginx.dev /etc/nginx/conf.d/default.conf
+COPY --from=cert_gen /tmp/dev.crt /etc/ssl/certs/dev.crt
+COPY --from=cert_gen /tmp/dev.key /etc/ssl/private/dev.key
+COPY ./natlas-server/app/static /opt/natlas/natlas-server/app/static/
+

--- a/docker-nginx/nginx.dev
+++ b/docker-nginx/nginx.dev
@@ -1,0 +1,81 @@
+server {
+        listen 80;
+        listen [::]:80;
+        server_name default; #CHANGEME
+        # The below location block is for Let's Encrypt, feel free to delete if you're not using LE.
+        location ~ /.well-known {
+            allow all;
+        }
+        return 301 https://$host$request_uri;
+}
+
+server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        server_name default; #CHANGEME
+
+        ssl_certificate /etc/ssl/certs/dev.crt; #CHANGEME
+        ssl_certificate_key /etc/ssl/private/dev.key; #CHANGEME
+        ssl_session_timeout 10m;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        ssl_protocols TLSv1.2;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_ecdh_curve secp384r1;
+#        ssl_dhparam /etc/nginx/dhparam.pem; # you should generate strong dhparams and then enable this
+
+        add_header X-Frame-Options DENY;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+        add_header X-Robots-Tag none;
+#        add_header Strict-Transport-Security "max-age=31536000"; # enable this after you've confirmed things are working
+
+        client_max_body_size 10M;
+
+        # Serve static files directly from nginx instead of putting that load on the app server
+        location /static/ {
+            alias /opt/natlas/natlas-server/app/static/;
+            access_log /dev/stdout;
+            error_log /dev/stderr;
+            gzip_static on;
+            expires modified +24h;
+            add_header Cache-Control public;
+        }
+
+        # Serve media files (screenshots of hosts)
+        location /media/ {
+            alias /data/media;
+            access_log /dev/stdout;
+            error_log /dev/stderr;
+            gzip_static on;
+            expires modified +72h;
+            add_header Cache-Control public;
+        }
+
+        # Pass requests to the application
+        location / {
+            access_log /dev/stdout;
+            error_log /dev/stderr;
+            proxy_set_header Host $host;
+            proxy_set_header REMOTE_ADDR $remote_addr;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://natlas-server:5000;
+        }
+
+        # Log calls to the api separately, we have to include the proxy settings here too, since it's still getting passed to natlas
+        location /api/ {
+            access_log /dev/stdout;
+            error_log /dev/stderr;
+            proxy_set_header Host $host;
+            proxy_set_header REMOTE_ADDR $remote_addr;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://natlas-server:5000;
+        }
+}


### PR DESCRIPTION
This adds nginx as a reverse proxy for the docker-compose stack. None of us thought it was good to open elastic, or natlas-server up to the internet. This should allow us to start the stack without some fears.

This is a stepping stone toward making a composable on-prem prod stack.