### PR TITLE
Fix incorrect rename during scope refactoring

### DIFF
--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -99,7 +99,7 @@ def toggleUser(id):
 @isAuthenticated
 @isAdmin
 def scope():
-	scope = ScopeItem.get_scope()
+	scope = ScopeItem.getScope()
 	scopeSize = current_app.ScopeManager.get_scope_size()
 
 	# if it's zero, let's make sure the ScopeManager is up to date


### PR DESCRIPTION
The admin route was incorrectly refactored and replaced the ScopeItem.getScope with ScopeItem.get_scope but without renaming ScopeItem's function. This is a quick fix for that until the ScopeItem gets refactored to snake_case_functions.