### PR TITLE
Server/Docker - Make logs writable

### DIFF
--- a/natlas-agent/natlas/utils.py
+++ b/natlas-agent/natlas/utils.py
@@ -42,7 +42,7 @@ def save_files(scan_id):
 		os.mkdir(failroot)
 	if os.path.isdir(f"data/natlas.{scan_id}"):
 		src = f"data/natlas.{scan_id}"
-		dst = f"data/failures/"
+		dst = "data/failures/"
 		shutil.move(src, dst)
 
 

--- a/natlas-server/Dockerfile
+++ b/natlas-server/Dockerfile
@@ -20,6 +20,8 @@ COPY . /opt/natlas/natlas-server
 COPY --from=webpack /app/app/static/dist app/static/dist
 
 RUN python3 -m compileall .
+RUN mkdir logs \
+  && chown www-data logs
 
 # Build final image
 FROM python:3.7.5-slim


### PR DESCRIPTION
Partially fixes Sentry NATLAS-SERVER-C

This will fix the log error:
```
PermissionError: [Errno 13] Permission denied: 'logs'
  File "flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "flask/_compat.py", line 35, in reraise
    raise value
  File "flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "app/auth/wrappers.py", line 44, in decorated_function
    return f(*args, **kwargs)
  File "app/api/routes.py", line 53, in getwork
    current_app.ScopeManager.update()
  File "app/scope/scope.py", line 121, in update
    self.update_scan_manager()
  File "app/scope/scope.py", line 111, in update_scan_manager
    log("Scan manager could not be instantiated because there was no scope configured.", printm=True)
  File "app/scope/scope.py", line 13, in log
    os.makedirs('logs', exist_ok=True)
  File "os.py", line 221, in makedirs
    mkdir(name, mode)
```