### PR TITLE
Fix agent_config url generation. Closes #325.

### DIFF
--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -427,7 +427,7 @@ def add_script():
     else:
         flash(f"{addScriptForm.scriptName.data} couldn't be added to scripts", "danger")
 
-    return redirect(url_for("admin.agents"))
+    return redirect(url_for("admin.agent_config"))
 
 
 @bp.route("/agents/script/<string:name>/delete", methods=["POST"])
@@ -448,7 +448,7 @@ def delete_script(name):
             flash(f"{name} successfully deleted.", "success")
         else:
             flash(f"{name} doesn't exist", "danger")
-        return redirect(url_for("admin.agents"))
+        return redirect(url_for("admin.agent_config"))
 
 
 @bp.route("/scans/delete/<scan_id>", methods=["POST"])


### PR DESCRIPTION
This is a hotfix to patch breaking capability. A long term fix should add a test that identifies all `url_for` calls and determines whether or not they resolve correctly. `flask routes` prints the route list in the meantime.