### PR TITLE
Password Reset (again)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "editor.insertSpaces": true
+    "editor.insertSpaces": true,
+    "python.analysis.extraPaths": [
+        "natlas-server/",
+        "natlas-agent/"
+    ]
 }

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -62,7 +62,7 @@ def register():
     return render_template("auth/register.html", title="Register", form=form)
 
 
-@bp.route("/reset_password", methods=["GET", "POST"])
+@bp.route("/reset_password_request", methods=["GET", "POST"])
 @is_not_authenticated
 def reset_password_request():
     form = ResetPasswordRequestForm()
@@ -72,7 +72,7 @@ def reset_password_request():
             return redirect(url_for("auth.reset_password_request"))
         user = User.get_reset_token(validemail)
         if user:
-            send_auth_email(user, user.password_reset_token, "reset")
+            send_auth_email(user.email, user.password_reset_token, "reset")
         db.session.commit()
         flash("Check your email for the instructions to reset your password", "info")
         return redirect(url_for("auth.login"))

--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -1,8 +1,9 @@
 from app import db
-from app.util import utcnow_tz, generate_hex_16
+from app.util import generate_hex_16
 import string
 import secrets
 from app.models.dict_serializable import DictSerializable
+from datetime import datetime
 
 
 # Agent registration
@@ -13,7 +14,7 @@ class Agent(db.Model, DictSerializable):
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     # agent identification string for storing in reports
     agentid = db.Column(db.String(16), index=True, unique=True, nullable=False)
-    date_created = db.Column(db.DateTime, nullable=False, default=utcnow_tz)
+    date_created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     # auth token
     token = db.Column(db.String(32), index=True, unique=True)
     # optional friendly name for viewing on user page

--- a/natlas-server/app/models/email_token.py
+++ b/natlas-server/app/models/email_token.py
@@ -1,5 +1,5 @@
 from app import db
-from app.util import utcnow_tz, generate_hex_32
+from app.util import generate_hex_32
 from datetime import datetime, timedelta
 from app.models.dict_serializable import DictSerializable
 
@@ -7,7 +7,7 @@ from app.models.dict_serializable import DictSerializable
 class EmailToken(db.Model, DictSerializable):
     id = db.Column(db.Integer, primary_key=True)
     token = db.Column(db.String(32), index=False, unique=True, nullable=False)
-    date_generated = db.Column(db.DateTime, nullable=False, default=utcnow_tz)
+    date_generated = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
 
     # Valid Token Types are: "register", "invite", and "reset"
@@ -23,7 +23,9 @@ class EmailToken(db.Model, DictSerializable):
         }
         if token_type not in supported_token_types:
             return False
-        expiration = utcnow_tz() + timedelta(seconds=supported_token_types[token_type])
+        expiration = datetime.utcnow() + timedelta(
+            seconds=supported_token_types[token_type]
+        )
         hasToken = EmailToken.query.filter_by(
             user_id=user_id, token_type=token_type
         ).first()

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -1,6 +1,6 @@
 from app import db
-from app.util import utcnow_tz
 from app.models.dict_serializable import DictSerializable
+from datetime import datetime
 
 
 # Rescan Queue
@@ -8,7 +8,9 @@ from app.models.dict_serializable import DictSerializable
 # Tracks when it was dispatched, when it was completed, and the scan id of the complete scan.
 class RescanTask(db.Model, DictSerializable):
     id = db.Column(db.Integer, primary_key=True)
-    date_added = db.Column(db.DateTime, index=True, default=utcnow_tz, nullable=False)
+    date_added = db.Column(
+        db.DateTime, index=True, default=datetime.utcnow, nullable=False
+    )
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     target = db.Column(db.String, index=True, nullable=False)
     dispatched = db.Column(db.Boolean, default=False, index=True)
@@ -19,12 +21,12 @@ class RescanTask(db.Model, DictSerializable):
 
     def dispatchTask(self):
         self.dispatched = True
-        self.date_dispatched = utcnow_tz()
+        self.date_dispatched = datetime.utcnow()
 
     def completeTask(self, scan_id):
         self.scan_id = scan_id
         self.complete = True
