### PR TITLE
Docker - Don't specify base image minor versions

### DIFF
--- a/natlas-agent/Dockerfile
+++ b/natlas-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.0 as build
+FROM python:3.6 as build
 
 RUN export DEBIAN_FRONTEND=noninteractive \
 	export BUILD_PKGS="unzip" \

--- a/natlas-server/Dockerfile
+++ b/natlas-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.20.0-jessie as webpack
+FROM node:10-jessie as webpack
 
 WORKDIR /app
 COPY ["package.json", "yarn.lock", "/app/"]
@@ -6,7 +6,7 @@ RUN yarn --no-progress --frozen-lockfile --non-interactive
 COPY . /app
 RUN yarn run webpack --mode production
 
-FROM python:3.7.5 as build
+FROM python:3.7 as build
 
 WORKDIR /opt/natlas/natlas-server
 COPY requirements.txt /opt/natlas/natlas-server
@@ -24,7 +24,7 @@ RUN mkdir logs \
   && chown www-data logs
 
 # Build final image
-FROM python:3.7.5-slim
+FROM python:3.7-slim
 
 COPY --from=build /install /
 COPY --from=build /opt/natlas /opt/natlas


### PR DESCRIPTION
Semver claims that minor/build version bumps are backwards compatible. Looking at NodeJS's changelog, we're missing out on a few vuln/bug fixes so we'll switch to major releases. I don't see it as very valuable bumping minor versions every time.

Python seems to make more breaking changes in an X.Y change, so we'll
stick with the major-minor versioning.

For NodeJS, we'll use X.*
For Python, we'll use X.Y.*.

With this change we'll go from NodeJS 10.20.0 -> 10.21.0 and Python 3.6.5 to 3.6.7.