### PR TITLE
Fix: Image verification on agent and server

### DIFF
--- a/natlas-agent/Pipfile
+++ b/natlas-agent/Pipfile
@@ -11,6 +11,7 @@ python-dotenv = "~=0.14.0"
 requests = "~=2.24.0"
 sentry-sdk = "~=0.16.3"
 natlas-libnmap = "*"
+pillow = "*"
 
 [requires]
 python_version = "3.6"

--- a/natlas-agent/Pipfile.lock
+++ b/natlas-agent/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "15a2c1e815addd78c323b237295731fb5d11d4e66af60ef3eb063cabfc58e635"
+            "sha256": "4bcdce143299be032259cfb4f9bc56dfb23ac6560db2c588fc16d7a74cff487b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -35,6 +35,7 @@
                 "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
                 "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.6.0"
         },
         "idna": {
@@ -42,6 +43,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "natlas-libnmap": {
@@ -51,6 +53,40 @@
             ],
             "index": "pypi",
             "version": "==0.7.1"
+        },
+        "pillow": {
+            "hashes": [
+                "sha256:0295442429645fa16d05bd567ef5cff178482439c9aad0411d3f0ce9b88b3a6f",
+                "sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8",
+                "sha256:09d7f9e64289cb40c2c8d7ad674b2ed6105f55dc3b09aa8e4918e20a0311e7ad",
+                "sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f",
+                "sha256:1ca594126d3c4def54babee699c055a913efb01e106c309fa6b04405d474d5ae",
+                "sha256:25930fadde8019f374400f7986e8404c8b781ce519da27792cbe46eabec00c4d",
+                "sha256:431b15cffbf949e89df2f7b48528be18b78bfa5177cb3036284a5508159492b5",
+                "sha256:52125833b070791fcb5710fabc640fc1df07d087fc0c0f02d3661f76c23c5b8b",
+                "sha256:5e51ee2b8114def244384eda1c82b10e307ad9778dac5c83fb0943775a653cd8",
+                "sha256:612cfda94e9c8346f239bf1a4b082fdd5c8143cf82d685ba2dba76e7adeeb233",
+                "sha256:6d7741e65835716ceea0fd13a7d0192961212fd59e741a46bbed7a473c634ed6",
+                "sha256:6edb5446f44d901e8683ffb25ebdfc26988ee813da3bf91e12252b57ac163727",
+                "sha256:725aa6cfc66ce2857d585f06e9519a1cc0ef6d13f186ff3447ab6dff0a09bc7f",
+                "sha256:8dad18b69f710bf3a001d2bf3afab7c432785d94fcf819c16b5207b1cfd17d38",
+                "sha256:94cf49723928eb6070a892cb39d6c156f7b5a2db4e8971cb958f7b6b104fb4c4",
+                "sha256:97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626",
+                "sha256:9ad7f865eebde135d526bb3163d0b23ffff365cf87e767c649550964ad72785d",
+                "sha256:9c87ef410a58dd54b92424ffd7e28fd2ec65d2f7fc02b76f5e9b2067e355ebf6",
+                "sha256:a060cf8aa332052df2158e5a119303965be92c3da6f2d93b6878f0ebca80b2f6",
+                "sha256:c79f9c5fb846285f943aafeafda3358992d64f0ef58566e23484132ecd8d7d63",
+                "sha256:c92302a33138409e8f1ad16731568c55c9053eee71bb05b6b744067e1b62380f",
+                "sha256:d08b23fdb388c0715990cbc06866db554e1822c4bdcf6d4166cf30ac82df8c41",
+                "sha256:d350f0f2c2421e65fbc62690f26b59b0bcda1b614beb318c81e38647e0f673a1",
+                "sha256:e901964262a56d9ea3c2693df68bc9860b8bdda2b04768821e4c44ae797de117",
+                "sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d",
+                "sha256:edf31f1150778abd4322444c393ab9c7bd2af271dd4dafb4208fb613b1f3cdc9",
+                "sha256:f7e30c27477dffc3e85c2463b3e649f751789e0f6c8456099eea7ddd53be4a8a",
+                "sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce"
+            ],
+            "index": "pypi",
+            "version": "==7.2.0"
         },
         "python-dotenv": {
             "hashes": [
@@ -81,6 +117,7 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
         }
     },
