### PR TITLE
Avoid landing on an empty search page. Fixes #267.

### DIFF
--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -48,6 +48,8 @@ def browse():
 def search():
 	''' Return search results for a given query '''
 	query = request.args.get('query', '')
+	if query == '':
+		return redirect(url_for('main.browse'))
 	page = int(request.args.get('page', 1))
 	format = request.args.get('format', '')
 	scan_ids = request.args.get('includeScanIDs', '')

--- a/natlas-server/app/templates/includes/nav.html
+++ b/natlas-server/app/templates/includes/nav.html
@@ -42,7 +42,7 @@
 			</div>
 			<form class="form-inline" action="{{ url_for('main.search') }}" name="search">
 				<div class="input-group">
-					<input type="text" class="form-control" aria-label="Search" value="{{query}}" name="query" placeholder="Search..." aria-describedby="search-addon"/>
+					<input type="text" class="form-control" aria-label="Search" value="{{query}}" required name="query" placeholder="Search..." aria-describedby="search-addon"/>
 					<div class="input-group-append">
 						<button class="btn btn-outline-secondary" type="submit" id="search-addon"><i class="fas fa-search"></i></button>
 					</div>


### PR DESCRIPTION
Added a redirect to `/search` if query is empty, and marked the input box as a required field for the search form. Closes #267.