### PR TITLE
Embed versions into the Webpack bundle

### DIFF
--- a/natlas-server/app/static/util/version-check.ts
+++ b/natlas-server/app/static/util/version-check.ts
@@ -1,3 +1,4 @@
+/* globals process */
 import makeXhrCall from './xhr';
 
 const updateURL = 'https://api.github.com/repos/natlas/natlas/releases/latest';
@@ -12,9 +13,10 @@ class UpdateCheckResult {
     }
 }
 
-// Not ideal. We should pack this into the bundle instead
+declare const NATLAS_VERSION: string;
+
 export function thisVersion(): string {
-    return document.getElementById('natlasVersion').innerText;
+    return NATLAS_VERSION;
 }
 
 function extractVersion(result: GithubReleases): string {

--- a/natlas-server/app/templates/includes/scripts.html
+++ b/natlas-server/app/templates/includes/scripts.html
@@ -2,5 +2,5 @@
 <!-- Scripts -->
 {% set mainjs = config['webpack'].main.js %}
 {% for url in mainjs.rel_urls %}
-<script type="text/javascript" src="{{ mainjs.static_url + url }}" defer async></script>
+<script type="application/javascript" src="{{ mainjs.static_url + url }}" defer async></script>
 {% endfor %}

--- a/natlas-server/webpack.config.js
+++ b/natlas-server/webpack.config.js
@@ -1,8 +1,20 @@
 /* eslint-env node */
 const path = require('path');
+const webpack = require('webpack');
 const WebpackManifestPlugin = require('webpack-yam-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const assetRootPath = path.resolve(__dirname, 'app', 'static');
+
+function revision() {
+    if (process.env.SOURCE_BRANCH === "main") {
+        return `main-${process.env.SOURCE_COMMIT}`;
+    }
+    const tag = process.env.DOCKER_TAG;
+    if (tag) {
+        return tag;
+    }
+    return "dev";
+}
 
 const config = (env, argv) => {
     const isDev = argv.mode === 'development';
@@ -31,9 +43,7 @@ const config = (env, argv) => {
                 },
                 {
                     test: /\.(svg|eot|woff|woff2|ttf)(\?v=\d+\.\d+\.\d+)?$/,
-                    use: [
-                        'file-loader?publicPath=/static/dist'
-                    ]
+                    use: 'file-loader?publicPath=/static/dist'
                 }
             ]
         },
@@ -46,6 +56,9 @@ const config = (env, argv) => {
             new WebpackManifestPlugin({
                 manifestPath: path.resolve(assetRootPath, 'dist', 'webpack_manifest.json'),
                 outputRoot: assetRootPath
+            }),
+            new webpack.DefinePlugin({
+                NATLAS_VERSION: JSON.stringify(revision())
             })
         ],
         resolve: {


### PR DESCRIPTION
JS on the login page is broken when Sentry.io is enabled because we're trying to get the version from a DOM element. This corrects the issue by injecting the correct version using the Git commit or tag into the JS bundle.