### PR TITLE
Fix: Incorrect column lengths for email and password_reset_token

### DIFF
--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -10,13 +10,13 @@ from datetime import datetime, timedelta
 
 class User(UserMixin, db.Model, DictSerializable):
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(128), index=True, unique=True)
+    email = db.Column(db.String(254), index=True, unique=True)
     password_hash = db.Column(db.String(128))
     is_admin = db.Column(db.Boolean, default=False)
     results_per_page = db.Column(db.Integer, default=100)
     preview_length = db.Column(db.Integer, default=100)
     result_format = db.Column(db.Integer, default=0)
-    password_reset_token = db.Column(db.String(32), unique=True)
+    password_reset_token = db.Column(db.String(256), unique=True)
     password_reset_expiration = db.Column(db.DateTime)
     creation_date = db.Column(db.DateTime, default=datetime.utcnow)
     is_active = db.Column(db.Boolean, default=False)

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -8,7 +8,7 @@ from app.models import User
 
 class UserInvitation(db.Model, DictSerializable):
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(320), unique=True)
+    email = db.Column(db.String(254), unique=True)
     token = db.Column(db.String(256), unique=True, nullable=False)
     creation_date = db.Column(db.DateTime, default=datetime.utcnow)
     expiration_date = db.Column(db.DateTime, nullable=False)

--- a/natlas-server/migrations/versions/6eb79ba67acb_better_invitations_and_resets.py
+++ b/natlas-server/migrations/versions/6eb79ba67acb_better_invitations_and_resets.py
@@ -21,7 +21,7 @@ def upgrade():
     op.create_table(
         "user_invitation",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("email", sa.String(length=320), nullable=True),
+        sa.Column("email", sa.String(length=254), nullable=True),
         sa.Column("token", sa.String(length=256), nullable=False),
         sa.Column("creation_date", sa.DateTime(), nullable=True),
         sa.Column("expiration_date", sa.DateTime(), nullable=False),
@@ -43,7 +43,7 @@ def upgrade():
             sa.Column("password_reset_expiration", sa.DateTime(), nullable=True)
         )
         batch_op.add_column(
-            sa.Column("password_reset_token", sa.String(length=32), nullable=True)
+            sa.Column("password_reset_token", sa.String(length=256), nullable=True)
         )
         batch_op.create_unique_constraint("uq_pw_reset_token", ["password_reset_token"])
 

--- a/natlas-server/migrations/versions/ed2f92f790d3_users_table.py
+++ b/natlas-server/migrations/versions/ed2f92f790d3_users_table.py
@@ -21,7 +21,7 @@ def upgrade():
     op.create_table(
         "user",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("email", sa.String(length=128), nullable=True),
+        sa.Column("email", sa.String(length=254), nullable=True),
         sa.Column("password_hash", sa.String(length=128), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )


### PR DESCRIPTION
In development of #373, I noticed that password reset tokens have the wrong length applied to them under the new mysql-compatible schema. Their length has been adjusted to 256 to match the invitation token length limitations, which will accommodate their current size (~42-45 bytes) as well as allow plenty of room if we need to increase length limit.

Similarly it was noticed that the User table enforced a 128 character limit on the `email` field, whereas the UserInvitation table enforced a 320 character limit on the `email` field. Upon further research, [RFC 3696](https://tools.ietf.org/html/rfc3696) has [an errata](https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690) that says:

>Since addresses that do not fit in those fields are not normally useful, the upper limit on address lengths should normally be considered to be 254.

So, too, shall we enforce a 254 character limit on the email address, which was already being enforced by the [email_validator](https://pypi.org/project/email-validator/) library that we use:

```
>>> import email_validator
>>> email = "123456789012345678901234567890123456789012345678901234567890@12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345.iana.org"
>>> email_validator.validate_email(email)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dade/natlas/natlas-server/.venv/lib/python3.8/site-packages/email_validator/__init__.py", line 249, in validate_email
    raise EmailSyntaxError("The email address is too long{}.".format(reason))
email_validator.EmailSyntaxError: The email address is too long (1 character too many).
```