### PR TITLE
Enable auto labeling for new PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+agent:
+- natlas-agent/*
+
+server:
+- natlas-server/*
+
+dependencies:
+- '*/Dockerfile'
+- '*/Pipfile*'
+- natlas-server/package.json
+- natlas-server/yarn.lock
+
+testing:
+  - '*/tests/*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Uses the `actions/labeler` github action to do automatic labeling on new pull requests.

[Labeler documentation](https://github.com/actions/labeler)