### PR TITLE
Fixed: Can now export scope from cli when items are tagged

### DIFF
--- a/natlas-server/app/cli/scope.py
+++ b/natlas-server/app/cli/scope.py
@@ -69,11 +69,19 @@ def export_items():
     result = {
         "timestamp": datetime.utcnow().isoformat(),
         "scope": [
-            {"target": item.target, "blacklist": item.blacklist, "tags": item.tags}
+            {
+                "target": item.target,
+                "blacklist": item.blacklist,
+                "tags": item.get_tag_names(),
+            }
             for item in ScopeItem.getScope()
         ],
         "blacklist": [
-            {"target": item.target, "blacklist": item.blacklist, "tags": item.tags}
+            {
+                "target": item.target,
+                "blacklist": item.blacklist,
+                "tags": item.get_tag_names(),
+            }
             for item in ScopeItem.getBlacklist()
         ],
     }

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -34,6 +34,9 @@ class ScopeItem(db.Model, DictSerializable):
     def is_tagged(self, tag):
         return tag in self.tags
 
+    def get_tag_names(self):
+        return [tag.name for tag in self.tags]
+
     @staticmethod
     def getBlacklist():
         return ScopeItem.query.filter_by(blacklist=True).all()


### PR DESCRIPTION
This fixes #426 by introducing a get_tags function that ensures it's a serializable format. It also introduces tests for the flask scope export command