### PR TITLE
Ensure Node 12.x is installed during setup-server

### DIFF
--- a/natlas-server/setup-server.sh
+++ b/natlas-server/setup-server.sh
@@ -66,6 +66,24 @@ else
 	echo "[+] Found python3: $(which python3)"
 fi
 
+if ! which node >/dev/null || ! node --version | grep "v12." >/dev/null; then
+	echo "[+] Installing dependencies for nodejs: apt-get -y install curl dirmngr apt-transport-https lsb-release ca-certificates"
+	apt-get -y install curl dirmngr apt-transport-https lsb-release ca-certificates
+	echo "[+] Downloading NodeJS 12.x: curl -sL https://deb.nodesource.com/setup_12.x | bash -"
+	curl -sL https://deb.nodesource.com/setup_12.x | bash -
+	echo "[+] Installing NodeJS 12.x: apt-get  -y install nodejs"
+	apt-get install -y nodejs
+	if ! which node >/dev/null; then
+		echo "[!] Failed to install nodejs" && exit 1
+	else
+		echo "[+] Successfully installed nodejs: $(which node)"
+		echo "[+] Nodejs version: $(node --version)"
+	fi
+else
+	echo "[+] Found Nodejs: $(which node)"
+	echo "[+] Nodejs version: $(node --version)"
+fi
+
 if ! which yarn >/dev/null; then
 	echo "[+] Fetching yarn gpg key: curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -"
 	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
This will close #262 by using nodesource's 12.x script to ensure that nodejs 12.x is installed instead of relying on the ubuntu packaged version which causes failures.

Tested `./setup-server.sh dev` and `./setup-server prod` from scratch on fresh instances and everything checked out. Also ran it a second time to make sure no problems should crop up in the event of an upgrade.

I think in a near-future version, 0.7.0 probably, we should consider these setup scripts deprecated and only support Dockerfile going forward. The declarative nature of the dockerfile makes it significantly easier to maintain these dependencies.