### PR TITLE
Make function returns explicit

### DIFF
--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -38,6 +38,8 @@ def unauthorized():
     if not current_user.is_admin:
         flash(f"You must be an admin to access {request.path}.", "warning")
         return redirect(url_for("main.index"))
+    flash("Unauthorized", "warning")
+    return redirect(url_for("auth.login"))
 
 
 def load_natlas_config(app):

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -196,7 +196,7 @@ def import_scope(scopetype=""):
         importBlacklist = False
         importForm = forms.ImportScopeForm()
     else:
-        abort(404)
+        return abort(404)
     if importForm.validate_on_submit():
         newScopeItems = importForm.scope.data.split("\n")
         fail, exist, success = ScopeItem.import_scope(newScopeItems, importBlacklist)
@@ -226,7 +226,7 @@ def export_scope(scopetype=""):
     elif scopetype == "scope":
         exportBlacklist = False
     else:
-        abort(404)
+        return abort(404)
     items = ScopeItem.query.filter_by(blacklist=exportBlacklist).all()
     return Response(
         "\n".join(str(item.target) for item in items), mimetype="text/plain"
@@ -238,7 +238,7 @@ def export_scope(scopetype=""):
 @is_admin
 def delete_scope(scopetype, id):
     if scopetype not in ["scope", "blacklist"]:
-        abort(404)
+        return abort(404)
     delForm = forms.ScopeDeleteForm()
     if delForm.validate_on_submit():
         item = ScopeItem.query.filter_by(id=id).first()
@@ -258,7 +258,7 @@ def delete_scope(scopetype, id):
 @is_admin
 def toggle_scope(scopetype, id):
     if scopetype not in ["scope", "blacklist"]:
-        abort(404)
+        return abort(404)
     toggleForm = forms.ScopeToggleForm()
     if toggleForm.validate_on_submit():
         item = ScopeItem.query.filter_by(id=id).first()
@@ -276,7 +276,7 @@ def toggle_scope(scopetype, id):
 @is_admin
 def tag_scope(scopetype, id):
     if scopetype not in ["scope", "blacklist"]:
-        abort(404)
+        return abort(404)
     addTagForm = forms.TagScopeForm()
     addTagForm.tagname.choices = [(row.name, row.name) for row in Tag.query.all()]
     if addTagForm.validate_on_submit():
@@ -295,7 +295,7 @@ def tag_scope(scopetype, id):
 @is_admin
 def untag_scope(scopetype, id):
     if scopetype not in ["scope", "blacklist"]:
-        abort(404)
+        return abort(404)
     delTagForm = forms.TagScopeForm()
     scope = ScopeItem.query.get(id)
     delTagForm.tagname.choices = [(row.name, row.name) for row in scope.tags.all()]

--- a/natlas-server/app/host/routes.py
+++ b/natlas-server/app/host/routes.py
@@ -58,7 +58,7 @@ def host_history(ip):
         ip, current_user.results_per_page, searchOffset
     )
     if count == 0:
-        abort(404)
+        return abort(404)
     next_url = (
         url_for("host.host_history", ip=ip, p=page + 1)
         if count > page * current_user.results_per_page
@@ -107,7 +107,7 @@ def host_historical_result(ip, scan_id):
 @is_authenticated
 def export_scan(ip, scan_id, ext):
     if ext not in ["xml", "nmap", "gnmap", "json"]:
-        abort(404)
+        return abort(404)
 
     export_field = f"{ext}_data"
 
@@ -118,7 +118,7 @@ def export_scan(ip, scan_id, ext):
     elif count > 0 and export_field in context:
         return Response(context[export_field], mimetype=mime)
     else:
-        abort(404)
+        return abort(404)
 
 
 @bp.route("/<ip>/screenshots")
@@ -207,7 +207,7 @@ def random_host():
     random_host = current_app.elastic.random_host()
     # This would most likely occur when there are no hosts up in the index, so just throw a 404
     if not random_host:
-        abort(404)
+        return abort(404)
     ip = random_host["ip"]
     info, context = hostinfo(ip)
     delForm = DeleteForm()


### PR DESCRIPTION
There are a number of places where there were implicit returns or returns that weren't clear that they were exit points for functions (specifically with the use of `abort(404)`, which raises an httpexception that WSGI handles in accordance with registered error handlers. `return abort(404)` works just the same and makes it much clearer that it's an exit point.