@@ -92,14 +129,6 @@
             ],
             "index": "pypi",
             "version": "==3.8.3"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
-                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.7.0"
         },
         "mccabe": {
             "hashes": [
@@ -113,6 +142,7 @@
                 "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
                 "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.6.0"
         },
         "pyflakes": {
@@ -120,14 +150,8 @@
                 "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
                 "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.2.0"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "version": "==3.1.0"
         }
     }
 }

--- a/natlas-agent/natlas/screenshots.py
+++ b/natlas-agent/natlas/screenshots.py
@@ -53,23 +53,23 @@ def parse_aquatone_page(page: dict, file_path: str) -> dict:
 
 def get_aquatone_session(base_dir: str) -> dict:
     session_path = os.path.join(base_dir, "aquatone_session.json")
-    output = {}
     if not os.path.isfile(session_path):
-        return output
+        return {}
 
     with open(session_path) as f:
         session = json.load(f)
 
     if session["stats"]["screenshotSuccessful"] == 0:
-        return output
+        return {}
     return session
 
 
 def parse_aquatone_session(base_dir: str) -> list:
     session = get_aquatone_session(base_dir)
-    output = []
     if not session:
-        return output
+        return []
+
+    output = []
     for _, page in session["pages"].items():
         fqScreenshotPath = os.path.join(base_dir, page["screenshotPath"])
         parsed_page = parse_aquatone_page(page, fqScreenshotPath)

--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -1,6 +1,5 @@
 import subprocess
 import threading
-import shutil
 import os
 import ipaddress
 
@@ -109,32 +108,19 @@ def scan(target_data, config):
         result.is_up(nmap_report.hosts[0].is_up())
         result.add_item("port_count", len(nmap_report.hosts[0].get_ports()))
 
-    if agentConfig["webScreenshots"] and shutil.which("aquatone") is not None:
+    if agentConfig["webScreenshots"]:
         screens = screenshots.get_web_screenshots(
             target, scan_id, agentConfig["webScreenshotTimeout"]
         )
         for item in screens:
             result.add_screenshot(item)
 
