### PR TITLE
Fix: xvfb-run negates the need to check for DISPLAY.

### DIFF
--- a/natlas-agent/natlas/screenshots.py
+++ b/natlas-agent/natlas/screenshots.py
@@ -80,8 +80,6 @@ def get_web_screenshots(target, scan_id, xml_data, proctimeout):
 
 
 def get_vnc_screenshots(target, scan_id, proctimeout):
-    if "DISPLAY" not in os.environ:
-        return False
 
     scan_dir = utils.get_scan_dir(scan_id)
     outFile = os.path.join(scan_dir, f"vncsnapshot.{scan_id}.jpg")


### PR DESCRIPTION
Fix: xvfb-run negates the need to check for DISPLAY. This has probably never worked in docker.

This is a bug fix only, the pending plugin architecture will make the vnc logic much more robust to check for other ports as well, since we'll have structured access to the data.

Thanks to @fdcarl for pointing this out as the problem.