### PR TITLE
Add some detail to package.json

### DIFF
--- a/natlas-server/package.json
+++ b/natlas-server/package.json
@@ -1,4 +1,10 @@
 {
+	"name": "natlas-web",
+	"description": "Natlas web app logic",
+	"license": "Apache-2.0",
+	"homepage": "https://github.com/natlas",
+	"bugs": "https://github.com/natlas/natlas/issues",
+	"repository": "github:natlas/natlas",
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^5.13.0",
 		"bootstrap": "^4.4.1",


### PR DESCRIPTION
Yarn complained about the lack of a license in package.json for quite some time now. Since the whole project is already licensed Apache 2.0, I've captured that in package.json, as well as added some other basic meta fields.