### PR TITLE
Move flake8 to pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  flake8: arrai/flake8@5.0.0
 jobs:
   general-analysis:
     docker:
@@ -15,10 +13,6 @@ jobs:
           name: Restore pipenv cache
           keys:
             - pipenv-v0-{{ checksum "Pipfile.lock" }}
-      - flake8/setup_flake8:
-          wd: ~/repo
-      - flake8/flake8_errors:
-          wd: ~/repo
       - run:
           name: Install pipenv
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     rev: 19.3b0
     hooks:
     -   id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+    -   id: flake8

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 ![Natlas](https://0xda.de/img/natlas-1000px.png)
 
-[![Release](https://img.shields.io/github/release/natlas/natlas.svg)](https://github.com/natlas/natlas/releases/latest)
 ![Last Commit](https://img.shields.io/github/last-commit/natlas/natlas.svg)
+[![Release](https://img.shields.io/github/release/natlas/natlas.svg)](https://github.com/natlas/natlas/releases/latest)
 [![Contributors](https://img.shields.io/github/contributors/natlas/natlas.svg)](https://github.com/natlas/natlas/graphs/contributors)
 [![License](https://img.shields.io/badge/license-Apache%202-blue.svg?style=flat)](LICENSE)
-[![Discord](https://img.shields.io/discord/638428906612850709?label=discord)](https://discord.gg/VMbyMMT)
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/321141e5cf7426874cd7/maintainability)](https://codeclimate.com/github/natlas/natlas/maintainability)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/natlas/natlas.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/natlas/natlas/alerts/)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 [![Server downloads](https://img.shields.io/docker/pulls/natlas/server?label=server%20downloads&logo=docker)](https://hub.docker.com/repository/docker/natlas/server)
 [![Agent downloads](https://img.shields.io/docker/pulls/natlas/agent?label=agent%20downloads&logo=docker)](https://hub.docker.com/repository/docker/natlas/agent)


### PR DESCRIPTION
Adds flake8 to pre-commit hooks

Since flake8 runs as part of pre-commit now, no need for the 3rd party flake8 orb in circleci

Also rearrange badges a little bit and add pre-commit and black badge. 