### PR TITLE
Change: Automatic migration detection prevents app from launching if …

### DIFF
--- a/natlas-server/.dockerignore
+++ b/natlas-server/.dockerignore
@@ -1,15 +1,14 @@
 # Ships with source
 deployment/
-elastic-snapshot.py
 *.md
 .dockerignore
 Dockerfile
 tests/
 docs/
-.scss-lint.yml
 tslint.json
 .eslintrc.yml
-.python-version
+.stylelintrc.yml
+natlas-migrate.py
 
 # Dev Environment
 __pycache__/

--- a/natlas-server/README.md
+++ b/natlas-server/README.md
@@ -50,6 +50,7 @@ MAIL_FROM=noreply@example.com
 # Natlas Specific Settings
 #####
 CONSISTENT_SCAN_CYCLE=True
+DB_AUTO_MIGRATE=True
 ```
 
 ### Launching Natlas Server
@@ -86,6 +87,7 @@ Environment configs are loaded from the environment or a `.env` file and require
 | `SECRET_KEY` | Randomly generated | Used for CSRF tokens and sessions. You should generate a unique value for this in `.env`, otherwise sessions will be invalidated whenever the app restarts. |
 | `DATA_DIR` | `/data` | Path to store any data that should be persisted. Sqlite database, any log files, and media files all go in subdirectories of this directory. |
 | `SQLALCHEMY_DATABASE_URI` | `sqlite:///$DATA_DIR/db/metadata.db` | A [SQLALCHEMY URI](https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/) that points to the database to store natlas metadata in. Supported types by natlas-server are: `sqlite:`, `mysql:` |
