### PR TITLE
Fix: Rendering of vnc to not assume png

### DIFF
--- a/natlas-server/app/filters.py
+++ b/natlas-server/app/filters.py
@@ -11,6 +11,8 @@ def ctime(s, human=False):
     return parser.parse(s).strftime("%Y-%m-%d %H:%M")
 
 
-@bp.app_template_filter("hashpath")
-def hashpath(inhash):
-    return f"{inhash[0:2]}/{inhash[2:4]}/{inhash}.png"
+@bp.app_template_filter("get_screenshot_path")
+def get_screenshot_path(inhash: str, service: str = "HTTP"):
+    ext_map = {"HTTP": ".png", "HTTPS": ".png", "VNC": ".jpg"}
+
+    return f"{inhash[0:2]}/{inhash[2:4]}/{inhash}{ext_map[service]}"

--- a/natlas-server/app/templates/host/versions/0.6.10/_host-row.html
+++ b/natlas-server/app/templates/host/versions/0.6.10/_host-row.html
@@ -40,7 +40,7 @@
           <div class="image-browser-service p-2">{{ screenshot.service }}</div>
           <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
         </div>
-        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
+        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
       </div>
       {% endif %}
     {% endfor %}

--- a/natlas-server/app/templates/host/versions/0.6.10/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.10/screenshots.html
@@ -26,7 +26,7 @@
                             <div class="image-browser-service p-2">{{ screenshot.service }}</div>
                             <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
                         </div>
-                        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' data-ip='{{ip}}' data-scan_id='{{entry.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != ip %} ({{ip}}){%endif%}">
+                        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{ip}}' data-scan_id='{{entry.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != ip %} ({{ip}}){%endif%}">
                     </div>
                 </div>
                 {% endif %}

--- a/natlas-server/app/templates/host/versions/0.6.7/_host-row.html
+++ b/natlas-server/app/templates/host/versions/0.6.7/_host-row.html
@@ -36,7 +36,7 @@
     {% for screenshot in host.screenshots %}
       {% if screenshot.hash %}
       <h5 class="mt-2">{{ screenshot.service }}</h5>
-      <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ host.ip }} - {{ screenshot.service }} Screenshot"></div>
+      <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ host.ip }} - {{ screenshot.service }} Screenshot"></div>
       {% endif %}
     {% endfor %}
   </div><!--meta column-->

--- a/natlas-server/app/templates/host/versions/0.6.7/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.7/screenshots.html
@@ -22,7 +22,7 @@
                 {% if screenshot.hash %}
                 <div class="col-xs-12 col-sm-3">
                     <strong class="mt-2">{{ screenshot.service }}</strong>
-                    <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ entry.ctime|ctime }} - {{ screenshot.service }}"></div>
+                    <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ entry.ctime|ctime }} - {{ screenshot.service }}"></div>
                 </div>
                 {% endif %}
                 {% if screenshot.path %}

--- a/natlas-server/app/templates/host/versions/0.6.8/_host-row.html
+++ b/natlas-server/app/templates/host/versions/0.6.8/_host-row.html
@@ -37,7 +37,7 @@
       {% if screenshot.hash %}
       <h5 class="mt-2">Port {{ screenshot.port }}</h5>
       <small>{{screenshot.host}}</small>
-      <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ host.ip }} - {{ screenshot.service }} Screenshot"></div>
+      <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ host.ip }} - {{ screenshot.service }} Screenshot"></div>
       {% endif %}
     {% endfor %}
   </div><!--meta column-->

--- a/natlas-server/app/templates/host/versions/0.6.8/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.8/screenshots.html
@@ -22,7 +22,7 @@
                 {% if screenshot.hash %}
                 <div class="col-xs-12 col-sm-3">
                     <strong class="mt-2">{{ screenshot.service }}</strong>
-                    <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ entry.ctime|ctime }} - {{ screenshot.service }}"></div>
+                    <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ entry.ctime|ctime }} - {{ screenshot.service }}"></div>
                 </div>
                 {% endif %}
                 {% if screenshot.path %}

--- a/natlas-server/app/templates/host/versions/0.6.9/_host-row.html
+++ b/natlas-server/app/templates/host/versions/0.6.9/_host-row.html
@@ -40,7 +40,7 @@
               <div class="image-browser-service p-2">{{ screenshot.service }}</div>
               <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
             </div>
-            <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
+            <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
           </div>
         {% endif %}
       {% endfor %}

--- a/natlas-server/app/templates/host/versions/0.6.9/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.9/screenshots.html
@@ -26,7 +26,7 @@
                             <div class="image-browser-service p-2">{{ screenshot.service }}</div>
                             <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
                         </div>
-                        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' data-ip='{{ip}}' data-scan_id='{{entry.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != ip %} ({{ip}}){%endif%}">
+                        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{ip}}' data-scan_id='{{entry.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != ip %} ({{ip}}){%endif%}">
                     </div>
                 </div>
                 {% endif %}

--- a/natlas-server/app/templates/main/screenshots.html
+++ b/natlas-server/app/templates/main/screenshots.html
@@ -22,7 +22,7 @@
                                 <div class="image-browser-service p-2">{{ screenshot.service }}</div>
                                 <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
                             </div>
-                            <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|hashpath}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|hashpath}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
+                            <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
                         </div>
                     </div>
                     {% endif %}


### PR DESCRIPTION
Now that agents can actually take screenshots of vnc again, they are being stored as jpg but the (poorly named) hashpath function hardcoded the extension to `.png` even though `.jpg` is the known format that vncsnapshot produces.

In the future we should update the screenshot stored in elastic to also contain the file extension, that way we could change the code to convert jpg to png or whatever else and the new documents would still be renderable instead of relying on the name of the service to map to extensions.

But this is just fixing the rendering for now. Trying not to make dramatic changes as we approach another tagged release.