-        self.date_completed = utcnow_tz()
+        self.date_completed = datetime.utcnow()
 
     @staticmethod
     def getPendingTasks():

--- a/natlas-server/app/models/scope_log.py
+++ b/natlas-server/app/models/scope_log.py
@@ -1,13 +1,13 @@
 from app import db
-from app.util import utcnow_tz
 from app.models.dict_serializable import DictSerializable
+from datetime import datetime
 
 
 # Basic Logging for Scope related events
 class ScopeLog(db.Model, DictSerializable):
     id = db.Column(db.Integer, primary_key=True)
     msg = db.Column(db.String)
-    created_at = db.Column(db.DateTime, nullable=False, default=utcnow_tz)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __init__(self, msg=None):
         self.msg = msg

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -62,8 +62,9 @@ class User(UserMixin, db.Model, DictSerializable):
         self.password_reset_expiration = None
 
     def validate_reset_token(self):
-        now = utcnow_tz()
-        return self.password_reset_expiration > now
+        if not (self.password_reset_token and self.password_reset_expiration):
+            return False
+        return self.password_reset_expiration > utcnow_tz()
 
     @staticmethod
     def get_reset_token(email):
@@ -77,6 +78,8 @@ class User(UserMixin, db.Model, DictSerializable):
     @staticmethod
     def get_user_by_token(url_token):
         record = User.query.filter_by(password_reset_token=url_token).first()
+        if not record:
+            return False
         return validate_token(
             record, url_token, record.password_reset_token, record.validate_reset_token
         )

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -5,8 +5,7 @@ from app import login, db
 from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
 import secrets
-from app.util import utcnow_tz
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 
 class User(UserMixin, db.Model, DictSerializable):
@@ -19,7 +18,7 @@ class User(UserMixin, db.Model, DictSerializable):
     result_format = db.Column(db.Integer, default=0)
     password_reset_token = db.Column(db.String(32), unique=True)
     password_reset_expiration = db.Column(db.DateTime)
-    creation_date = db.Column(db.DateTime, default=utcnow_tz)
+    creation_date = db.Column(db.DateTime, default=datetime.utcnow)
     is_active = db.Column(db.Boolean, default=False)
     rescans = db.relationship("RescanTask", backref="submitter", lazy="select")
     agents = db.relationship("Agent", backref="user", lazy=True)
@@ -53,7 +52,7 @@ class User(UserMixin, db.Model, DictSerializable):
 
     def new_reset_token(self):
         self.password_reset_token = secrets.token_urlsafe(User.token_length)
-        self.password_reset_expiration = utcnow_tz() + timedelta(
+        self.password_reset_expiration = datetime.utcnow() + timedelta(
             seconds=User.expiration_duration
         )
 
@@ -64,7 +63,7 @@ class User(UserMixin, db.Model, DictSerializable):
     def validate_reset_token(self):
         if not (self.password_reset_token and self.password_reset_expiration):
             return False
-        return self.password_reset_expiration > utcnow_tz()
+        return self.password_reset_expiration > datetime.utcnow()
 
     @staticmethod
     def get_reset_token(email):

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -1,5 +1,4 @@
 from app import db
-from app.util import utcnow_tz
 import secrets
 from datetime import timedelta, datetime
 from app.models.dict_serializable import DictSerializable
@@ -10,7 +9,7 @@ class UserInvitation(db.Model, DictSerializable):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(128), unique=True)
     token = db.Column(db.String(32), unique=True, nullable=False)
-    creation_date = db.Column(db.DateTime, default=utcnow_tz)
+    creation_date = db.Column(db.DateTime, default=datetime.utcnow)
     expiration_date = db.Column(db.DateTime, nullable=False)
     accepted_date = db.Column(db.DateTime)
     is_expired = db.Column(db.Boolean, default=False)

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -3,6 +3,7 @@ import secrets
 from datetime import timedelta, datetime
 from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
+from app.models import User
 
 
 class UserInvitation(db.Model, DictSerializable):