+| `DB_AUTO_MIGRATE` | `False` | Automatically perform necessary data migrations when upgrading to a new version of natlas. Not recommended for multi-node deployments. |
 | `ELASTICSEARCH_URL` | `http://localhost:9200` | A URL that points to the elasticsearch cluster to store natlas scan data in |
 | `FLASK_ENV` | `production` | Used to tell flask which environment to run. Only change this if you are debugging or developing, and never leave your server running in anything but `production`.  |
 | `FLASK_APP` | `natlas-server.py` | The file name that launches the flask application. This should not be changed as it allows commands like `flask run`, `flask db upgrade`, and `flask shell` to run.|

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -55,7 +55,7 @@ class Config(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # Automatically perform any required migrations on app init
-    DB_AUTO_MIGRATE = casted_bool(os.environ.get("DB_AUTO_MIGRATE", False))
+    DB_AUTO_UPGRADE = casted_bool(os.environ.get("DB_AUTO_UPGRADE", False))
 
     # This isn't in the database because it really shouldn't be changing on-the-fly
     # Also make sure that you're using an absolute path if you're serving your app directly via flask

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -54,6 +54,9 @@ class Config(object):
     # This isn't in the database because we'll never want to change it
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    # Automatically perform any required migrations on app init
+    DB_AUTO_MIGRATE = casted_bool(os.environ.get("DB_AUTO_MIGRATE", False))
+
     # This isn't in the database because it really shouldn't be changing on-the-fly
     # Also make sure that you're using an absolute path if you're serving your app directly via flask
     MEDIA_DIRECTORY = os.environ.get(

--- a/natlas-server/entrypoint.sh
+++ b/natlas-server/entrypoint.sh
@@ -3,6 +3,5 @@ set +x
 
 mkdir -p /data/{db,media}
 
-flask db upgrade
 chown -R www-data:www-data /data
 exec runuser -u www-data -- "$@"

--- a/natlas-server/migrations/migrator.py
+++ b/natlas-server/migrations/migrator.py
@@ -1,0 +1,27 @@
+from alembic.migration import MigrationContext
+from alembic import context
+from alembic.config import Config as alembic_cfg
+from alembic.script import ScriptDirectory
+import flask_migrate
+from sqlalchemy import create_engine
+
+
+def migration_needed(sqlalchemy_uri):
+    engine = create_engine(sqlalchemy_uri)
+    conn = engine.connect()
+    m_ctx = MigrationContext.configure(conn)
+    cfg = alembic_cfg("migrations/alembic.ini")
+    cfg.set_main_option("script_location", "migrations")
+    scripts_dir = ScriptDirectory.from_config(cfg)
+    with context.EnvironmentContext(cfg, scripts_dir):
+        print(f"{context.get_head_revision()} =? {m_ctx.get_current_revision()}")
+        return context.get_head_revision() != m_ctx.get_current_revision()
+
+
+def handle_db_migration(app):
+    if app.config["DB_AUTO_MIGRATE"]:
+        with app.app_context():
+            flask_migrate.upgrade()
+            return True
+    else:
+        return False

--- a/natlas-server/migrations/migrator.py
+++ b/natlas-server/migrations/migrator.py
@@ -3,25 +3,38 @@ from alembic import context
 from alembic.config import Config as alembic_cfg
 from alembic.script import ScriptDirectory
 import flask_migrate
-from sqlalchemy import create_engine
+import sqlalchemy
 
 
 def migration_needed(sqlalchemy_uri):
-    engine = create_engine(sqlalchemy_uri)
+    engine = sqlalchemy.create_engine(sqlalchemy_uri)
     conn = engine.connect()
+
     m_ctx = MigrationContext.configure(conn)
     cfg = alembic_cfg("migrations/alembic.ini")
     cfg.set_main_option("script_location", "migrations")
     scripts_dir = ScriptDirectory.from_config(cfg)
     with context.EnvironmentContext(cfg, scripts_dir):
-        print(f"{context.get_head_revision()} =? {m_ctx.get_current_revision()}")
         return context.get_head_revision() != m_ctx.get_current_revision()
 
 
-def handle_db_migration(app):
-    if app.config["DB_AUTO_MIGRATE"]:
+def handle_db_upgrade(app):
+    if app.config["DB_AUTO_UPGRADE"]:
         with app.app_context():
+            print("upgrading")
             flask_migrate.upgrade()
             return True
     else:
         return False
+
+
+def handle_db_downgrade(app):
+    with app.app_context():
+        print("downgrading")
+        flask_migrate.downgrade()
+
+
+def handle_db_migrate(app, message=""):
+    with app.app_context():
+        print("migrating")
+        flask_migrate.migrate(message=message)

--- a/natlas-server/natlas-db.py
+++ b/natlas-server/natlas-db.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""
+    This is a special app instance that allows us to perform database operations
+    without going through the app's migration_needed check. Running this script
+    is functionally equivalent to what `flask db` normally does. The reason we
+    can't continue to use that is that command is that it invokes the app instance from
+    FLASK_APP env variable (natlas-server.py) which performs the migration check and exits
+    during initialization.
+"""
+import argparse
+
+from app import create_app
+from config import Config
+from migrations import migrator
+
+parser_desc = """Perform database operations for Natlas.\
+It is best practice to take a backup of your database before you upgrade or downgrade, just in case something goes wrong.\
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=parser_desc)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--upgrade",
+        action="store_true",
+        help="Perform a database upgrade, if necessary",
+    )
+    group.add_argument(
+        "--downgrade",
+        action="store_true",
+        help="Revert the most recent database upgrade. Danger: This will destroy data as necessary to revert to the previous version.",
+    )
+    args = parser.parse_args()
+
+    config = Config()
+    app = create_app(config, migrating=True)
+    if args.upgrade:
+        app.config.update({"DB_AUTO_UPGRADE": True})
+        migrator.handle_db_upgrade(app)
+    elif args.downgrade:
+        migrator.handle_db_downgrade(app)
+
+
+if __name__ == "__main__":
+    main()

--- a/natlas-server/natlas-migrate.py
+++ b/natlas-server/natlas-migrate.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import argparse
+
+from app import create_app
+from config import Config
+from migrations import migrator
+
+parser_desc = """\
+This is a special app instance for developers to generate a new migration without \
+going through the full app init process\
+"""
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description=parser_desc)
+    parser.add_argument(
+        "--message",
+        required=True,
+        help="Supply a human-readable description of the migration",
+    )
+    args = parser.parse_args()
+
+    config = Config()
+    app = create_app(config, migrating=True)
+    migrator.handle_db_migrate(app, args.message)
+
+
+if __name__ == "__main__":
+    main()

--- a/natlas-server/natlas-server.py
+++ b/natlas-server/natlas-server.py
@@ -22,7 +22,7 @@ try:
     app = create_app(config)
 except Exception as e:
     capture_exception(e)
