### PR TITLE
Update external links to open in new tab/window

### DIFF
--- a/natlas-server/app/templates/host/versions/0.6.3/_port-info.html
+++ b/natlas-server/app/templates/host/versions/0.6.3/_port-info.html
@@ -14,7 +14,7 @@
         </div>
         {% if 'http' in port.service.name %}
         <div class="port-link">
-            <a class="d-block" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
+            <a class="d-block" target="_blank" rel="noopener noreferrer" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
         </div>
         {% endif %}
     </div><!--end port-summary-->

--- a/natlas-server/app/templates/host/versions/0.6.4/_port-info.html
+++ b/natlas-server/app/templates/host/versions/0.6.4/_port-info.html
@@ -14,7 +14,7 @@
         </div>
         {% if 'http' in port.service.name %}
         <div class="port-link">
-            <a class="d-block" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
+            <a class="d-block" target="_blank" rel="noopener noreferrer" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
         </div>
         {% endif %}
     </div><!--end port-summary-->

--- a/natlas-server/app/templates/host/versions/0.6.5/_port-info.html
+++ b/natlas-server/app/templates/host/versions/0.6.5/_port-info.html
@@ -14,7 +14,7 @@
         </div>
         {% if 'http' in port.service.name %}
         <div class="port-link">
-            <a class="d-block" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
+            <a class="d-block" target="_blank" rel="noopener noreferrer" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
         </div>
         {% endif %}
     </div><!--end port-summary-->

--- a/natlas-server/app/templates/host/versions/0.6.6/_port-info.html
+++ b/natlas-server/app/templates/host/versions/0.6.6/_port-info.html
@@ -14,7 +14,7 @@
         </div>
         {% if 'http' in port.service.name %}
         <div class="port-link">
-            <a class="d-block" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
+            <a class="d-block" target="_blank" rel="noopener noreferrer" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
         </div>
         {% endif %}
     </div><!--end port-summary-->

--- a/natlas-server/app/templates/host/versions/0.6.7/_port-info.html
+++ b/natlas-server/app/templates/host/versions/0.6.7/_port-info.html
@@ -14,7 +14,7 @@
         </div>
         {% if 'http' in port.service.name %}
         <div class="port-link">
-            <a class="d-block" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
+            <a class="d-block" target="_blank" rel="noopener noreferrer" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
         </div>
         {% endif %}
     </div><!--end port-summary-->

--- a/natlas-server/app/templates/includes/footer.html
+++ b/natlas-server/app/templates/includes/footer.html
@@ -2,10 +2,10 @@
   <div class="container justify-content-between">
         <div class="px-2 my-flex">
             <ul class="footer-links">
-              <li><a title="Check out Natlas on Github" href="https://github.com/natlas/natlas">GitHub</a></li>
-              <li><a title="Checkout the issues" href="https://github.com/natlas/natlas/issues">Issues</a></li>
-              <li><a title="Visit the wiki" href="https://github.com/natlas/natlas/wiki">Wiki</a></li>
-              <li><a title="View our license" href="https://github.com/natlas/natlas/blob/main/LICENSE">License</a></li>
+              <li><a title="Check out Natlas on Github" target="_blank" rel="noopener noreferrer" href="https://github.com/natlas/natlas">GitHub</a></li>
+              <li><a title="Checkout the issues" target="_blank" rel="noopener noreferrer" href="https://github.com/natlas/natlas/issues">Issues</a></li>
+              <li><a title="Visit the wiki" target="_blank" rel="noopener noreferrer" href="https://github.com/natlas/natlas/wiki">Wiki</a></li>
+              <li><a title="View our license" target="_blank" rel="noopener noreferrer" href="https://github.com/natlas/natlas/blob/main/LICENSE">License</a></li>
             </ul>
         </div>
         <div class="px-2 my-flex">

