### PR TITLE
Trying on some new LGTM Rules

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -2,3 +2,6 @@ extraction:
   python:
     python_setup:
       version: "3"
+
+queries:
+  - include: "*"


### PR DESCRIPTION
Explicitly marking queries as "*" should cause the results from all queries to be displayed, whereas right now there are a handful of results that don't get displayed. 

* [Javascript](https://lgtm.com/projects/g/natlas/natlas/queries/?pack=com.lgtm%2Fjavascript-queries)
* [Python](https://lgtm.com/projects/g/natlas/natlas/queries/?pack=com.lgtm%2Fpython-queries)