### PR TITLE
Fix: Raise elasticsearch.connectionerror correctly

### DIFF
--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -23,5 +23,10 @@ def internal_server_error(e):
 
 @bp.app_errorhandler(elasticsearch.ConnectionError)
 def elastic_unavailable(e):
+    """
+        This capture_exception happens here but not in others because
+        the others use Flask's exception handling already. Since we are handling
+        a specific exception class, we have to capture it explicitly.
+    """
     sentry_sdk.capture_exception(e)
     return render_template("errors/503.html"), 503

--- a/natlas-server/app/templates/errors/503.html
+++ b/natlas-server/app/templates/errors/503.html
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="row">
       <div class="col">
-          <h2 class="sub-header">503: Service Unavailable</h2>
+          <h2 class="sub-header">503: Service Temporarily Unavailable</h2>
       </div>
   </div>
   <div class="row">


### PR DESCRIPTION
Raise ConnectionError with a value so that `str()` should work correctly.

Updated the template to reflect temporarily unavailable.

Added a comment about why that one error handler has a sentry line but the others don't.

Closes #342.