--- a/natlas-server/app/templates/includes/nav.html
+++ b/natlas-server/app/templates/includes/nav.html
@@ -1,59 +1,64 @@
-    <nav class="navbar navbar-dark bg-dark fixed-top navbar-expand-md">
-      <div class="container">
-        <a class="navbar-brand natlas-brand" href="{{ url_for('main.index') }}" title="Natlas Home"><img src="/static/img/natlas-logo.png" class="img-fluid natlas-logo" alt="Natlas Globe"/><span class="sr-only">Natlas</span>{% if config.CUSTOM_BRAND %}<span class="ml-1">{{ config.CUSTOM_BRAND }}</span>{%endif%}</a>
-          <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span>
-          </button>
+<nav class="navbar navbar-dark bg-dark fixed-top navbar-expand-md">
+	<div class="container">
+		<a class="navbar-brand natlas-brand" href="{{ url_for('main.index') }}" title="Natlas Home">
+			<img src="/static/img/natlas-logo.png" class="img-fluid natlas-logo" alt="Natlas Globe"/>
+			<span class="sr-only">Natlas</span>
+			{% if config.CUSTOM_BRAND %}<span class="ml-1">{{ config.CUSTOM_BRAND }}</span>{%endif%}
+		</a>
+			<button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar" aria-label="Toggle navigation">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+		<div id="navbar" class="collapse navbar-collapse">
+			<ul class="navbar-nav mr-auto mt-2 mt-lg-0">
+				<li class="nav-item">
+					<a class="nav-link" href="{{ url_for('main.browse') }}">Browse</a>
+				</li>
+				<li>
+					<a class="nav-link" href="{{ url_for('main.screenshots') }}">Screenshots</a>
+				</li>
+				<li>
+					<a class="nav-link" href="{{ url_for('host.random_host') }}">Random</a>
+				</li>
+			</ul>
+			<div class="dropdown mr-2">
+				<button class="btn btn-secondary dropdown-toggle" type="button" id="userDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					<i class="fas fa-user"></i>
+				</button>
+				<div class="dropdown-menu" aria-labelledby="userDropdown">
+					{% if current_user.is_admin %}
+					<a class="dropdown-item" href="{{ url_for('admin.admin') }}">Admin</a>
+					{% endif %}
+					{% if current_user.is_anonymous %}
+					<a class="dropdown-item" href="{{ url_for('auth.login') }}">Login</a>
+					{% else %}
+					<a class="dropdown-item" href="{{ url_for('user.profile') }}">Profile</a>
+					<div class="dropdown-divider"></div>
+					<a class="dropdown-item" href="{{ url_for('auth.logout') }}">Logout</a>
+					{% endif %}
+				</div>
+			</div>
+			<form class="form-inline" action="{{ url_for('main.search') }}" name="search">
+				<div class="input-group">
+					<input type="text" class="form-control" aria-label="Search" value="{{query}}" name="query" placeholder="Search..." aria-describedby="search-addon"/>
+					<div class="input-group-append">
+						<button class="btn btn-outline-secondary" type="submit" id="search-addon"><i class="fas fa-search"></i></button>
+					</div>
+				</div>
 
-        <div id="navbar" class="collapse navbar-collapse">
-
-          <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
-            <li class="nav-item">
-              <a class="nav-link" href="{{ url_for('main.browse') }}">Browse</a>
-            </li>
-            <li>
-              <a class="nav-link" href="{{ url_for('main.screenshots') }}">Screenshots</a>
-            </li>
-            <li>
-              <a class="nav-link" href="{{ url_for('host.random_host') }}">Random</a>
-            </li>
-          </ul>
-
-          <div class="dropdown mr-2">
-            <button class="btn btn-secondary dropdown-toggle" type="button" id="userDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class="fas fa-user"></i>
-            </button>
-            <div class="dropdown-menu" aria-labelledby="userDropdown">
-              {% if current_user.is_admin %}
-              <a class="dropdown-item" href="{{ url_for('admin.admin') }}">Admin</a>
-              {% endif %}
-              {% if current_user.is_anonymous %}
-              <a class="dropdown-item" href="{{ url_for('auth.login') }}">Login</a>
-              {% else %}
-              <a class="dropdown-item" href="{{ url_for('user.profile') }}">Profile</a>
-              <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="{{ url_for('auth.logout') }}">Logout</a>
-              {% endif %}
-            </div>
-          </div>
-
-          <form class="form-inline" action="{{ url_for('main.search') }}" name="search">
-            <div class="input-group">
-              <input type="text" class="form-control" aria-label="Search" value="{{query}}" name="query" placeholder="Search..." aria-describedby="search-addon"/>
-              <div class="input-group-append">
-                <button class="btn btn-outline-secondary" type="submit" id="search-addon"><i class="fas fa-search"></i></button>
-              </div>
-            </div>
-
-            <a href="#" class="ml-1" data-toggle="modal" data-target="#searchHelp" onclick="loadModalContent()"><i class="fas fa-question-circle natlas-pink"></i></a>
-          </form>
-         <!--http://tholman.com/github-corners/ -->
-         <span class="d-none d-md-block">
-          <a href="https://github.com/natlas/natlas" class="github-corner" aria-label="View source on GitHub"><svg width="50" height="50" viewBox="0 0 250 250" style="fill:#fff; color:#222; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
-        </span>
-
-
-        </div>
-      </div>
-    </nav>
+				<a href="#" class="ml-1" data-toggle="modal" data-target="#searchHelp" onclick="loadModalContent()"><i class="fas fa-question-circle natlas-pink"></i></a>
+			</form>
+			<!--http://tholman.com/github-corners/ -->
+			<span class="d-none d-md-block">
+				<a target="_blank" rel="noopener noreferrer" href="https://github.com/natlas/natlas" class="github-corner" aria-label="View source on GitHub">
+					<svg width="50" height="50" viewBox="0 0 250 250" style="fill:#fff; color:#222; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+						<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+						<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+						<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+					</svg>
+				</a>
+			</span>
+		</div>
+	</div>
+</nav>
 
 {% include 'includes/search_modal.html' %}


### PR DESCRIPTION
No ticket for this one, but it's something that a number of folks have mentioned to me in private. Especially opening http links to scan targets as new tabs, but I went ahead and updated it one step further so that all (known) external links will open in a new tab.

A lot of this will end up getting refactored again with the migration to document schema versioning independent of agent versioning, but I wanted to make sure the "_blank" made it in before I forgot about it.