### PR TITLE
Weekly dependabot version bumps

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/natlas-server"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/natlas-server"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/natlas-server"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/natlas-agent"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/natlas-agent"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Closes #307 by introducing a dependabot config that tells it to update our packages once a week. I figure once a week is a good way to start and then we can adjust from there if we want it to be faster or slower.