@@ -23,6 +24,8 @@ class UserInvitation(db.Model, DictSerializable):
     # Build a new invitation
     @staticmethod
     def new_invite(email=None, is_admin=False):
+        if email and User.query.filter_by(email=email).first():
+            return False
         now = datetime.utcnow()
         expiration_date = now + timedelta(seconds=UserInvitation.expiration_duration)
         new_token = secrets.token_urlsafe(UserInvitation.token_length)

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -58,10 +58,11 @@ class UserInvitation(db.Model, DictSerializable):
             msg = f"Share this link: {invite_url}"
         return msg
 
-    # Get invite from database in (roughly) constant time
     @staticmethod
     def get_invite(url_token):
         record = UserInvitation.query.filter_by(token=url_token).first()
+        if not record:
+            return False
         return validate_token(record, url_token, record.token, record.validate_invite)
 
     def accept_invite(self):

--- a/natlas-server/app/templates/email/user_invite.txt
+++ b/natlas-server/app/templates/email/user_invite.txt
@@ -1,4 +1,4 @@
-You've been invited to Natlas! Use the link below to set a password. This link will expire in 48 hours. If you are unable to accept this invite before it expires, you can simply use the "Forgot your password?" link on the login page to set your password.
+You've been invited to Natlas! Use the link below to set a password. This link will expire in 48 hours.
 
 {{ url_for('auth.invite_user', token=token, _external=True, _scheme='https') }}
 

--- a/natlas-server/tests/config.py
+++ b/natlas-server/tests/config.py
@@ -3,6 +3,7 @@ from config import Config
 
 class TestConfig(Config):
     MAIL_FROM = "Test Mail <noreply@example.com>"
+    MAIL_SERVER = "localhost"
     TESTING = True
     # This uses an in-memory database
     SQLALCHEMY_DATABASE_URI = "sqlite://"

--- a/natlas-server/tests/models/test_user.py
+++ b/natlas-server/tests/models/test_user.py
@@ -1,0 +1,45 @@
+import secrets
+
+import pytest
+
+from app import db
+from app.models import User
+
+test_password = secrets.token_urlsafe(16)
+
+
+def test_new_user(app):
+    test_user = User(email="newuser@example.com", is_active=True)
+    test_user.set_password(test_password)
+    db.session.add(test_user)
+    db.session.commit()
+    assert test_user.check_password(test_password)
+    assert not test_user.check_password("password")
+    assert test_user.is_active
+    assert not test_user.is_admin
+    assert not test_user.password_reset_token
+    assert not test_user.password_reset_expiration
+
+
+def test_validate_email():
+    assert User.validate_email("test@example.com")
+    assert User.validate_email("test+extensions@example.com")
+    assert User.validate_email("test.extensions@example.com")
+    assert not User.validate_email("test")
+    assert not User.validate_email("test@")
+    assert not User.validate_email("test@example")
+
+
+def test_reset_token():
+    email = "resettoken@example.com"
+    user = User(email=email)
+    db.session.add(user)
+    db.session.commit()
+    assert not user.validate_reset_token()
+    assert User.get_reset_token(email)
+    assert user.validate_reset_token()
+    assert User.get_user_by_token(user.password_reset_token)
+    assert not User.get_reset_token("notoken@example.com")
+    assert not User.get_user_by_token("notoken")
+    user.expire_reset_token()
+    assert not user.validate_reset_token()

--- a/natlas-server/tests/models/test_user.py
+++ b/natlas-server/tests/models/test_user.py
@@ -1,6 +1,5 @@
 import secrets
 
-import pytest
 
 from app import db
 from app.models import User
@@ -12,13 +11,13 @@ def test_new_user(app):
     test_user = User(email="newuser@example.com", is_active=True)
     test_user.set_password(test_password)
     db.session.add(test_user)
-    db.session.commit()
     assert test_user.check_password(test_password)
     assert not test_user.check_password("password")
     assert test_user.is_active
     assert not test_user.is_admin
     assert not test_user.password_reset_token
     assert not test_user.password_reset_expiration
+    db.session.rollback()
 
 
 def test_validate_email():