-    if (
-        agentConfig["vncScreenshots"]
-        and "5900/tcp" in result.result["nmap_data"]
-        and screenshots.get_vnc_screenshots(
+    if agentConfig["vncScreenshots"] and "5900/tcp" in result.result["nmap_data"]:
+        vnc_screenshot = screenshots.get_vnc_screenshots(
             target, scan_id, agentConfig["vncScreenshotTimeout"]
         )
-    ):
-
-        screenshotPath = os.path.join(scan_dir, f"vncsnapshot.{scan_id}.jpg")
-        if os.path.isfile(screenshotPath):
-            result.add_screenshot(
-                {
-                    "host": target,
-                    "port": 5900,
-                    "service": "VNC",
-                    "data": screenshots.base64_image(screenshotPath),
-                }
-            )
-            logger.info(f"VNC screenshot acquired for {result.result['ip']}")
+        if vnc_screenshot:
+            result.add_screenshot(vnc_screenshot)
 
     # submit result
 

--- a/natlas-server/app/api/processing/screenshot.py
+++ b/natlas-server/app/api/processing/screenshot.py
@@ -2,7 +2,33 @@ from flask import current_app
 import base64
 import hashlib
 import os
-from PIL import Image
+from io import BytesIO
+from PIL import Image, UnidentifiedImageError
+
+
+def is_valid_image(path: str) -> bool:
+    try:
+        Image.open(path)
+        return True
+    except (FileNotFoundError, UnidentifiedImageError):
+        return False
+
+
+def get_file_ext(service: str) -> str:
+    service_ext_map = {
+        "VNC": ".jpg",
+        "HTTP": ".png",
+        "HTTPS": ".png",
+        "default": ".png",
+    }
+    return service_ext_map.get(service, "default")
+
+
+def get_file_path(img_hash: str, subdir: str, ext: str) -> str:
+    hash_path = f"{img_hash[0:2]}/{img_hash[2:4]}"
+    hash_dir = os.path.join(current_app.config["MEDIA_DIRECTORY"], subdir, hash_path)
+    os.makedirs(hash_dir, exist_ok=True)
+    return os.path.join(hash_dir, img_hash + ext)
 
 
 def create_thumbnail(fname, file_ext):
@@ -10,46 +36,41 @@ def create_thumbnail(fname, file_ext):
     thumb = Image.open(fname)
     thumb.thumbnail(thumb_size)
     thumb_hash = hashlib.sha256(thumb.tobytes()).hexdigest()
-    thumbhashpath = f"{thumb_hash[0:2]}/{thumb_hash[2:4]}"
-    thumbpath = os.path.join(
-        current_app.config["MEDIA_DIRECTORY"], "thumbs", thumbhashpath
-    )
-    # makedirs attempts to make every directory necessary to get to the "thumbs" folder
-    os.makedirs(thumbpath, exist_ok=True)
-    fname = os.path.join(thumbpath, thumb_hash + file_ext)
+    fname = get_file_path(thumb_hash, "thumbs", file_ext)
     thumb.save(fname)
     thumb.close()
     return thumb_hash
 
 
-def process_screenshots(screenshots):
-    # Handle screenshots
+def process_screenshot(screenshot: dict):
+    file_ext = get_file_ext(screenshot["service"])
+    image = base64.b64decode(screenshot["data"])
+    del screenshot["data"]
 
-    num_screenshots = 0
+    if not is_valid_image(BytesIO(image)):
+        return {}
+
+    image_hash = hashlib.sha256(image).hexdigest()
+    fname = get_file_path(image_hash, "original", file_ext)
+
+    with open(fname, "wb") as f:
+        f.write(image)
+
+    screenshot["hash"] = image_hash
+    screenshot["thumb_hash"] = create_thumbnail(fname, file_ext)
+
+    return screenshot
+
+
+def process_screenshots(screenshots: list) -> tuple:
+    processed_screenshots = []
     for item in screenshots:
-        if item["service"] == "VNC":
-            file_ext = ".jpg"
-        else:  # Handles http, https files from aquatone/chromium-headless
-            file_ext = ".png"
+        screenshot = process_screenshot(item)
+        if not screenshot:
+            current_app.logger.warning(
+                f"Received invalid image for {screenshot['hostname']} port {screenshot['port']}"
+            )
+            continue
+        processed_screenshots.append(item)
 
-        image = base64.b64decode(item["data"])
-        image_hash = hashlib.sha256(image).hexdigest()
-
-        hashpath = f"{image_hash[0:2]}/{image_hash[2:4]}"
-        dirpath = os.path.join(
-            current_app.config["MEDIA_DIRECTORY"], "original", hashpath
-        )
-
-        # makedirs attempts to make every directory necessary to get to the "original" folder
-        os.makedirs(dirpath, exist_ok=True)
-
-        fname = os.path.join(dirpath, image_hash + file_ext)
-        with open(fname, "wb") as f:
-            f.write(image)
-        item["hash"] = image_hash
-        del item["data"]
-
-        item["thumb_hash"] = create_thumbnail(fname, file_ext)
-        num_screenshots += 1
-
-    return screenshots, num_screenshots
+    return processed_screenshots, len(processed_screenshots)


### PR DESCRIPTION
This closes #412 by implementing agent side image validation before including the image in the scan results. The server also makes use of a similar function to validate that an image is valid before saving it.