### PR TITLE
Fixed: Scope import CLI command inversion

### DIFF
--- a/natlas-server/app/cli/scope.py
+++ b/natlas-server/app/cli/scope.py
@@ -14,10 +14,10 @@ import_helptext = "Import scope/blacklist from a file containing line-separated 
 Optionally, each line can contain a comma separated list of tags to apply to that target. e.g. 127.0.0.1,local,private,test"
 
 
-def import_scope(scope: typing.TextIO, blacklist: bool):
-    if not scope:
+def import_scope(scope_file: typing.TextIO, blacklist: bool):
+    if not scope_file:
         return {"failed": 0, "existed": 0, "successful": 0}
-    addresses = scope.readlines()
+    addresses = scope_file.readlines()
     fail, exist, success = ScopeItem.import_scope_list(addresses, blacklist)
     db.session.commit()
 
@@ -44,8 +44,9 @@ def print_import_output(results: dict, verbose: bool):
 @cli_group.command("import", help=import_helptext)
 @click.argument("file", type=click.File("r"))
 @click.option(
-    "--scope/--blacklist",
-    default=True,
+    "--blacklist/--scope",
+    "import_as_blacklist",
+    default=False,
     help="Should this file be considered in scope or blacklisted?",
 )
 @click.option(
@@ -53,9 +54,9 @@ def print_import_output(results: dict, verbose: bool):
     default=False,
     help="Print status of all addresses / ranges instead of only the summary.",
 )
-def import_items(file: str, scope: bool, verbose: bool):
-    import_name = "scope" if scope else "blacklist"
-    results = {import_name: import_scope(file, scope)}
+def import_items(file: str, import_as_blacklist: bool, verbose: bool):
+    import_name = "blacklist" if import_as_blacklist else "scope"
+    results = {import_name: import_scope(file, import_as_blacklist)}
     results["summary"] = {
         "timestamp": datetime.utcnow().isoformat(),
         import_name: summarize_import_results(results[import_name]),

--- a/natlas-server/tests/cli/conftest.py
+++ b/natlas-server/tests/cli/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def runner(app):
+    return app.test_cli_runner()

--- a/natlas-server/tests/cli/test_scope_cli.py
+++ b/natlas-server/tests/cli/test_scope_cli.py
@@ -1,0 +1,55 @@
+import json
+
+from app.cli.scope import import_items
+from app.models import ScopeItem
+
+DEFAULT_SCOPE_ITEMS = ["10.0.0.0/8", "192.168.1.0/24", "192.168.5.0/28"]
+
+
+def mock_scope_file(scope_items: list = DEFAULT_SCOPE_ITEMS) -> str:
+    with open("scope.txt", "w") as f:
+        f.write("\n".join(scope_items))
+    return "scope.txt"
+
+
+def test_import_items_no_flags(runner):
+    with runner.isolated_filesystem():
+        scope_file = mock_scope_file()
+        result = runner.invoke(import_items, [scope_file])
+        assert result.exit_code == 0
+        imported_scope = [item.target for item in ScopeItem.getScope()]
+        assert DEFAULT_SCOPE_ITEMS == imported_scope
+        result_dict = json.loads(result.output)
+        assert len(result_dict["scope"]) == len(DEFAULT_SCOPE_ITEMS)
+
+
+def test_import_items_scope_flag(runner):
+    with runner.isolated_filesystem():
+        scope_file = mock_scope_file()
+        result = runner.invoke(import_items, ["--scope", scope_file])
+        assert result.exit_code == 0
+        imported_scope = [item.target for item in ScopeItem.getScope()]
+        assert DEFAULT_SCOPE_ITEMS == imported_scope
+        result_dict = json.loads(result.output)
+        assert len(result_dict["scope"]) == len(DEFAULT_SCOPE_ITEMS)
+
+
+def test_import_items_blacklist_flag(runner):
+    with runner.isolated_filesystem():
+        scope_file = mock_scope_file()
+        result = runner.invoke(import_items, ["--blacklist", scope_file])
+        assert result.exit_code == 0
+        imported_blacklist = [item.target for item in ScopeItem.getBlacklist()]
+        assert DEFAULT_SCOPE_ITEMS == imported_blacklist
+        result_dict = json.loads(result.output)
+        assert len(result_dict["blacklist"]) == len(DEFAULT_SCOPE_ITEMS)
+
+
+def test_import_items_verbose(runner):
+    with runner.isolated_filesystem():
+        scope_file = mock_scope_file()
+        result = runner.invoke(import_items, ["--verbose", scope_file])
+        assert result.exit_code == 0
+        result_dict = json.loads(result.output)
+        assert len(result_dict["scope"]) == len(DEFAULT_SCOPE_ITEMS)
+        assert result_dict["summary"]["scope"]["successful"] == len(DEFAULT_SCOPE_ITEMS)


### PR DESCRIPTION
Fixes #436 by inverting the scope bool before it's passed into the import. This way scope remains the default import and when we import it, blacklist=False. Also introduces tests for the cli command being modified.