@@ -34,12 +33,23 @@ def test_reset_token():
     email = "resettoken@example.com"
     user = User(email=email)
     db.session.add(user)
-    db.session.commit()
     assert not user.validate_reset_token()
     assert User.get_reset_token(email)
     assert user.validate_reset_token()
     assert User.get_user_by_token(user.password_reset_token)
-    assert not User.get_reset_token("notoken@example.com")
-    assert not User.get_user_by_token("notoken")
     user.expire_reset_token()
     assert not user.validate_reset_token()
+    assert not User.get_reset_token("notoken@example.com")
+    assert not User.get_user_by_token("notoken")
+    db.session.rollback()
+
+
+def test_double_reset_token():
+    email = "double_validate@example.com"
+    user = User(email=email)
+    db.session.add(user)
+    assert user.get_reset_token(email)
+    assert user.validate_reset_token()
+    assert user.validate_reset_token()
+    assert user.get_reset_token(email)
+    db.session.rollback()

--- a/natlas-server/tests/models/test_user_invitation.py
+++ b/natlas-server/tests/models/test_user_invitation.py
@@ -1,0 +1,66 @@
+from app import db, mail
+from app.models import UserInvitation, User
+
+
+def test_new_anonymous_invite(app):
+    test_invite = UserInvitation.new_invite()
+    assert test_invite.token in UserInvitation.deliver_invite(test_invite)
+    assert not test_invite.is_expired
+    assert not test_invite.is_admin
+    assert UserInvitation.get_invite(test_invite.token)
+    test_invite.accept_invite()
+    assert test_invite.accepted_date
+    assert test_invite.is_expired
+    db.session.rollback()
+
+
+def test_new_email_invite(app):
+    email = "test_invite@example.com"
+    test_invite = UserInvitation.new_invite(email)
+    with mail.record_messages() as outbox:
+        UserInvitation.deliver_invite(test_invite)
+    assert test_invite.email in outbox[0].recipients
+    assert test_invite.token in outbox[0].body
+    assert UserInvitation.get_invite(test_invite.token)
+    test_invite.accept_invite()
+    assert test_invite.accepted_date
+    assert test_invite.is_expired
+    db.session.rollback()
+
+
+def test_double_anonymous_deliver(app):
+    test_invite = UserInvitation.new_invite()
+    assert test_invite.token in UserInvitation.deliver_invite(test_invite)
+    assert test_invite.token in UserInvitation.deliver_invite(test_invite)
+    db.session.rollback()
+
+
+def test_double_email_deliver(app):
+    email = "test_invite@example.com"
+    test_invite = UserInvitation.new_invite(email)
+    with mail.record_messages() as outbox:
+        UserInvitation.deliver_invite(test_invite)
+        UserInvitation.deliver_invite(test_invite)
+    assert len(outbox) == 2
+    db.session.rollback()
+
+
+def test_double_invite(app):
+    email = "test_invite@example.com"
+    invite_1 = UserInvitation.new_invite(email)
+    old_token = invite_1.token
+    # invite_2 should be an instance of UserInvitation(id=1) with a new token
+    invite_2 = UserInvitation.new_invite(email)
+    assert old_token != invite_2.token
+    assert invite_1.token == invite_2.token
+    assert not UserInvitation.get_invite(old_token)
+    assert UserInvitation.get_invite(invite_1.token)
+    db.session.rollback()
+
+
+def test_inviting_existing_user(app):
+    email = "test_invite@example.com"
+    u = User(email=email)
+    db.session.add(u)
+    assert not UserInvitation.new_invite(email)
+    db.session.rollback()


### PR DESCRIPTION
Fixing the previous password reset bug uncovered another bug involving comparisons against NoneType in cases where a user doesn't already have a reset token. 

Fixing *that* bug uncovered yet another bug involving comparison of offset-aware and offset-naive datetime objects. Since all datetimes that go into the database are converted to offset-naive, it helps if we reference them as offset-naive throughout the model code. This makes it easier to test and creates less edge cases, since the data format going into the model is the same as the data format coming out of the model.

This will close #330 

Added a few tests against the User data model that should cover everything that caused these bugs, I think.