### PR TITLE
Use natlas' libnmap instead of the unmaintained libnmap

### DIFF
--- a/natlas-agent/Pipfile
+++ b/natlas-agent/Pipfile
@@ -8,9 +8,9 @@ flake8 = "*"
 
 [packages]
 python-dotenv = "~=0.13.0"
-python-libnmap = {editable = false, git = "https://github.com/natlas/python-libnmap.git"}
 requests = "~=2.23.0"
 sentry-sdk = "~=0.14.4"
+natlas-libnmap = "*"
 
 [requires]
 python_version = "3.6"

--- a/natlas-agent/Pipfile
+++ b/natlas-agent/Pipfile
@@ -8,7 +8,7 @@ flake8 = "*"
 
 [packages]
 python-dotenv = "~=0.13.0"
-python-libnmap = "~=0.7.0"
+python-libnmap = {editable = false, git = "https://github.com/natlas/python-libnmap.git"}
 requests = "~=2.23.0"
 sentry-sdk = "~=0.14.4"
 

--- a/natlas-agent/Pipfile.lock
+++ b/natlas-agent/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e278b91636323422e2ed88595982159b19bf80a9ad87826d8153f9b7b6af431a"
+            "sha256": "18977e564d2130bdb5ec592806c367d7c4dd4c23a8908a7e4cc0bfdff04476e8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
-                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2020.4.5.2"
+            "version": "==2020.6.20"
         },
         "chardet": {
             "hashes": [
@@ -30,13 +30,21 @@
             ],
             "version": "==3.0.4"
         },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.6.0"
+        },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.9"
+            "version": "==2.10"
         },
         "python-dotenv": {
             "hashes": [
@@ -47,11 +55,9 @@
             "version": "==0.13.0"
         },
         "python-libnmap": {
-            "hashes": [
-                "sha256:9d14919142395aaca952e129398f0c7371c0f0a034c63de6dad99cd7050177ad"
-            ],
-            "index": "pypi",
-            "version": "==0.7.0"
+            "editable": false,
+            "git": "https://github.com/natlas/python-libnmap.git",
+            "ref": "e1ce4328123f184d4390f94b708cca165ebf1dd9"
         },
         "requests": {
             "hashes": [
@@ -88,6 +94,14 @@
             "index": "pypi",
             "version": "==3.8.3"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.7.0"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
@@ -110,6 +124,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.1.0"
         }
     }
 }

