### PR TITLE
Ensure that there is a host before trying to reference it

### DIFF
--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -91,7 +91,7 @@ def submit():
 			response_body = json.dumps({"status": status_code, "message": "XML had too many hosts in it", "retry": False})
 
 		# If it's not an acceptable target, tell the agent it's out of scope
-		elif not current_app.ScopeManager.isAcceptableTarget(nmap.hosts[0].address):
+		elif len(nmap.hosts) == 1 and current_app.ScopeManager.isAcceptableTarget(nmap.hosts[0].address):
 			status_code = 400
 			response_body = json.dumps({"status": status_code, "message": "Out of scope: " + nmap.hosts[0].address, "retry": False})
 

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -91,7 +91,7 @@ def submit():
 			response_body = json.dumps({"status": status_code, "message": "XML had too many hosts in it", "retry": False})
 
 		# If it's not an acceptable target, tell the agent it's out of scope
-		elif len(nmap.hosts) == 1 and current_app.ScopeManager.isAcceptableTarget(nmap.hosts[0].address):
+		elif len(nmap.hosts) == 1 and not current_app.ScopeManager.isAcceptableTarget(nmap.hosts[0].address):
 			status_code = 400
 			response_body = json.dumps({"status": status_code, "message": "Out of scope: " + nmap.hosts[0].address, "retry": False})
 


### PR DESCRIPTION
There's no ticket for this particular bug right now but it did get mentioned in #227. This is a simple fix to ensure that the `elif` statement doesn't throw an exception if there isn't an item in the `nmap.hosts` array.