### PR TITLE
Javascript replaceState to rewrite the url for random

### DIFF
--- a/natlas-server/app/static/js/natlas.js
+++ b/natlas-server/app/static/js/natlas.js
@@ -89,4 +89,11 @@ $(document).ready(function() {
 		let localDate = new Date(times[i].dateTime)
 		times[i].textContent = localDate.toLocaleString()
 	}
-})
+});
+
+$(document).ready(function() {
+	if (window.location.pathname == '/host/random/') {
+		var permalink = document.getElementsByClassName('date-submitted')[0].childNodes[3].href;
+		history.replaceState(null, '', permalink);
+	}
+});


### PR DESCRIPTION
Doing this via javascript helps reduce load on elasticsearch by only making the request once per click of "random". It breaks the "f5 to win" functionality of the random button, you have to actually click random each time now. Closes #247.