### PR TITLE
Fixed version injection

### DIFF
--- a/natlas-server/Dockerfile
+++ b/natlas-server/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:12-stretch as webpack
+ARG NATLAS_VERSION=unknown
 
 WORKDIR /app
 COPY ["package.json", "yarn.lock", "/app/"]
+ENV NATLAS_VERSION=$NATLAS_VERSION
 RUN yarn --no-progress --frozen-lockfile --non-interactive
 COPY . /app
 RUN yarn run webpack --mode production

--- a/natlas-server/hooks/build
+++ b/natlas-server/hooks/build
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set +e
+set +x
+
+NATLAS_VERSION=${DOCKER_TAG:?Specify DOCKER_TAG}
+
+if [ "$DOCKER_TAG" == "latest" ]
+then
+  NATLAS_VERSION=$SOURCE_COMMIT
+fi
+
+exec docker build -t "$IMAGE_NAME" --build-arg "NATLAS_VERSION=$NATLAS_VERSION" .

--- a/natlas-server/webpack.config.js
+++ b/natlas-server/webpack.config.js
@@ -5,17 +5,6 @@ const WebpackManifestPlugin = require('webpack-yam-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const assetRootPath = path.resolve(__dirname, 'app', 'static');
 
-function revision() {
-    if (process.env.SOURCE_BRANCH === "main") {
-        return `main-${process.env.SOURCE_COMMIT}`;
-    }
-    const tag = process.env.DOCKER_TAG;
-    if (tag) {
-        return tag;
-    }
-    return "dev";
-}
-
 const config = (env, argv) => {
     const isDev = argv.mode === 'development';
     return {
@@ -57,8 +46,8 @@ const config = (env, argv) => {
                 manifestPath: path.resolve(assetRootPath, 'dist', 'webpack_manifest.json'),
                 outputRoot: assetRootPath
             }),
-            new webpack.DefinePlugin({
-                NATLAS_VERSION: JSON.stringify(revision())
+            new webpack.EnvironmentPlugin({
+                NATLAS_VERSION: "dev"
             })
         ],
         resolve: {


### PR DESCRIPTION
Turns out, Docker Hub didn't work the way that I expected it did so the previous version stamping didn't actually work. This change makes it actually work. Additionally, the Python code now respects the same version stamped on the Docker image.

Tested by actually building the image on Docker Hub:
ajacques/natlas:latest:
```
"Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "NODE_VERSION=12.18.3",
                "YARN_VERSION=1.22.4",
                "NATLAS_VERSION=ee538d78364c7be6acb04a06c91a28ea2b045d0a"
            ],
```
ajacques/natlas:1.2.3:
```
 "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "NODE_VERSION=12.18.3",
                "YARN_VERSION=1.22.4",
                "NATLAS_VERSION=1.2.3"
            ],
```