### PR TITLE
Fix: ipv6 related assumptions, agent support for ipv6 nmap addresses

### DIFF
--- a/natlas-agent/natlas-agent.py
+++ b/natlas-agent/natlas-agent.py
@@ -26,15 +26,15 @@ netsrv = NatlasNetworkServices(config)
 
 
 def add_targets_to_queue(target, q):
-    targetNetwork = ipaddress.ip_interface(target.strip())
-    if targetNetwork.with_prefixlen.endswith("/32"):
-        target_data = netsrv.get_work(target=str(targetNetwork.ip))
+    targetNetwork = ipaddress.ip_network(target.strip())
+    if targetNetwork.num_addresses == 1:
+        target_data = netsrv.get_work(target=str(targetNetwork.network_address))
         if not target_data:
             return
         q.put(target_data)
     else:
         # Iterate over usable hosts in target, queue.put will block until a queue slot is available
-        for t in targetNetwork.network.hosts():
+        for t in targetNetwork.hosts():
             target_data = netsrv.get_work(target=str(t))
             if not target_data:
                 continue
@@ -55,13 +55,13 @@ def main():
     mutually_exclusive.add_argument(
         "--target",
         metavar="IPADDR",
-        help="An IPv4 address or CIDR range to scan. e.g. 192.168.0.1, 192.168.0.1/24",
+        help="An IP address or CIDR range to scan. e.g. 192.168.0.1, 192.168.0.1/24, 2001:db8:dead:dade:fade:cafe:babe:beef/128",
         dest="target",
     )
     mutually_exclusive.add_argument(
         "--target-file",
         metavar="FILENAME",
-        help="A file of line separated target IPv4 addresses or CIDR ranges",
+        help="A file of line separated target IP addresses or CIDR ranges",
         dest="tfile",
     )
     args = parser.parse_args()

--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -2,6 +2,7 @@ import subprocess
 import threading
 import shutil
 import os
+import ipaddress
 
 from libnmap.parser import NmapParser, NmapParserException
 from sentry_sdk import capture_exception
@@ -38,7 +39,8 @@ def command_builder(scan_id, agentConfig, target):
     for k, v in agentConfig.items():
         if agentConfig[k] and k in commandDict:
             command.append(commandDict[k].format(**agentConfig))
-
+    if ipaddress.ip_network(target).version == 6:
+        command.append("-6")
     command.append(target)
     return command
 

--- a/natlas-server/app/admin/forms.py
+++ b/natlas-server/app/admin/forms.py
@@ -53,15 +53,13 @@ class NewScopeForm(FlaskForm):
     submit = SubmitField("Add Target")
 
     def validate_target(self, target):
-        if "/" not in target.data:
-            target.data = target.data + "/32"
         try:
             isValid = ipaddress.ip_network(target.data, False)
             item = ScopeItem.query.filter_by(target=isValid.with_prefixlen).first()
             if item is not None:
                 raise ValidationError(f"Target {item.target} already exists!")
-        except ipaddress.AddressValueError:
-            raise ValidationError(f"Target {target.data} couldn't be validated")
+        except ipaddress.AddressValueError as e:
+            raise ValidationError(e)
 
 
 class ImportScopeForm(FlaskForm):

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -129,8 +129,6 @@ def scope():
     addTagForm = forms.TagScopeForm()
     addTagForm.tagname.choices = [(row.name, row.name) for row in Tag.query.all()]
     if newForm.validate_on_submit():
-        if "/" not in newForm.target.data:
-            newForm.target.data = newForm.target.data + "/32"
         target = ipaddress.ip_network(newForm.target.data, False)
         newTarget = ScopeItem(target=target.with_prefixlen, blacklist=False)
         db.session.add(newTarget)
@@ -164,8 +162,6 @@ def blacklist():
     addTagForm = forms.TagScopeForm()
     addTagForm.tagname.choices = [(row.name, row.name) for row in Tag.query.all()]
     if newForm.validate_on_submit():
-        if "/" not in newForm.target.data:
-            newForm.target.data = newForm.target.data + "/32"
         target = ipaddress.ip_network(newForm.target.data, False)
         newTarget = ScopeItem(target=target.with_prefixlen, blacklist=True)
         db.session.add(newTarget)

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -62,8 +62,6 @@ class ScopeItem(db.Model, DictSerializable):
             ip = line
             tags = []
 
-        if "/" not in ip:
-            ip = ip + "/32"
         ip = ScopeItem.validate_ip(ip)
         return ip, tags
 

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -38,7 +38,7 @@ class ScopeManager:
         return self.blacklist
 
     def get_effective_scope_size(self):
-        return len(self.scope_set - self.blacklist_set)
+        return (self.scope_set - self.blacklist_set).size
 
     def get_pending_rescans(self):
         return self.pendingRescans
@@ -69,7 +69,7 @@ class ScopeManager:
 
         self.scope = [IPNetwork(item.target, False) for item in ScopeItem.getScope()]
         self.scope_set = IPSet(self.scope)
-        self.scopeSize = len(self.scope_set)
+        self.scopeSize = self.scope_set.size
 
     def update_blacklist(self):
         from app.models import ScopeItem
@@ -78,7 +78,7 @@ class ScopeManager:
             IPNetwork(item.target, False) for item in ScopeItem.getBlacklist()
         ]
         self.blacklist_set = IPSet(self.blacklist)
-        self.blacklistSize = len(self.blacklist_set)
+        self.blacklistSize = self.blacklist_set.size
 
     def update_scan_manager(self):
 
@@ -106,7 +106,6 @@ class ScopeManager:
         current_app.logger.info(f"{str(datetime.utcnow())} - ScopeManager Updated\n")
 
     def is_acceptable_target(self, target: str):
-        # Ensure it's a valid IPv4Address
         try:
             IPAddress(target)
         except AddrFormatError:

--- a/natlas-server/tests/models/test_scope.py
+++ b/natlas-server/tests/models/test_scope.py
@@ -8,6 +8,12 @@ def test_new_scope(app):
     assert test_scope.target == "10.0.0.0/8"
 
 
+def test_ip6_scope(app):
+    test_scope = ScopeItem(target="2001:db8::/32", blacklist=False)
+    assert not test_scope.blacklist
+    assert test_scope.target == "2001:db8::/32"
+
+
 def test_add_tags(app):
     tags = ["test", "tag", "three"]
     test_scope = ScopeItem(target="127.0.0.1/8", blacklist=False)
@@ -43,6 +49,7 @@ scopefile = """
 10.13.14.15,one,two
 10.12.13.14
 notevenanip
+2001:db8::/32
 """
 
 
@@ -50,9 +57,11 @@ def test_import_scope(app):
     fails, exists, succeeds = ScopeItem.import_scope_list(scopefile.split(), False)
     assert len(fails) == 1
     assert len(exists) == 1
-    assert len(succeeds) == 4
+    assert len(succeeds) == 5
     item = ScopeItem.query.filter_by(target="127.0.0.1/32").first()
     tags = [t.name for t in item.tags]
     assert len(tags) == 3
     assert "one" in tags
     assert "four" not in tags
+    item = ScopeItem.query.filter_by(target="10.12.13.14/32").first()
+    assert len(item.tags) == 0


### PR DESCRIPTION
Closes #355. Closes #61. IPv6 support should work throughout, assuming your agents can route ipv6 addresses.