### PR TITLE
Fix: Ignore malformed dates from ssl certs.

### DIFF
--- a/natlas-server/defaults/elastic/mapping.json
+++ b/natlas-server/defaults/elastic/mapping.json
@@ -173,10 +173,12 @@
               }
             },
             "notAfter": {
-              "type": "date"
+              "type": "date",
+              "ignore_malformed": true
             },
             "notBefore": {
-              "type": "date"
+              "type": "date",
+              "ignore_malformed": true
             },
             "pem": {
               "type": "text",


### PR DESCRIPTION
I know this doesn't address all the other weird mapping issues. I'm just trying to clean up obvious impact bugs. This one results in the entire document being discarded because some people take "not caring about ssl validity" to the extreme.

We can keep this open for a little bit and add additional changes if you'd like.

Closes #261.