### PR TITLE
Release: v0.6.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,9 +7,59 @@ and this project strives to adhere to [Semantic Versioning](https://semver.org/s
 
 ## [Unreleased]
 
+## [v0.6.11]
+
+### Added
+
+- (Both) Default natlas-services file has been updated to include common dockerd, kubeadm, elastic, and minecraft ports. ([#423](https://github.com/natlas/natlas/pull/423))
+- (Server) Support for Elasticsearch 7 ([#263](https://github.com/natlas/natlas/pull/263))
+- (Server) There is now an optional consistent scan cycle option, via `CONSISTENT_SCAN_CYCLE`. This will still traverse the scope in a random order, but after a cycle is completed it will reuse the same order. This produces more consistent time deltas between scans of a given host. ([#337](https://github.com/natlas/natlas/pull/337))
+- (Server) New landing page instead of automatically redirecting to `/browse` or `/auth/login` depending on your configuration. ([#343](https://github.com/natlas/natlas/pull/343))
+- (Server) Support for dark mode via the `prefers-color-scheme` media query. ([#343](https://github.com/natlas/natlas/pull/343))
+- (Server) Support for reduced motion across the application via `prefers-reduced-motion` media query. ([#343](https://github.com/natlas/natlas/pull/343))
+- (Server) Support for MySQL databases ([#358](https://github.com/natlas/natlas/pull/358))
+- (Agent) Uses dumb-init to ensure chromium processes get cleaned up rather than left around as zombies. ([#302](https://github.com/natlas/natlas/issues/302))
+
+### Changed
+
+- (Both) Natlas now uses a docker-only deployment, which makes it easier to produce consistent running environments. ([#281](https://github.com/natlas/natlas/pull/281))
+- (Both) Dependency versions updated significantly ([Dependabot activity](https://github.com/natlas/natlas/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+is%3Aclosed))
+- (Server) Web assets (js/css) are compiled via webpack ([#254](https://github.com/natlas/natlas/pull/254))
+- (Server) System status page automatically refreshes ([#258](https://github.com/natlas/natlas/pull/258))
+- (Server) Secure default settings for new deployments - User login required and agent authentication are now the default. ([#279](https://github.com/natlas/natlas/issues/279))
+- (Server) `add-user.py` and `add-scope.py` have been replaced with flask cli commands, `flask user new` and `flask scope import`, respectively. ([#216](https://github.com/natlas/natlas/issues/216))
+- (Server) Default mail settings have been changed to use port 587 with STARTTLS, rather than port 25 with no TLS ([#409](https://github.com/natlas/natlas/pull/409))
+- (Agent) Agent scanning threads now stagger their start time to alleviate some strain on both the agent and the server when an agent starts up. ([#312](https://github.com/natlas/natlas/issues/312))
+
+### Fixed
+
+- (Both) Fix file handles that don't get closed ([#338](https://github.com/natlas/natlas/pull/338))
+- (Both) Targeting IPv6 addresses should behave like IPv4 addresses now, instead of throwing errors at random points in the stack ([#61](https://github.com/natlas/natlas/issues/61), [#355](https://github.com/natlas/natlas/issues/355))
+- (Both) Image verification takes place to ensure that empty or otherwise malformed images aren't being passed from agent -> server or from server -> disk. ([#412](https://github.com/natlas/natlas/issues/412))
+- (Server) You can no longer visit `/search` without a search query, which previously showed an empty search results page. It now redirects you to `/browse`. ([#267](https://github.com/natlas/natlas/issues/267))
+- (Server) Significant performance improvements to the scope manager when using a large number of distinct cidr ranges ([#351](https://github.com/natlas/natlas/pull/351))
+- (Server) Screenshots don't automatically assume `.png` file format, enabling the `jpg` VNC screenshots. ([#365](https://github.com/natlas/natlas/pull/365))
+- (Server) SSL Certificates with malformed dates now ignore the malformed fields rather than abandoning the entire scan document ([#261](https://github.com/natlas/natlas/issues/261))
+- (Server) Initial database population is now handled by the database migrations rather than at application initialization. This fixes a bug where you can't have 0 scripts defined for the agent. ([#400](https://github.com/natlas/natlas/issues/400))
+- (Server) Server no longer uses cached data when loading admin panel webpages, which could occasionally lead to bugs with loading the agent config page ([#326](https://github.com/natlas/natlas/issues/326))
+- (Agent) VNC Screenshots don't rely on `DISPLAY` environment variable anymore since it uses `vxfb-run`. ([#364](https://github.com/natlas/natlas/pull/364))
+- (Agent) No longer echo huge xml files to the command line to pipe into aquatone ([#420](https://github.com/natlas/natlas/issues/420))
+
+### Removed
+
+- (Server) `add-scope.py`, `add-user.py` scripts have been removed in favor of the new cli commands ([#216](https://github.com/natlas/natlas/issues/216))
+- (Server) `elastic-snapshot.py` script has been removed. It was barely functional to begin with and was largely unmaintained. ([#373](https://github.com/natlas/natlas/pull/373))
+
+### Security
+
+- (Agent) Use a seccomp profile when launching the agent container so that chrome can take screenshots without requiring `--no-sandbox` or `SYS_ADMIN` capability. ([#285](https://github.com/natlas/natlas/issues/285))
+- (Server) Removed referrer redirects to avoid potential redirect vulnerabilities ([#305](https://github.com/natlas/natlas/issues/305))
+- (Both) XML parsing is now defused via the [natlas-libnmap](https://github.com/natlas/natlas-libnmap) library ([#318](https://github.com/natlas/natlas/pull/318))
+
 ## [v0.6.10]
 
 ### Changed
+
 - Web screenshots now use aquatone 1.7.0 for more reliability
 - Web screenshots now apply to all http ports instead of just 80/443
 - Web screenshots have been cleaned up in the UI to look cleaner.
@@ -16,17 +67,21 @@ and this project strives to adhere to [Semantic Versioning](https://semver.org/s
 ## [v0.6.9]
 
 ### Added
+
 - Search can now be augmented with `&format=json` to return search results in json format.
 
 ### Changed
+
 - Random button now replaces the url with the current host it finds. This means you can no longer spam f5 to load a new random host, however you can now go back in history to previous random findings.
 
 ### Security
+
 - Updated Pillow dependency to address CVE-2020-5313 and CVE-2019-19911.
 
 ## [v0.6.8]
 
 ### Added
+
 - Docker files are available for the agent and server now.
 - Request tracing and metrics integration are now available via integrations with OpenCensus ([#219](https://github.com/natlas/natlas/issues/219))
 - API Swagger Spec can be found in `/spec/swagger.yaml` and will be very helpful as natlas moves towards more of an api model. ([#225](https://github.com/natlas/natlas/issues/225))
@@ -34,9 +89,11 @@ and this project strives to adhere to [Semantic Versioning](https://semver.org/s
 - A simple status interface and api to look at the current status of the natlas deployment. Includes information about when the server was started, the number of completed scan cycles, when the last scan cycle started, the number of effective hosts in scope, and how many scans have been submitted in the current scan cycle. (No ticket)
 
 ### Changed
+
 - A lot of files have been refactored to simplify the code and reduce complexity.
 
 ### Fixed
+
 - Fixed the add scope function when no tags are defined for a scope item. ([#196](https://github.com/natlas/natlas/issues/196))
 - Fixed a bug where the tagging interface for blacklisted IPs was exposed but not functional. ([#206](https://github.com/natlas/natlas/issues/206))
 - Fixed a bug where a scope of 2 addresses would not be randomly selected very well. ([#215](https://github.com/natlas/natlas/issues/215))
@@ -46,16 +103,19 @@ and this project strives to adhere to [Semantic Versioning](https://semver.org/s
 ## [v0.6.7]
 
 ### Added
+
 - Administrators can now configure process timeout values for web and vnc screenshot agent capabilities. ([#186](https://github.com/natlas/natlas/issues/186))
 - Users may now choose to search historical results by including `includeHistory=1` in the query parameters. ([#110](https://github.com/natlas/natlas/issues/110))
 - Agents can now optionally save data that failed to upload to the server via the `NATLAS_SAVE_FAILS` environment variable. ([#129](https://github.com/natlas/natlas/issues/129))
 - Importing scope, either via the web interface or via the `./add-scope.py` script, now supports importing scope items with tags. Each imported line can have a comma separated list of tags. Tags will be created if they don't already exist. ([#142](https://github.com/natlas/natlas/issues/142))
 
 ### Changed
+
 - Screenshots are stored in deterministic location based purely on their file hash, instead of `timestamp/<hash>.ext`. ([#182](https://github.com/natlas/natlas/issues/182))
 - Agents will now get work definitions from the server even when scanning targets from a file or the command line. ([#179](https://github.com/natlas/natlas/issues/179))
 
 ### Fixed
+
 - Agent now correctly makes sure that it's logs folder exists before trying to use it. ([#181](https://github.com/natlas/natlas/issues/181))
 - Agent checks for `timed_out` before it checks for `is_up` ([#184](https://github.com/natlas/natlas/issues/184))
 - Handle exceptions when export requests are made for non-existing data ([#191](https://github.com/natlas/natlas/issues/191)
@@ -64,18 +124,21 @@ and this project strives to adhere to [Semantic Versioning](https://semver.org/s
 ## [v0.6.6]
 
 ### Added
+
 - Screenshot Browser ([#173](https://github.com/natlas/natlas/issues/173))
 - Administrative settings:
-    - Optionally use local subresources instead of CDN subresources (#[105](https://github.com/natlas/natlas/issues/105))
-    - Optionally add a custom brand field to navigation to more easily identify the natlas instance you're viewing ([#106](https://github.com/natlas/natlas/issues/106))
+  - Optionally use local subresources instead of CDN subresources (#[105](https://github.com/natlas/natlas/issues/105))
+  - Optionally add a custom brand field to navigation to more easily identify the natlas instance you're viewing ([#106](https://github.com/natlas/natlas/issues/106))
 - Store structured SSL certificate data for any port that we've identified an ssl-cert for ([#146](https://github.com/natlas/natlas/issues/146))
 
 ### Changed
+
 - Agent logging is done via an app logger now with timestamps and to a file. ([#170](https://github.com/natlas/natlas/issues/170))
 - Agent relies on nmap capabilities being set instead of running as root. ([#123](https://github.com/natlas/natlas/issues/123)) (Thanks droberson!)
 - Agent refactoring to improve maintainability
 
 ### Fixed
+
 - Handle NmapParserException when malformed xml files are encountered ([#169](https://github.com/natlas/natlas/issues/169))
 - Improve randomness of `/random/` route by selecting a rand int each time instead of seeding with timestamp. ([#178]https://github.com/natlas/natlas/issues/178)
 
@@ -83,6 +146,7 @@ and this project strives to adhere to [Semantic Versioning](https://semver.org/s
 More information can be found at [natlas/v0.6.5](https://github.com/natlas/natlas/releases/tag/v0.6.5)
 
 ### Added
+
 - Consolidate server logs into logs/ folder ([#163](https://github.com/natlas/natlas/issues/163))
 - Logging scope manager and cyclical prng starts and restarts ([#118](https://github.com/natlas/natlas/issues/118))
 - Screenshot filter ([#78](https://github.com/natlas/natlas/issues/78))
@@ -91,15 +155,17 @@ More information can be found at [natlas/v0.6.5](https://github.com/natlas/natla
 - Optional natlas version override for developing changes to the way host data is stored and presented. (No ticket)
 
 ### Changed
+
 - Screenshot overhaul ([#72](https://github.com/natlas/natlas/issues/72))
-	- Thumbnails of images
-	- Save images on disk and serve as files (cacheable, less overhead than base64)
-	- Serve thumbnail and only serve full image when clicked
-	- nginx example location block included
-	- serves from `$DOMAIN/media/`
+  - Thumbnails of images
+  - Save images on disk and serve as files (cacheable, less overhead than base64)
+  - Serve thumbnail and only serve full image when clicked
+  - nginx example location block included
+  - serves from `$DOMAIN/media/`
 - Load Search Modal Only When Clicked ([#141](https://github.com/natlas/natlas/issues/141))
 
 ### Fixed
+
 - Failure to cleanup Aquatone files ([#157](https://github.com/natlas/natlas/issues/157))
 - Screenshots Page Only Shows Most Recent Screenshots ([#98](https://github.com/natlas/natlas/issues/98))
 
@@ -107,142 +173,172 @@ More information can be found at [natlas/v0.6.5](https://github.com/natlas/natla
 More information can be found at [natlas/v0.6.4](https://github.com/natlas/natlas/releases/tag/v0.6.4)
 
 ### Added
-* Server - Random button gives us a random host
-* Server - User profiles can now select between different view formats (Currently supported: Pretty and Raw)
-* Server - Added `tags` example to search help modal
+
+- Server - Random button gives us a random host
+- Server - User profiles can now select between different view formats (Currently supported: Pretty and Raw)
+- Server - Added `tags` example to search help modal
 
 ### Changed
-* Server - Automatically attempt to reconnect to elasticsearch on the next request if our last attempt failed and it's been more than 60 seconds.
-* Server/Agent - `scan_id` field increased from 10 characters in length to 16 characters.
+
+- Server - Automatically attempt to reconnect to elasticsearch on the next request if our last attempt failed and it's been more than 60 seconds.
+- Server/Agent - `scan_id` field increased from 10 characters in length to 16 characters.
 
 ### Fixed
-* Server - Fixed bug in scan manager ([#150](https://github.com/natlas/natlas/issues/150)) where updating the networks in range to scan caused unexpected scan targets.
-* Server - Fixed view issue not populating user's settings in profile page
-* Server - Cleanup relationship between a scope item and tags when a scope item is deleted
-* Agent - Fixed retry failures when server is down so agents should now automatically try to reconnect as intended
+
+- Server - Fixed bug in scan manager ([#150](https://github.com/natlas/natlas/issues/150)) where updating the networks in range to scan caused unexpected scan targets.
+- Server - Fixed view issue not populating user's settings in profile page
+- Server - Cleanup relationship between a scope item and tags when a scope item is deleted
+- Agent - Fixed retry failures when server is down so agents should now automatically try to reconnect as intended
 
 ## [v0.6.3]
 More information can be found at [natlas/v0.6.3](https://github.com/natlas/natlas/releases/tag/v0.6.3)
 
 ### Added
-* Normal users can now be added with the add-admin.py bootstrap script
+
+- Normal users can now be added with the add-admin.py bootstrap script
 
 ### Changed
-* SECURITY - Invite and Password Reset tokens have moved from using JWT to database-backed stateful tokens. These tokens expire after a defined period of time, as well as if the token is successfully used.
-* Various styling improvements for authentication pages
+
+- SECURITY - Invite and Password Reset tokens have moved from using JWT to database-backed stateful tokens. These tokens expire after a defined period of time, as well as if the token is successfully used.
+- Various styling improvements for authentication pages
 
 ### Fixed
-* SECURITY - Invite and Password Reset flows have been updated to include an intermediary step that prevents the secret tokens from leaking to 3rd parties via the Referer header.
-* SECURITY - Email validation is much stricter now, through the use of python-email-validator. This fixes problems where emails like `test@test.com@test.com` or `test @test.com` could have been treated as valid emails, causing unexpected behaviors.
-* New users are explicitly created with "is_admin" set to false, instead of the previous "None" that they would get in certain flows.
-* The nginx deployment script now correctly recommends placing all logs in the same folder, instead of `/var/log/nginx/natlas` and `/var/log/nginx/natlas.io`.
-* Fixed erroneous help string in search help modal that was a holdover from v0.5.x.
+
+- SECURITY - Invite and Password Reset flows have been updated to include an intermediary step that prevents the secret tokens from leaking to 3rd parties via the Referer header.
+- SECURITY - Email validation is much stricter now, through the use of python-email-validator. This fixes problems where emails like `test@test.com@test.com` or `test @test.com` could have been treated as valid emails, causing unexpected behaviors.
+- New users are explicitly created with "is_admin" set to false, instead of the previous "None" that they would get in certain flows.
+- The nginx deployment script now correctly recommends placing all logs in the same folder, instead of `/var/log/nginx/natlas` and `/var/log/nginx/natlas.io`.
+- Fixed erroneous help string in search help modal that was a holdover from v0.5.x.
 
 ### Removed
-* Removed an unused css load from adobe for the NATLAS logo font. We previously settled on using the image, but had forgotten to remove the font stylesheet include.
+
+- Removed an unused css load from adobe for the NATLAS logo font. We previously settled on using the image, but had forgotten to remove the font stylesheet include.
 
 ## [v0.6.2]
+
 More information can be found at [natlas/v0.6.2](https://github.com/natlas/natlas/releases/tag/v0.6.2)
 
 ### Added
-* Branding improvements
-* Version is now visible in the server footer
-* Back-to-top button
-* Server doesn't interact with mismatched versions
+
+- Branding improvements
+- Version is now visible in the server footer
+- Back-to-top button
+- Server doesn't interact with mismatched versions
 
 ### Changed
-* Style improvements
-* Communication between agent and server has been more standardized around json messaging
+
+- Style improvements
+- Communication between agent and server has been more standardized around json messaging
 
 ### Fixed
-* Agent standalone mode got broken with the agent configurations, fixed the standalone default scanning options
+
+- Agent standalone mode got broken with the agent configurations, fixed the standalone default scanning options
 
 ## [v0.6.1] - Bugfixes
+
 More information can be found at [natlas/v0.6.1](https://github.com/natlas/natlas/releases/tag/v0.6.1)
 
 ### Fixed
-* /api/natlas-services no longer breaks the admin page
-* Extraneous debugging print statements removed
 
+- /api/natlas-services no longer breaks the admin page
+- Extraneous debugging print statements removed
 
 ## [v0.6.0] - Structured data, better config, agent authn
+
 More information can be found at [natlas/v0.6.0](https://github.com/natlas/natlas/releases/tag/v0.6.0)
 
 ### Added
-* Server/Agent authentication using agent ID and secret
-* Servers can assign tags to scope ranges
-* Logged in users can request hosts to be rescanned, which puts them in a priority work queue
-* XML parsing of nmap data to provide some structured elasticsearch data
-* JSON export for scan results
-* Agents can optionally ignore SSL validation warnings
-* Agents can give themselves a maximum retry target before giving up a submit call to the server
+
+- Server/Agent authentication using agent ID and secret
+- Servers can assign tags to scope ranges
+- Logged in users can request hosts to be rescanned, which puts them in a priority work queue
+- XML parsing of nmap data to provide some structured elasticsearch data
+- JSON export for scan results
+- Agents can optionally ignore SSL validation warnings
+- Agents can give themselves a maximum retry target before giving up a submit call to the server
 
 ### Changed
-* jQuery and Bootstrap have been significantly upgraded to more modern versions
-* Server setup script generates new random secret key if one doesn't already exist
-* Move away from raw data view and into using the structured data
-* Agents now report back to the server regardless if the host is up or not, which allows us to better track how many times we're actually scanning hosts.
-* Tabled data now appears in DataTables, which allow for sorting, searching, and pagination
+
+- jQuery and Bootstrap have been significantly upgraded to more modern versions
+- Server setup script generates new random secret key if one doesn't already exist
+- Move away from raw data view and into using the structured data
+- Agents now report back to the server regardless if the host is up or not, which allows us to better track how many times we're actually scanning hosts.
+- Tabled data now appears in DataTables, which allow for sorting, searching, and pagination
 
 ### Fixed
-* Agents properly clean up scan data that were inadvertently left around when scans timeout
-* Agents no longer request extra work for their local queue, resulting in extra data loss when agents are stopped
-* Tons of HTML errors were corrected
+
+- Agents properly clean up scan data that were inadvertently left around when scans timeout
+- Agents no longer request extra work for their local queue, resulting in extra data loss when agents are stopped
+- Tons of HTML errors were corrected
 
 ## [v0.5.4] - Server stability improvements
+
 More information can be found at [natlas/v0.5.4](https://github.com/natlas/natlas/releases/tag/v0.5.4)
 
 ### Fixed
-* Setup-elastic now enables the elasticsearch systemd unit so that it survives reboots
+
+- Setup-elastic now enables the elasticsearch systemd unit so that it survives reboots
 
 
 ## [v0.5.3] - Server setup improvements
+
 More information can be found at [natlas/v0.5.3](https://github.com/natlas/natlas/releases/tag/v0.5.3)
 
 ### Changed
-* Setup-server uses apt to install virtualenv instead of pip3
+
+- Setup-server uses apt to install virtualenv instead of pip3
 
 ## [v0.5.2] - Server setup improvements
+
 More information can be found at [natlas/v0.5.2](https://github.com/natlas/natlas/releases/tag/v0.5.2)
 
 ### Fixed
-* Setup-server handles user creation correctly now
+
+- Setup-server handles user creation correctly now
 
 ### Changed
-* Setup-server changes ownership of the files to not be owned by root once finished setting up.
+
+- Setup-server changes ownership of the files to not be owned by root once finished setting up.
 
 ## [v0.5.1] - Agent bugfix, Responsive Views
+
 More information can be found at [natlas/v0.5.1](https://github.com/natlas/natlas/releases/tag/v0.5.1)
 
 ### Changes
-* Server has more responsive views
+
+- Server has more responsive views
 
 ### Fixed
-* Agent environment variables parse correctly now after correcting type casting
+
+- Agent environment variables parse correctly now after correcting type casting
 
 
 ## [v0.5.0] - Initial Release
+
 More Info can be found at [natlas/v0.5.0](https://github.com/natlas/natlas/releases/tag/v0.5.0)
 
 ### Server Added
-* Automatic setup via setup scripts
-* Server-side scripts for various management and bootstrap tasks
-* Server-defined service database
-* Server-defined agent config options
-* Basic User-access controls
-* Web service front end
-* API agent access
-* Example systemd and nginx deployment files
+
+- Automatic setup via setup scripts
+- Server-side scripts for various management and bootstrap tasks
+- Server-defined service database
+- Server-defined agent config options
+- Basic User-access controls
+- Web service front end
+- API agent access
+- Example systemd and nginx deployment files
 
 ### Agent Added
-* Use of nmap for port scans
-* Headless web screenshots with [aquatone](https://github.com/michenriksen/aquatone)
-* Headless VNC screenshots with vncsnapshot
-* Configuration via .env file
-* Ability to run in standalone mode
+
+- Use of nmap for port scans
+- Headless web screenshots with [aquatone](https://github.com/michenriksen/aquatone)
+- Headless VNC screenshots with vncsnapshot
+- Configuration via .env file
+- Ability to run in standalone mode
 
 
 [Unreleased]: https://github.com/natlas/natlas/compare/v0.6.10...HEAD
+[v0.6.11]: https://github.com/natlas/natlas/compare/v0.6.10...v0.6.11
 [v0.6.10]: https://github.com/natlas/natlas/compare/v0.6.9...v0.6.10
 [v0.6.9]: https://github.com/natlas/natlas/compare/v0.6.8...v0.6.9
 [v0.6.8]: https://github.com/natlas/natlas/compare/v0.6.7...v0.6.8

--- a/natlas-agent/config.py
+++ b/natlas-agent/config.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 class Config:
 
     # Current Version
-    NATLAS_VERSION = "0.6.10"
+    NATLAS_VERSION = "0.6.11"
 
     BASEDIR = os.path.abspath(os.path.dirname(__file__))
     load_dotenv(os.path.join(BASEDIR, ".env"))

--- a/natlas-server/app/templates/host/versions/0.6.11/_header.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_header.html
@@ -1,0 +1,36 @@
+<div class="row page-header">
+    <div class="col-xs-12 col-sm">
+        <h1>{% if host %}{% include 'host/versions/0.6.11/_host-status.html' %}{% endif %}{{ ip }}{% if host %}<small class="text-muted host-header-date"> - <time datetime="{{host.ctime}}">{{ host.ctime | ctime }}</time></small>{% endif %}</h1>
+    </div>
+    {% if current_user.is_authenticated %}
+    <div class="col-xs-12 col-sm-2" style="text-align:right;">
+        <div class="btn-group host-history-export" role="group">
+            <form method="POST" action="{{ url_for('host.rescan_host', ip=ip) }}">{{ rescanForm.hidden_tag() }}<button id="requestRescan" class="btn btn-primary" title="Request Rescan" name="requestRescan" type="submit" onclick="return confirm('Request rescan of {{ ip }}?')"><i class="fas fa-redo-alt"></i></button></form>
+            {% if current_user.is_admin %}
+                <button id="deleteGroup" type="button" class="btn btn-danger dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                 <i class="fas fa-trash-alt text-white"></i>
+                </button>
+                <div class="dropdown-menu" aria-labelledby="deleteGroup">
+                {% if host %}
+                    <form method="POST" class="dropdown-item" action="{{ url_for('admin.delete_scan', scan_id=host.scan_id) }}">{{ delForm.hidden_tag() }} <button class="dropdown-item" id="deleteScan" name="deleteScan" title="Delete Scan" aria-hidden="true" onclick="return confirm('Are you sure you want to delete scan: {{ host.scan_id }}')" type="submit" ><i class="fas fa-trash-alt text-danger"></i> Delete Scan</button></form>
+                {% endif %}
+                  <form method="POST" class="dropdown-item" action="{{ url_for('admin.delete_host', ip=ip) }}">{{ delHostForm.hidden_tag() }} <button class="dropdown-item" id="deleteHost" name="deleteHost" title="Delete Host" aria-hidden="true" onclick="return confirm('Are you sure you want to delete host: {{ ip }}')" type="submit" ><i class="fas fa-dumpster-fire text-danger"></i> Delete Host</button></form>
+                </div> <!-- End delete dropdown-->
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+</div>
+<div class="row">
+  <ul class="nav nav-tabs host-nav">
+    <li role="presentation" class="nav-item">
+        <a id="summary" class="nav-link{{ ' active' if active_page == 'summary' }}" href="{{ url_for('host.host', ip=ip) }}">Summary</a>
+    </li>
+    <li role="presentation" class="nav-item">
+        <a id="history" class="nav-link{{ ' active' if active_page == 'history' }}" href="{{ url_for('host.host_history', ip=ip) }}">History <span class="badge badge-dark">{{ info.history }}</span></a>
+    </li>
+    <li role="presentation" class="nav-item">
+        <a id="headshots" class="nav-link{{ ' active' if active_page == 'screenshots' }}" href="{{ url_for('host.host_screenshots', ip=ip) }}">Screenshots {% if info.screenshot_count > 0%}<span class="badge badge-dark">{{ info.screenshot_count }}</span>{% endif %}</a>
+    </li>
+  </ul>
+</div>

--- a/natlas-server/app/templates/host/versions/0.6.11/_host-export.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_host-export.html
@@ -1,0 +1,11 @@
+<div class="btn-group host-export" role="group">
+  <button id="exportGroup-{{host.scan_id}}" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i class="fas fa-file-export mr-1"></i>Export
+  </button>
+  <div class="dropdown-menu" aria-labelledby="exportGroup-{{host.scan_id}}">
+    {% if host.xml_data %}<a class="dropdown-item" href="{{ url_for('host.export_scan', ip=host.ip, scan_id=host.scan_id, ext='xml') }}">.xml</a>{% endif %}
+    {% if host.nmap_data %}<a class="dropdown-item" href="{{ url_for('host.export_scan', ip=host.ip, scan_id=host.scan_id, ext='nmap') }}">.nmap</a>{% endif %}
+    {% if host.gnmap_data %}<a class="dropdown-item" href="{{ url_for('host.export_scan', ip=host.ip, scan_id=host.scan_id, ext='gnmap') }}">.gnmap</a>{% endif %}
+    <a class="dropdown-item" href="{{ url_for('host.export_scan', ip=host.ip, scan_id=host.scan_id, ext='json') }}">.json</a>
+  </div>
+</div>

--- a/natlas-server/app/templates/host/versions/0.6.11/_host-row-history.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_host-row-history.html
@@ -1,0 +1,49 @@
+<div class="row host-row py-1 no-gutters">
+    <div class="col col-xs-6 col-sm-4 vert-flex-mid">
+      <span class="host-row-text pl-2">
+        {% include 'host/versions/0.6.11/_host-status.html' %}
+        <a href="{{ url_for('host.host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">
+          <time datetime={{ host.ctime }} title="{{ host.ctime|ctime(human=True) }}">{{ host.ctime | ctime }}</time>
+        </a>
+      </span>
+    </div>
+      <div class="col col-xs-6 col-sm-4 col-md-7 pr-2 vert-flex-mid">
+        {% if host.is_up and host.port_count == 0 %}
+          No ports open
+        {% elif not host.is_up and host.timed_out %}
+          Scan Timed Out
+        {% elif not host.is_up %}
+          Host down
+        {% elif host.is_up and host.port_count > 0 %}
+          <div class="d-xs-flex d-md-none"><span>{% for port in host.ports %}{{ port.port }}{% if not loop.last %}, {% endif %}{% endfor %}</span></div>
+          <div class="row d-none d-md-flex">
+          {% for port in host.ports %}
+            <div class="col-xs-4 col-sm-2 port-summary my-1">
+              <div class="port-number">
+                  {{ port.port }}
+              </div>
+              <div class="port-protocol">
+                  {{port.protocol}}
+              </div>
+              <div class="clearfix"></div>
+              <div class="port-service">
+                  {{ port.service.name }}
+              </div>
+            </div><!--end port-summary-->
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+
+    <div class="col col-sm-4 col-md-1 d-none d-sm-flex vert-flex-mid">
+      {% if host.nmap_data or host.xml_data or host.gnmap_data %}
+       {% include 'host/versions/0.6.11/_host-export.html' %}
+    {% else %}
+      <div class="btn-group host-history-export" role="group">
+        <button id="exportGroup-{{host.scan_id}}" type="button" class="btn btn-primary dropdown-toggle" disabled data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" title="No data available to export">
+          Export
+        </button>
+      </div>
+    {% endif %}
+    </div>
+</div>

--- a/natlas-server/app/templates/host/versions/0.6.11/_host-row.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_host-row.html
@@ -1,0 +1,60 @@
+<div class="row host-row py-1">
+  <div class="col-xs-12 col-sm-4 col-md-3">
+    {% if pagetype == 'search' %}
+      <h3 class="mt-2"><a href="{{ url_for('host.host', ip=host.ip) }}">{{ host.ip }}</a></h3>
+    {% endif %}
+    {% if host.ctime %}
+      <div class="date-submitted">
+        <span class="submitted-text text-muted pr-1">Submitted:</span>
+        <a href="{{ url_for('host.host_historical_result', ip=host.ip, scan_id=host.scan_id) }}">
+          <time datetime={{ host.ctime }} title="{{ host.ctime|ctime(human=True) }}">{{ host.ctime | ctime }}</time>
+        </a>
+      </div>
+    {% endif %}
+    {% if host.ports|length > 0 %}
+      <h5 class="mt-2">Open Ports</h5>
+      <span class="port-str">{{ host.port_str }}</span>
+    {% elif host.port_count == 0 and host.is_up %}
+      <h5 class="mt-2">No open ports</h5>
+    {% elif not host.is_up %}
+      <h5 class="mt-2">Host down</h5>
+    {% endif %}
+    {% if host.hostname %}
+    <h5 class="mt-2">Hostname</h5>
+    <span class="host-hostname">{{ host.hostname }}</span>
+    {% endif %}
+    {% if host.tags %}
+    <h5 class="mt-2">Tags</h5>
+      {% for tag in host.tags %}
+        <a href="{{ url_for('main.search', query="tags:" + tag)}}"><span class="badge badge-secondary badge-tag">{{ tag }}</span></a>
+      {% endfor %}
+    {% endif %}
+    <div class="btn-group export-group mt-2" role="group">
+        {% include 'host/versions/0.6.11/_host-export.html' %}
+      </div>
+
+    {% for screenshot in host.screenshots %}
+      {% if screenshot.hash %}
+      <div class="image-browser">
+        <div class="thumbnail-hover d-flex flex-column justify-content-between">
+          <div class="image-browser-service p-2">{{ screenshot.service }}</div>
+          <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
+        </div>
+        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{host.ip}}' data-scan_id='{{host.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != host.ip %} ({{host.ip}}){%endif%}">
+      </div>
+      {% endif %}
+    {% endfor %}
+  </div><!--meta column-->
+  {% if current_user.result_format == 0 or not current_user.result_format %}
+  <div class="col-xs-12 col-sm-8 col-md-9">
+      {% for port in host.ports %}
+          {% set portloop = loop %}
+          {% include 'host/versions/0.6.11/_port-info.html' %}
+      {% endfor %}
+    </div><!--data column-->
+  {% elif current_user.result_format == 1 %}
+  <div class="col-xs-12 col-sm-8 col-md-9">
+    <pre class="nmap_data px-2 py-2 mt-2">{{ host.nmap_data }}</pre>
+  </div>
+  {% endif %}
+</div><!-- end host row -->

--- a/natlas-server/app/templates/host/versions/0.6.11/_host-status.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_host-status.html
@@ -1,0 +1,9 @@
+{% if host.is_up and host.port_count == 0 %}
+<i class="fas fa-circle text-warning" title="No ports open"></i>
+{% elif not host.is_up and host.timed_out %}
+<i class="fas fa-circle text-warning" title="Scan timed out"></i>
+{% elif not host.is_up %}
+<i class="fas fa-circle text-danger" title="Host down"></i>
+{% elif host.is_up and host.port_count > 0 %}
+<i class="fas fa-circle text-success" title="{{ host.port_count }} ports open"></i>
+{% endif %}

--- a/natlas-server/app/templates/host/versions/0.6.11/_imagemodal.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_imagemodal.html
@@ -1,0 +1,11 @@
+<div class="modal fade" id="imagemodal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-body">
+          <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+          <h3 class="imagetitle">Placeholder Title</h3>
+        <img src="/static/img/placeholder.png" alt="Placeholder Alt" class="imagepreview" style="width: 100%;" >
+      </div>
+    </div>
+  </div>
+</div>

--- a/natlas-server/app/templates/host/versions/0.6.11/_port-info.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/_port-info.html
@@ -1,0 +1,52 @@
+<div class="row py-3{% if not portloop.last %} port-row{% endif %}">
+    <div class="col-xs-6 col-sm-2 port-summary">
+        <div class="port-num-proto d-block">
+            <div class="port-number">
+                {{ port.port }}
+            </div>
+            <div class="port-protocol">
+                {{ port.protocol }}
+            </div>
+            <div class="clearfix"></div>
+        </div>
+        <div class="port-service">
+            {{ port.service.name }}
+        </div>
+        {% if 'http' in port.service.name %}
+        <div class="port-link">
+            <a class="d-block" target="_blank" rel="noopener noreferrer" href="{% if port.service.tunnel == 'ssl' %}https://{% else %}http://{% endif %}{{ host.ip }}{% if port.port not in [80,443] %}:{{ port.port }}{% endif %}"><i class="fas fa-external-link-alt"></i></a>
+        </div>
+        {% endif %}
+    </div><!--end port-summary-->
+
+    <div class="col-xs-12 col-sm-10 port-details">
+        {% if port.service.product or port.service.version or port.service.extrainfo %}
+        <h5 class="service-header">{{ port.service.product }}{% if port.service.version %}<small class="text-muted service-version pl-2">{{ port.service.version }}</small>{% endif %}{% if port.service.extrainfo %}<small class="text-muted service-extrainfo pl-2">{{ port.service.extrainfo }}</small>{% endif %}</h5>
+        {% endif %}
+        {% if port.banner %}
+            <div class="row port-banner">
+                <div class="col">
+                    <p><small class="text-muted">{{ port.banner }}</small></p>
+                </div>
+            </div>
+        {% endif %}
+        {% if port.scripts %}
+            {% for script in port.scripts %}
+                {% if script.output.rstrip() != "" %}
+                <div class="row script-header">
+                    <div class="col">
+                        <div class="script-container" id="{{ port.protocol }}-{{ port.port }}-{{ script.id }}-{{ host.scan_id }}">
+                            <h5 class="text-muted script-id">{{ script.id }}</h5>
+                        </div>
+                    </div>
+                </div>
+                <div class="row script-data">
+                    <div class="col">
+                        <pre class="script-output pl-2 pt-2">{{ script.output }}</pre>
+                    </div>
+                </div>
+                {% endif %}
+            {% endfor %}
+        {% endif %} <!--end scripts-->
+    </div><!--end port-details-->
+</div><!--end port-->

--- a/natlas-server/app/templates/host/versions/0.6.11/history.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/history.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% set title = ip ~ " | History | Page " ~ page %}
+{% set active_page = "history" %}
+{% set pagetype = 'multi' %}
+{% block content %}
+  {% include 'host/versions/0.6.11/_header.html' %}
+  <div class="host-rows">
+  {% for host in hosts %}
+    {% include 'host/versions/0.6.11/_host-row-history.html' %}
+  {% endfor %}
+  </div>
+  {% include 'host/versions/0.6.11/_imagemodal.html' %}
+  {% if numresults > current_user.results_per_page %}
+    <div class="row">
+      <div class="col text-center my-2">
+      {% include 'includes/pagination.html' %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/natlas-server/app/templates/host/versions/0.6.11/screenshots.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/screenshots.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% set title = ip ~ " | Screenshots" %}
+{% set active_page = "screenshots" %}
+{% block content %}
+    {% include 'host/versions/0.6.11/_header.html' %}
+    {% include 'host/versions/0.6.11/_imagemodal.html' %}
+    {% if numresults > current_user.results_per_page %}
+        <div class="row">
+          <div class="col text-center my-2">
+          {% include 'includes/pagination.html' %}
+          </div>
+        </div>
+      {% endif %}
+    {% for entry in historical_screenshots %}
+        <div class="row screenshot-header-row mt-2">
+            <h5 class="border-bottom">
+                <a href="{{url_for('host.host_historical_result', ip=ip, scan_id=entry.scan_id)}}"><time datetime={{ entry.ctime }} title="{{ entry.ctime|ctime(human=True) }}">{{ entry.ctime | ctime }}</time></a>
+            </h5>
+        </div>
+        <div class="row image-row">
+            {% for screenshot in entry.screenshots %}
+                {% if screenshot.hash %}
+                <div class="col-xs-12 col-sm-3">
+                    <div class="image-browser">
+                        <div class="thumbnail-hover d-flex flex-column justify-content-between">
+                            <div class="image-browser-service p-2">{{ screenshot.service }}</div>
+                            <div class="image-browser-port p-2">{{ screenshot.host }}:{{ screenshot.port }}</div>
+                        </div>
+                        <img class="img-responsive img-thumbnail" data-path='/media/original/{{screenshot.hash|get_screenshot_path(screenshot.service)}}' data-ip='{{ip}}' data-scan_id='{{entry.scan_id}}' src='/media/thumbs/{{screenshot.thumb_hash|get_screenshot_path(screenshot.service)}}' alt="{{ screenshot.host }} - {{ screenshot.port }}{%if screenshot.host != ip %} ({{ip}}){%endif%}">
+                    </div>
+                </div>
+                {% endif %}
+                {% if screenshot.path %}
+                <div class="col-xs-12 col-sm-3">
+                    <strong class="mt-2">{{ screenshot.service }}</strong>
+                    <div class="expand-img"><img class="img-responsive img-thumbnail" data-path='/media/{{screenshot.path}}' src='/media/{{screenshot.thumb}}' alt="{{ entry.ctime|ctime }} - {{ screenshot.service }}"></div>
+                </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endfor %}
+    {% if numresults > current_user.results_per_page %}
+    <div class="row">
+      <div class="col text-center my-2">
+      {% include 'includes/pagination.html' %}
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/natlas-server/app/templates/host/versions/0.6.11/summary.html
+++ b/natlas-server/app/templates/host/versions/0.6.11/summary.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% set title = ip ~ " | Summary" %}
+{% set active_page = "summary" %}
+{% set pagetype = 'single' %}
+{% block content %}
+    {% include 'host/versions/0.6.11/_header.html' %}
+    {% include 'host/versions/0.6.11/_host-row.html' %}
+    {% include 'host/versions/0.6.11/_imagemodal.html' %}
+{% endblock %}

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -27,7 +27,7 @@ def casted_value(expected_type, value):
 class Config(object):
 
     # Current Version
-    NATLAS_VERSION = "0.6.10"
+    NATLAS_VERSION = "0.6.11"
 
     BASEDIR = os.path.abspath(os.path.dirname(__file__))
     load_dotenv(os.path.join(BASEDIR, ".env"))


### PR DESCRIPTION
This pull request makes the necessary changes to provide a stable v0.6.11 release.

Namely:

1) The final app-version template folder for 0.6.11 (I can't wait for rendering to be based on document version). This is a direct copy of 0.6.10 templates, with find-and-replace `0.6.10` to `0.6.11`.
2) `config.py` changes to modify the version reported by both the agent and the server.
3) Accumulated changes into a curated CHANGELOG entry, which will be mirrored into the Github release, as well as into the new [natlas documentation](https://docs.natlas.io/blog/releases/).

Once this PR is approved, the [v0.6.11 release](https://github.com/natlas/natlas/releases/tag/untagged-b235878397ba5e1b0da1) will be ready to publish.