### PR TITLE
Localize time tags

### DIFF
--- a/natlas-server/app/static/js/natlas.js
+++ b/natlas-server/app/static/js/natlas.js
@@ -82,3 +82,11 @@ $(document).ready(function() {
 	});
 
 });
+
+$(document).ready(function() {
+	let times = document.body.getElementsByTagName('time');
+	for (let i = 0; i < times.length; i++){
+		let localDate = new Date(times[i].dateTime)
+		times[i].textContent = localDate.toLocaleString()
+	}
+})

--- a/natlas-server/app/templates/host/versions/0.6.3/_header.html
+++ b/natlas-server/app/templates/host/versions/0.6.3/_header.html
@@ -1,6 +1,6 @@
 <div class="row page-header">
     <div class="col-xs-12 col-sm">
-        <h1>{% if host %}{% include 'host/versions/0.6.4/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - {{ host.ctime | ctime }}</small>{% endif %}</h1>
+        <h1>{% if host %}{% include 'host/versions/0.6.4/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - <time datetime="{{host.ctime}}">{{ host.ctime | ctime }}</time></small>{% endif %}</h1>
     </div>
     {% if current_user.is_authenticated %}
     <div class="col-xs-12 col-sm-2" style="text-align:right;">

--- a/natlas-server/app/templates/host/versions/0.6.4/_header.html
+++ b/natlas-server/app/templates/host/versions/0.6.4/_header.html
@@ -1,6 +1,6 @@
 <div class="row page-header">
     <div class="col-xs-12 col-sm">
-        <h1>{% if host %}{% include 'host/versions/0.6.4/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - {{ host.ctime | ctime }}</small>{% endif %}</h1>
+        <h1>{% if host %}{% include 'host/versions/0.6.4/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - <time datetime="{{host.ctime}}">{{ host.ctime | ctime }}</time></small>{% endif %}</h1>
     </div>
     {% if current_user.is_authenticated %}
     <div class="col-xs-12 col-sm-2" style="text-align:right;">

--- a/natlas-server/app/templates/host/versions/0.6.5/_header.html
+++ b/natlas-server/app/templates/host/versions/0.6.5/_header.html
@@ -1,6 +1,6 @@
 <div class="row page-header">
     <div class="col-xs-12 col-sm">
-        <h1>{% if host %}{% include 'host/versions/0.6.5/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - {{ host.ctime | ctime }}</small>{% endif %}</h1>
+        <h1>{% if host %}{% include 'host/versions/0.6.5/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - <time datetime="{{host.ctime}}">{{ host.ctime | ctime }}</time></small>{% endif %}</h1>
     </div>
     {% if current_user.is_authenticated %}
     <div class="col-xs-12 col-sm-2" style="text-align:right;">

--- a/natlas-server/app/templates/host/versions/0.6.6/_header.html
+++ b/natlas-server/app/templates/host/versions/0.6.6/_header.html
@@ -1,6 +1,6 @@
 <div class="row page-header">
     <div class="col-xs-12 col-sm">
-        <h1>{% if host %}{% include 'host/versions/0.6.6/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - {{ host.ctime | ctime }}</small>{% endif %}</h1>
+        <h1>{% if host %}{% include 'host/versions/0.6.6/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - <time datetime="{{host.ctime}}">{{ host.ctime | ctime }}</time></small>{% endif %}</h1>
     </div>
     {% if current_user.is_authenticated %}
     <div class="col-xs-12 col-sm-2" style="text-align:right;">

--- a/natlas-server/app/templates/host/versions/0.6.6/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.6/screenshots.html
@@ -14,7 +14,7 @@
 	{% for entry in historical_screenshots %}
 		<div class="row screenshot-header-row">
 			<h5 class="border-bottom">
-				<a href="{{url_for('host.host_historical_result', ip=ip, scan_id=entry.scan_id)}}">{{ entry.ctime | ctime }}</a>
+				<a href="{{url_for('host.host_historical_result', ip=ip, scan_id=entry.scan_id)}}"><time datetime={{ entry.ctime }} title="{{ entry.ctime|ctime(human=True) }}">{{ entry.ctime | ctime }}</time></a>
 			</h5>
 		</div>
 		<div class="row image-row">

--- a/natlas-server/app/templates/host/versions/0.6.7/_header.html
+++ b/natlas-server/app/templates/host/versions/0.6.7/_header.html
@@ -1,6 +1,6 @@
 <div class="row page-header">
     <div class="col-xs-12 col-sm">
-        <h1>{% if host %}{% include 'host/versions/0.6.7/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - {{ host.ctime | ctime }}</small>{% endif %}</h1>
+        <h1>{% if host %}{% include 'host/versions/0.6.7/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - <time datetime="{{host.ctime}}">{{ host.ctime | ctime }}</time></small>{% endif %}</h1>
     </div>
     {% if current_user.is_authenticated %}
     <div class="col-xs-12 col-sm-2" style="text-align:right;">

--- a/natlas-server/app/templates/host/versions/0.6.7/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.7/screenshots.html
@@ -14,7 +14,7 @@
 	{% for entry in historical_screenshots %}
 		<div class="row screenshot-header-row">
 			<h5 class="border-bottom">
-				<a href="{{url_for('host.host_historical_result', ip=ip, scan_id=entry.scan_id)}}">{{ entry.ctime | ctime }}</a>
+				<a href="{{url_for('host.host_historical_result', ip=ip, scan_id=entry.scan_id)}}"><time datetime={{ entry.ctime }} title="{{ entry.ctime|ctime(human=True) }}">{{ entry.ctime | ctime }}</time></a>
 			</h5>
 		</div>
 		<div class="row image-row">


### PR DESCRIPTION
Closes #240 by using javascript to create new date objects and replacing the content of time tags with their toLocaleString counterparts.