### PR TITLE
Updated Pillow version to fix CVE-2020-5313 and CVE-2019-19911

### DIFF
--- a/natlas-server/requirements.txt
+++ b/natlas-server/requirements.txt
@@ -22,7 +22,7 @@ netaddr==0.7.19
 opencensus-ext-flask==0.7.3
 opencensus-ext-ocagent==0.7.1
 opencensus-ext-sqlalchemy==0.1.2
-Pillow==6.2.0
+Pillow==6.2.2
 PyJWT==1.7.1
 python-dateutil==2.8.0
 python-dotenv==0.10.1


### PR DESCRIPTION
More information about this change can be found here:

https://pillow.readthedocs.io/en/stable/releasenotes/6.2.2.html

More information about the alert from Github: https://github.com/natlas/natlas/network/alert/natlas-server/requirements.txt/Pillow/open
