### PR TITLE
Explicit declaration of duplication checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,3 +21,12 @@ plugins:
     enabled: true
   stylelint:
     enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - python:
+          python_version: 3
+    exclude_patterns:
+    # machine generated, duplication likely
+    - "natlas-server/migrations/versions/" 


### PR DESCRIPTION
Exclude database migrations as they are machine generated and shouldn't create issues for duplication.