--- a/natlas-agent/Pipfile.lock
+++ b/natlas-agent/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "18977e564d2130bdb5ec592806c367d7c4dd4c23a8908a7e4cc0bfdff04476e8"
+            "sha256": "b0e09cd3f29a45974b789b5971a552ed52a68a27b104785fd1c6d02391bf4c2f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,6 +46,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
+        "natlas-libnmap": {
+            "hashes": [
+                "sha256:30099b8d8556b64df8ffeaa66b8f79103422297264e6a3c05acafbe92e31fb00",
+                "sha256:52195fa1bf56e7b23d5c5a9a1164d5b1e58a9be6dc980cdfc37aefb8c6d1fdd6"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1"
+        },
         "python-dotenv": {
             "hashes": [
                 "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7",
@@ -53,11 +61,6 @@
             ],
             "index": "pypi",
             "version": "==0.13.0"
-        },
-        "python-libnmap": {
-            "editable": false,
-            "git": "https://github.com/natlas/python-libnmap.git",
-            "ref": "e1ce4328123f184d4390f94b708cca165ebf1dd9"
         },
         "requests": {
             "hashes": [

--- a/natlas-server/Pipfile
+++ b/natlas-server/Pipfile
@@ -23,7 +23,7 @@ opencensus-ext-sqlalchemy = "~=0.1.2"
 Pillow = "~=7.1.2"
 PyJWT = "~=1.7.1"
 python-dotenv = "~=0.13.0"
-python-libnmap = "~=0.7.0"
+python-libnmap = {editable = false, git = "https://github.com/natlas/python-libnmap.git"}
 semver = "~=2.10.1"
 sentry-sdk = "~=0.14.4"
 sympy = "~=1.6"

--- a/natlas-server/Pipfile
+++ b/natlas-server/Pipfile
@@ -23,11 +23,11 @@ opencensus-ext-sqlalchemy = "~=0.1.2"
 Pillow = "~=7.1.2"
 PyJWT = "~=1.7.1"
 python-dotenv = "~=0.13.0"
-python-libnmap = {editable = false, git = "https://github.com/natlas/python-libnmap.git"}
 semver = "~=2.10.1"
 sentry-sdk = "~=0.14.4"
 sympy = "~=1.6"
 webpack-manifest = "~=2.1.1"
+natlas-libnmap = "*"
 
 [requires]
 python_version = "3.8"

--- a/natlas-server/Pipfile.lock
+++ b/natlas-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "077524e82df1b3eba3e4ae59c526733bb5509060a99fd78627880331698115bd"
+            "sha256": "32d7678c1cf14aa3759661910b0e0c72ee40e6233809e1aab1e0b4f2ebef558d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,11 +31,11 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab",
-                "sha256:de5d88f87781602201cde465d3afe837546663b168e8b39df67411b0bf10cefc"
+                "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98",
+                "sha256:bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20"
             ],
             "markers": "python_version ~= '3.5'",
-            "version": "==4.1.0"
+            "version": "==4.1.1"
         },
         "certifi": {
             "hashes": [
@@ -65,6 +65,14 @@
             ],
             "index": "pypi",
             "version": "==2.4"
+        },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.6.0"
         },
         "dnspython": {
             "hashes": [
@@ -472,11 +480,9 @@
             "version": "==1.0.4"
         },
         "python-libnmap": {
-            "hashes": [
-                "sha256:9d14919142395aaca952e129398f0c7371c0f0a034c63de6dad99cd7050177ad"
-            ],
-            "index": "pypi",
-            "version": "==0.7.0"
+            "editable": false,
+            "git": "https://github.com/natlas/python-libnmap.git",
+            "ref": "e1ce4328123f184d4390f94b708cca165ebf1dd9"
         },
         "pytz": {
             "hashes": [

--- a/natlas-server/Pipfile.lock
+++ b/natlas-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "32d7678c1cf14aa3759661910b0e0c72ee40e6233809e1aab1e0b4f2ebef558d"
+            "sha256": "c2ee05ceba2686d75e65a1a57d352801b1876409fa996f9bf0f942a36571aba1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -308,6 +308,14 @@
             ],
             "version": "==1.1.0"
         },
+        "natlas-libnmap": {
+            "hashes": [
+                "sha256:30099b8d8556b64df8ffeaa66b8f79103422297264e6a3c05acafbe92e31fb00",
+                "sha256:52195fa1bf56e7b23d5c5a9a1164d5b1e58a9be6dc980cdfc37aefb8c6d1fdd6"
+            ],
+            "index": "pypi",
+            "version": "==0.7.1"
+        },
         "netaddr": {
             "hashes": [
                 "sha256:7a9c8f58d048b820df1882439bb04fb2de13c03ec8af3112a1099822b0a2a4b8",
@@ -478,11 +486,6 @@
                 "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"
             ],
             "version": "==1.0.4"
-        },
-        "python-libnmap": {
-            "editable": false,
-            "git": "https://github.com/natlas/python-libnmap.git",
-            "ref": "e1ce4328123f184d4390f94b708cca165ebf1dd9"
         },
         "pytz": {
             "hashes": [


### PR DESCRIPTION
Drafting to start to show it works, but we shouldn't merge this until natlas/python-libnmap gets detached to a standalone repository. Once we do that, I'll change the repo name and setup deployment to pypi so that we can pip install it like normal, probably under the name `natlas-libnmap`.

When this lands it will close #299 