### PR TITLE
Add OpenCensus-based request tracing

### DIFF
--- a/natlas-server/README.md
+++ b/natlas-server/README.md
@@ -33,6 +33,10 @@ Can't be changed via the web interface (only `.env`):
 | `FLASK_APP` | `natlas-server.py` | The file name that launches the flask application. This should not be changed as it allows commands like `flask run`, `flask db upgrade`, and `flask shell` to run.|
 | `MEDIA_DIRECTORY` | `$BASEDIR/media/` | If you want to store media (screenshots) in a larger mounted storage volume, set this value to an absolute path. If you change this value, be sure to copy the contents of the previous media directory to the new location, otherwise old media will not render.|
 | `NATLAS_VERSION_OVERRIDE` | `None` | **Danger**: This can be optionally set for development purposes to override the version string that natlas thinks it's running. Doing this can have adverse affects and should only be done with caution. The only reason to really do this is if you're developing changes to the way host data is stored and presented. |
+| `SENTRY_DSN` | `""` | Enables automatic reporting of all exceptions to a [Sentry.io instance](https://sentry.io/). Example: http://mytoken@mysentry.example.com/1 |
+| `OPENCENSUS_ENABLE` | `false` | Enables OpenCensus instrumentation to help identify performance bottlenecks. |
+| `OPENCENSUS_SAMPLE_RATE` | `1.0` | Specifies the percentage of requests that are traced with OpenCensus. A number from 0 to 1. |
+| `OPENCENSUS_AGENT` | `127.0.0.1:55678` | An OpenCensus agent or collector that this instance will emit traffic to. |
 
 
 Can be changed via the web interface:
@@ -49,7 +53,6 @@ Can be changed via the web interface:
 | `MAIL_FROM` | `""` | Address to be used as the "From" address for outgoing mail |
 | `LOCAL_SUBRESOURCES` | `False` | Use local subresources (js,css,fonts) instead of CDN resources |
 | `CUSTOM_BRAND` | `""` | Custom branding for the navigation bar to help distinguish different natlas installations from one another |
-| `SENTRY_DSN` | `""` | Enables automatic reporting of all exceptions to a [Sentry.io instance](https://sentry.io/). Example: http://mytoken@mysentry.example.com/1 |
 
 For most installations, the defaults will probably be fine (with the exception of `SECRET_KEY`, but this should get generated automatically by `setup-server.sh`), however user invitations won't work without a valid mail server.
 

--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -43,7 +43,7 @@ def create_app(config_class=Config, load_config=False):
 	app = Flask(__name__)
 	initialize_opencensus(config_class, app)
 
-	app.config.from_object(Config)
+	app.config.from_object(config_class)
 	app.jinja_env.add_extension('jinja2.ext.do')
 
 	db.init_app(app)

--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -7,10 +7,9 @@ from flask_wtf.csrf import CSRFProtect
 from config import Config, populate_defaults, get_defaults
 from app.elastic import ElasticInterface
 from app.scope import ScopeManager
-from urllib.parse import urlparse
 import os
 import hashlib
-import sentry_sdk
+from .instrumentation import initialize_opencensus
 
 
 class AnonUser(AnonymousUserMixin):
@@ -30,14 +29,6 @@ migrate = Migrate()
 csrf = CSRFProtect()
 
 
-def initialize_sentryio(config):
-	if config.sentry_dsn:
-		url = urlparse(config.sentry_dsn)
-		print("Sentry.io enabled and reporting errors to %s://%s" % (url.scheme, url.hostname))
-		from sentry_sdk.integrations.flask import FlaskIntegration
-		sentry_sdk.init(dsn=config.sentry_dsn, release=config.NATLAS_VERSION, integrations=[FlaskIntegration()])
-
-
 @login.unauthorized_handler
 def unauthorized():
 	if current_user.is_anonymous:
@@ -49,8 +40,9 @@ def unauthorized():
 
 
 def create_app(config_class=Config, load_config=False):
-	initialize_sentryio(config_class)
 	app = Flask(__name__)
+	initialize_opencensus(config_class, app)
+
 	app.config.from_object(Config)
 	app.jinja_env.add_extension('jinja2.ext.do')
 

--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -3,6 +3,8 @@ from config import Config
 import elasticsearch
 from datetime import datetime
 import logging
+from opencensus.trace import execution_context
+from opencensus.trace import span as span_module
 
 
 class ElasticClient:
@@ -40,7 +42,8 @@ class ElasticClient:
 
 	def _ping(self):
 		''' Returns True if the cluster is up, False otherwise'''
-		return self.es.ping()
+		with self._new_trace_span(operation='ping') as span:
+			return self.es.ping()
 
 	def _attempt_reconnect(self):
 		''' Attempt to reconnect if we haven't tried to reconnect too recently '''
@@ -58,52 +61,80 @@ class ElasticClient:
 			raise elasticsearch.ConnectionError
 		return self.status
 
-	def _execute_raw_query(self, func, **kargs):
-		''' Wraps the es client to make sure that ConnectionErrors are handled uniformly '''
-		self._check_status()
-		try:
-			results = func(**kargs)
-			return results
-		except elasticsearch.ConnectionError:
-			self.status = False
-			raise elasticsearch.ConnectionError
-
-	def execute_search(self, **kargs):
-		''' Execute an arbitrary search. This is where we should instrument things specific to es.search '''
-		results = self._execute_raw_query(self.es.search, doc_type='_doc', **kargs)
-		return results
-
-	def execute_count(self, **kargs):
-		''' Executes an arbitrary count. This is where we should instrument things specific to es.count '''
-		results = self._execute_raw_query(self.es.count, doc_type='_doc', **kargs)
-		if not results:
-			return 0
-		return results
-
-	def execute_delete_by_query(self, **kargs):
-		''' Executes an arbitrary delete_by_query. This is where we should instrument things specific to es.delete_by_query '''
-		results = self._execute_raw_query(self.es.delete_by_query, doc_type='_doc', **kargs)
-		return results
-
-	def execute_index(self, **kargs):
-		''' Executes an arbitrary index. This is where we should instrument things specific to es.index '''
-		results = self._execute_raw_query(self.es.index, doc_type='_doc', **kargs)
-		return results
-
-	def get_collection(self, **kargs):
+	def get_collection(self, **kwargs):
 		''' Execute a search and return a collection of results '''
-		results = self.execute_search(**kargs)
+		results = self.execute_search(**kwargs)
 		if not results:
 			return 0, []
 		docsources = self.collate_source(results['hits']['hits'])
 		return results['hits']['total'], docsources
 
-	def get_single_host(self, **kargs):
+	def get_single_host(self, **kwargs):
 		''' Execute a search and return a single result '''
-		results = self.execute_search(**kargs)
+		results = self.execute_search(**kwargs)
 		if not results or results['hits']['total'] == 0:
 			return 0, None
 		return results['hits']['total'], results['hits']['hits'][0]['_source']
 
 	def collate_source(self, documents):
 		return map(lambda doc: doc['_source'], documents)
+
+	# Mid-level query executor abstraction.
+	def execute_search(self, **kwargs):
+		''' Execute an arbitrary search.'''
+		with self._new_trace_span(operation='search', **kwargs) as span:
+			results = self._execute_raw_query(self.es.search, doc_type='_doc', **kwargs)
+			span.add_attribute('es.hits.total', results['hits']['total'])
+			self._attach_shard_span_attrs(span, results)
+			return results
+
+	def execute_count(self, **kwargs):
+		''' Executes an arbitrary count.'''
+		results = None
+		with self._new_trace_span(operation='count', **kwargs) as span:
+			results = self._execute_raw_query(self.es.count, doc_type='_doc', **kwargs)
+			self._attach_shard_span_attrs(span, results)
+		if not results:
+			return 0
+		return results
+
+	def execute_delete_by_query(self, **kwargs):
+		''' Executes an arbitrary delete_by_query.'''
+		with self._new_trace_span(operation='delete_by', **kwargs) as span:
+			results = self._execute_raw_query(self.es.delete_by_query, doc_type='_doc', **kwargs)
+			self._attach_shard_span_attrs(span, results)
+			return results
+
+	def execute_index(self, **kwargs):
+		''' Executes an arbitrary index. '''
+		with self._new_trace_span(operation='index', **kwargs) as span:
+			results = self._execute_raw_query(self.es.index, doc_type='_doc', **kwargs)
+			return results
+
+	# Inner-most query executor. All queries route through here.
+	def _execute_raw_query(self, func, **kwargs):
+		''' Wraps the es client to make sure that ConnectionErrors are handled uniformly '''
+		self._check_status()
+		try:
+			return func(**kwargs)
+		except elasticsearch.ConnectionError:
+			self.status = False
+			raise elasticsearch.ConnectionError
+
+	# Tracing methods
+	def _new_trace_span(self, operation, **kwargs):
+		tracer = execution_context.get_opencensus_tracer()
+		span_name = "elasticsearch"
+		if 'index' in kwargs:
+			span_name += '.' + operation
+		span = tracer.span(name=span_name)
+		span.span_kind = span_module.SpanKind.CLIENT
+		if 'index' in kwargs:
+			span.add_attribute('es.index', kwargs['index'])
+		if 'body' in kwargs:
+			span.add_attribute('es.query', kwargs['body'])
+		return span
+
+	def _attach_shard_span_attrs(self, span, results):
+		span.add_attribute('es.shards.total', results['_shards']['total'])
+		span.add_attribute('es.shards.successful', results['_shards']['successful'])

--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -42,7 +42,7 @@ class ElasticClient:
 
 	def _ping(self):
 		''' Returns True if the cluster is up, False otherwise'''
-		with self._new_trace_span(operation='ping') as span:
+		with self._new_trace_span(operation='ping'):
 			return self.es.ping()
 
 	def _attempt_reconnect(self):
@@ -107,7 +107,7 @@ class ElasticClient:
 
 	def execute_index(self, **kwargs):
 		''' Executes an arbitrary index. '''
-		with self._new_trace_span(operation='index', **kwargs) as span:
+		with self._new_trace_span(operation='index', **kwargs):
 			results = self._execute_raw_query(self.es.index, doc_type='_doc', **kwargs)
 			return results
 

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -65,11 +65,8 @@ class ElasticInterface:
 		searchBody = {
 			"size": 1,
 			"query": {
-				"query_string": {
-					"query": ip,
-					"fields": ["ip"],
-					"default_operator":
-					"AND"
+				"term": {
+					"ip": ip
 				}
 			},
 			"sort": {
@@ -86,10 +83,8 @@ class ElasticInterface:
 			"size": limit,
 			"from": offset,
 			"query": {
-				"query_string": {
-					"query": ip,
-					"fields": ["ip"],
-					"default_operator": "AND"
+				"term": {
+					"ip": ip
 				}
 			},
 			"sort": {
@@ -106,7 +101,8 @@ class ElasticInterface:
 			"query": {
 				"term": {
 					"ip": ip
-				}},
+				}
+			},
 			"aggs": {
 				"screenshot_count": {
 					"sum": {

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -1,0 +1,50 @@
+import flask
+import sentry_sdk
+import threading
+from opencensus.ext.ocagent import stats_exporter as ocagent_stats_exporter
+from opencensus.ext.ocagent import trace_exporter as ocagent_trace_exporter
+from opencensus.ext.flask.flask_middleware import FlaskMiddleware
+from opencensus.trace.print_exporter import PrintExporter
+from opencensus.trace import config_integration, samplers
+from opencensus.trace import tracer as tracer_module
+from opencensus.trace import execution_context
+from .sentryio_middleware import SentryIoContextMiddleware
+from urllib.parse import urlparse
+
+
+SERVICE_NAME = 'natlas-server'
+template_span = threading.local()
+
+
+def render_template_end(*kargs, **kwargs): # sender, template, context):
+	span = template_span.x
+	template_span.x = None
+	span.__exit__(None, None, None)
+
+
+def render_template_start(app, template, context):
+	tracer = execution_context.get_opencensus_tracer()
+	template_span.x = tracer.span(name="render_template")
+	template_span.x.add_attribute('flask.template', template.name)
+
+
+def initialize_opencensus(config, flask_app):
+	if config.opencensus_enable:
+		agent = config.opencensus_agent
+		print("OpenCensus enabled and reporting to %s using gRPC" % agent)
+		exporter = ocagent_trace_exporter.TraceExporter(service_name=SERVICE_NAME, endpoint=agent)
+		sampler = samplers.ProbabilitySampler(rate=config.opencensus_sample_rate)
+		config_integration.trace_integrations(['sqlalchemy'])
+		FlaskMiddleware(flask_app, exporter=exporter, sampler=sampler)
+		flask_app.wsgi_app = SentryIoContextMiddleware(flask_app.wsgi_app)
+
+		flask.before_render_template.connect(render_template_start, flask_app)
+		flask.template_rendered.connect(render_template_end, flask_app)
+
+
+def initialize_sentryio(config):
+	if config.sentry_dsn:
+		url = urlparse(config.sentry_dsn)
+		print("Sentry.io enabled and reporting errors to %s://%s" % (url.scheme, url.hostname))
+		from sentry_sdk.integrations.flask import FlaskIntegration
+		sentry_sdk.init(dsn=config.sentry_dsn, release=config.NATLAS_VERSION, integrations=[FlaskIntegration()])

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -28,7 +28,7 @@ def render_template_start(app, template, context):
 def initialize_opencensus(config, flask_app):
 	if config.opencensus_enable:
 		agent = config.opencensus_agent
-		print("OpenCensus enabled and reporting to %s using gRPC" % agent)
+		print(f"OpenCensus enabled and reporting to {agent} using gRPC")
 		exporter = ocagent_trace_exporter.TraceExporter(service_name=SERVICE_NAME, endpoint=agent)
 		sampler = samplers.ProbabilitySampler(rate=config.opencensus_sample_rate)
 		config_integration.trace_integrations(['sqlalchemy'])
@@ -42,6 +42,6 @@ def initialize_opencensus(config, flask_app):
 def initialize_sentryio(config):
 	if config.sentry_dsn:
 		url = urlparse(config.sentry_dsn)
-		print("Sentry.io enabled and reporting errors to %s://%s" % (url.scheme, url.hostname))
+		print(f"Sentry.io enabled and reporting errors to {url.scheme}://{url.hostname}")
 		from sentry_sdk.integrations.flask import FlaskIntegration
 		sentry_sdk.init(dsn=config.sentry_dsn, release=config.NATLAS_VERSION, integrations=[FlaskIntegration()])

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -1,12 +1,9 @@
 import flask
 import sentry_sdk
 import threading
-from opencensus.ext.ocagent import stats_exporter as ocagent_stats_exporter
 from opencensus.ext.ocagent import trace_exporter as ocagent_trace_exporter
 from opencensus.ext.flask.flask_middleware import FlaskMiddleware
-from opencensus.trace.print_exporter import PrintExporter
 from opencensus.trace import config_integration, samplers
-from opencensus.trace import tracer as tracer_module
 from opencensus.trace import execution_context
 from .sentryio_middleware import SentryIoContextMiddleware
 from urllib.parse import urlparse

--- a/natlas-server/app/instrumentation/sentryio_middleware.py
+++ b/natlas-server/app/instrumentation/sentryio_middleware.py
@@ -1,0 +1,13 @@
+from sentry_sdk import configure_scope
+from opencensus.trace import execution_context
+
+
+class SentryIoContextMiddleware(object):
+	def __init__(self, app):
+		self.app = app
+
+	def __call__(self, environ, start_response):
+		tracer = execution_context.get_opencensus_tracer()
+		with configure_scope() as scope:
+			scope.set_extra("trace_id", tracer.span_context.trace_id)
+			return self.app(environ, start_response)

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -38,6 +38,10 @@ class Config(object):
 
 	sentry_dsn = os.environ.get("SENTRY_DSN") or None
 
+	opencensus_enable = os.environ.get("OPENCENSUS_ENABLE") or False
+	opencensus_sample_rate = float(os.environ.get("OPENCENSUS_SAMPLE_RATE") or 1)
+	opencensus_agent = os.environ.get("OPENCENSUS_AGENT") or '127.0.0.1:55678'
+
 	if version_override:
 		NATLAS_VERSION = version_override
 

--- a/natlas-server/natlas-server.py
+++ b/natlas-server/natlas-server.py
@@ -1,9 +1,18 @@
 from app import create_app, db
 from app.models import User, ScopeItem, ConfigItem, NatlasServices, AgentConfig, RescanTask, \
 	Tag, Agent, AgentScript, EmailToken
+from app.instrumentation import initialize_sentryio
+from sentry_sdk import capture_exception
+from config import Config
 
 
-app = create_app(load_config=True)
+config = Config()
+initialize_sentryio(config)
+try:
+	app = create_app(config_class=config, load_config=True)
+except Exception as e:
+	capture_exception(e)
+	raise e
 
 
 @app.shell_context_processor

--- a/natlas-server/requirements.txt
+++ b/natlas-server/requirements.txt
@@ -19,6 +19,9 @@ Mako==1.0.8
 MarkupSafe==1.1.1
 mpmath==1.1.0
 netaddr==0.7.19
+opencensus-ext-flask==0.7.3
+opencensus-ext-ocagent==0.7.1
+opencensus-ext-sqlalchemy==0.1.2
 Pillow==6.2.0
 PyJWT==1.7.1
 python-dateutil==2.8.0
@@ -27,6 +30,7 @@ python-editor==1.0.4
 python-libnmap==0.7.0
 semver==2.9.0
 sentry-sdk[flask]==0.10.2
+setuptools==28.8.0
 six==1.12.0
 SQLAlchemy==1.3.2
 sympy==1.4


### PR DESCRIPTION
Fixes #219  

This adds OpenCensus request tracing to natlas-server. It instruments:
* Elasticsearch queries
* SQL queries
* render_template

Based on my testing, this accounts for the majority of the time spent on the server.

Relevant:
* https://opencensus.io
* http://opentelemetry.io - OpenTelemetry is deprecating OpenCensus, but it's nowhere near production ready.