### PR TITLE
Change: Default MAIL_USE_TLS to True (secure by default), update docs

### DIFF
--- a/natlas-server/README.md
+++ b/natlas-server/README.md
@@ -98,7 +98,8 @@ Environment configs are loaded from the environment or a `.env` file and require
 | `OPENCENSUS_AGENT` | `127.0.0.1:55678` | An OpenCensus agent or collector that this instance will emit traffic to. |
 | `MAIL_SERVER` | `None` | Mail server to use for invitations, registrations, and password resets |
 | `MAIL_PORT` | `587` | Port that `MAIL_SERVER` is listening on |
-| `MAIL_USE_TLS` | `False` | Whether or not to connect to `MAIL_SERVER` with TLS |
+| `MAIL_USE_TLS` | `True` | Whether or not to connect to `MAIL_SERVER` with STARTTLS |
+| `MAIL_USE_SSL` | `False` | Whether or not to connect to `MAIL_SERVER` with SSL (E.g. Port 465) |
 | `MAIL_USERNAME` | `None` | Username (if required) to connect to `MAIL_SERVER` |
 | `MAIL_PASSWORD` | `None` | Password (if required) to connect to `MAIL_SERVER` |
 | `MAIL_FROM` | `None` | Address to be used as the "From" address for outgoing mail. This is required if `MAIL_SERVER` is set. |

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -66,7 +66,8 @@ class Config(object):
     # MAIL SETTINGS
     MAIL_SERVER = os.environ.get("MAIL_SERVER", None)
     MAIL_PORT = int(os.environ.get("MAIL_PORT", 587))
-    MAIL_USE_TLS = casted_bool(os.environ.get("MAIL_USE_TLS", False))
+    MAIL_USE_TLS = casted_bool(os.environ.get("MAIL_USE_TLS", True))
+    MAIL_USE_SSl = casted_bool(os.environ.get("MAIL_USE_SSL", False))
     MAIL_USERNAME = os.environ.get("MAIL_USERNAME", None)
     MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD", None)
     MAIL_FROM = os.environ.get("MAIL_FROM", None)


### PR DESCRIPTION
This closes #407 by updating documentation around the MAIL_USE_TLS and MAIL_USE_SSL options. Additionally, setting the default MAIL_USE_TLS to True makes sense since MAIL_PORT defaults to 587 now.