-    raise e
+    raise
 
 
 @app.shell_context_processor

--- a/natlas-server/natlas-server.py
+++ b/natlas-server/natlas-server.py
@@ -16,11 +16,10 @@ from app.instrumentation import initialize_sentryio
 from sentry_sdk import capture_exception
 from config import Config
 
-
 config = Config()
 initialize_sentryio(config)
 try:
-    app = create_app(config_class=config, load_config=True)
+    app = create_app(config)
 except Exception as e:
     capture_exception(e)
     raise e

--- a/natlas-server/tests/config.py
+++ b/natlas-server/tests/config.py
@@ -7,4 +7,5 @@ class TestConfig(Config):
     TESTING = True
     # This uses an in-memory database
     SQLALCHEMY_DATABASE_URI = "sqlite://"
+    DB_AUTO_MIGRATE = True
     ELASTICSEARCH_URL = "http://localhost:9200"

--- a/natlas-server/tests/config.py
+++ b/natlas-server/tests/config.py
@@ -2,10 +2,22 @@ from config import Config
 
 
 class TestConfig(Config):
+
+    # MAIL_FROM and MAIL_SERVER are required checks for delivering mail
     MAIL_FROM = "Test Mail <noreply@example.com>"
     MAIL_SERVER = "localhost"
+
+    # Tell Flask that it's in testing mode
     TESTING = True
-    # This uses an in-memory database
+
+    # This uses an in-memory database.
+    # It will not work with database migrations.
+    # But will work if you just want an app instance with
+    # an empty database via db.create_all()
     SQLALCHEMY_DATABASE_URI = "sqlite://"
-    DB_AUTO_MIGRATE = True
+
+    # By enabling this, we can test migrations automatically whenever the app is used
+    DB_AUTO_UPGRADE = True
+
+    # Assume that the test environment has access to elastic via localhost:9200
     ELASTICSEARCH_URL = "http://localhost:9200"

--- a/natlas-server/tests/conftest.py
+++ b/natlas-server/tests/conftest.py
@@ -23,4 +23,3 @@ def app():
 def client(app):
     with app.test_client() as client:
         yield client
-

--- a/natlas-server/tests/conftest.py
+++ b/natlas-server/tests/conftest.py
@@ -1,4 +1,6 @@
-from app import create_app, db
+import tempfile
+import os
+from app import create_app
 
 from tests.config import TestConfig
 
@@ -7,13 +9,18 @@ import pytest
 
 @pytest.fixture
 def app():
-    app = create_app(TestConfig)
+    conf = TestConfig()
+    db_fd, db_name = tempfile.mkstemp()
+    conf.SQLALCHEMY_DATABASE_URI = "sqlite:///" + db_name
+    app = create_app(conf)
     with app.app_context():
-        db.create_all()
         yield app
+    os.close(db_fd)
+    os.unlink(db_name)
 
 
 @pytest.fixture
 def client(app):
     with app.test_client() as client:
         yield client
+

--- a/natlas-server/tests/email/conftest.py
+++ b/natlas-server/tests/email/conftest.py
@@ -1,17 +1,9 @@
-from app import create_app, db
-
-from tests.config import TestConfig
-
 import pytest
 
 
 @pytest.fixture
-def app_no_email():
-    app = create_app(TestConfig)
+def app_no_email(app):
     app.config.update(
         {"MAIL_SERVER": None, "MAIL_FROM": None, "SERVER_NAME": "example.com"}
     )
-    app_context = app.app_context()
-    app_context.push()
-    db.create_all()
-    return app
+    yield app


### PR DESCRIPTION
…migration needed

**Is this pull request related to an existing issue? What is the issue number?**

This change closes #255 and introduces a new config option, DB_AUTO_UPGRADE, to provide optional automatic migration support.

**Description of proposed changes:**

This is a change in the default behavior of previous versions, which would do a db upgrade at the start of every run even if unnecessary. By only doing migrate when we need to, it saves us an entire app init cycle during launch (which involves ensuring connectivity to the database as well as connectivity to the elasticsearch node), and providing the option to not migrate will support multi-node server deployments better.

Tests that use the database also all implicitly do migration testing now, which ensures that all tests have a state that is equivalent to that of an actual deployment (default values are populated, migrations actually function, etc)