### PR TITLE
Fix: Error handlers respond with json if applicable

### DIFF
--- a/natlas-server/app/errors/http_error.py
+++ b/natlas-server/app/errors/http_error.py
@@ -1,0 +1,17 @@
+import json
+
+
+class HTTPError:
+    def __init__(self, status_code: int, message: str, template: str = None):
+        self.status_code = status_code
+        self.message = message
+        self.template = f"errors/{self.status_code}.html" if not template else template
+
+    def __str__(self):
+        return f"{self.status_code}: {self.message}"
+
+    def get_dict(self):
+        return {"status": self.status_code, "message": self.message}
+
+    def get_json(self):
+        return json.dumps(self.get_dict(), sort_keys=True, indent=4)

--- a/natlas-server/app/errors/responses.py
+++ b/natlas-server/app/errors/responses.py
@@ -1,0 +1,25 @@
+from flask import Response, render_template
+
+from .http_error import HTTPError
+
+
+def json_response(err: HTTPError) -> Response:
+    return Response(
+        err.get_json(), err.status_code, content_type="application/json; charset=utf-8"
+    )
+
+
+def html_response(err: HTTPError) -> Response:
+    return Response(render_template(err.template, err=err), err.status_code)
+
+
+# This belongs below the function definitions due to Python's line-by-line interpretation
+supported_formats = {"text/html": html_response, "application/json": json_response}
+
+
+def get_response(requested_format: str, err: HTTPError) -> Response:
+    return supported_formats.get(requested_format)(err)
+
+
+def get_supported_formats() -> list:
+    return supported_formats.keys()

--- a/natlas-server/app/templates/errors/400.html
+++ b/natlas-server/app/templates/errors/400.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% set title = "405 - Method Not Allowed" %}
+{% set title = "400 - Bad Request" %}
 {% block content %}
   <div class="row">
       <h2 class="sub-header">{{ err }}</h2>

--- a/natlas-server/app/templates/errors/404.html
+++ b/natlas-server/app/templates/errors/404.html
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="row">
       <div class="col">
-          <h2 class="sub-header">404: Page Not Found</h2>
+          <h2 class="sub-header">{{ err }}</h2>
       </div>
   </div>
   <div class="row">

--- a/natlas-server/app/templates/errors/500.html
+++ b/natlas-server/app/templates/errors/500.html
@@ -3,12 +3,12 @@
 {% block content %}
   <div class="row">
       <div class="col">
-          <h2 class="sub-header">500: Internal Server Error</h2>
+          <h2 class="sub-header">{{ err }}</h2>
       </div>
   </div>
   <div class="row">
       <div class="col">
-        <p>You can try to return to <a href="{{ url_for('main.index') }}">browse</a></p>
+        <p>You can try to return to <a href="{{ url_for('main.browse') }}">browse</a></p>
         <p>If you continue to see this message, please contact the administrator.</p>
     </div>
    </div>

--- a/natlas-server/app/templates/errors/503.html
+++ b/natlas-server/app/templates/errors/503.html
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="row">
       <div class="col">
-          <h2 class="sub-header">503: Service Temporarily Unavailable</h2>
+          <h2 class="sub-header">{{ err }}</h2>
       </div>
   </div>
   <div class="row">

--- a/natlas-server/tests/conftest.py
+++ b/natlas-server/tests/conftest.py
@@ -12,3 +12,9 @@ def app():
     app_context.push()
     db.create_all()
     return app
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as client:
+        yield client

--- a/natlas-server/tests/test_errors.py
+++ b/natlas-server/tests/test_errors.py
@@ -1,0 +1,38 @@
+json_headers = {"Accept": "application/json"}
+html_headers = {"Accept": "text/html"}
+weighted_headers = {"Accept": "text/html;q=0.8, application/json"}
+
+NONEXISTANT_URL = "/very_long_obviously_not_legitimate_url"
+
+
+def test_404_error(client):
+    expected_err_code = 404
+    response = client.get(NONEXISTANT_URL)
+    assert response.status_code == expected_err_code
+
+
+def test_405_error(client):
+    expected_err_code = 405
+    response = client.delete("/")
+    assert response.status_code == expected_err_code
+
+
+def test_json_error(client):
+    expected_err_code = 404
+    expected_keys = ["status", "message"]
+    response = client.get(NONEXISTANT_URL, headers=json_headers)
+    assert response.content_type == "application/json; charset=utf-8"
+    assert response.get_json()
+    for key in expected_keys:
+        assert key in response.get_json()
+    assert response.get_json()["status"] == expected_err_code
+
+
+def test_html_error(client):
+    response = client.get(NONEXISTANT_URL, headers=html_headers)
+    assert response.content_type == "text/html; charset=utf-8"
+
+
+def test_content_type_matching(client):
+    response = client.get(NONEXISTANT_URL, headers=weighted_headers)
+    assert response.content_type == "application/json; charset=utf-8"


### PR DESCRIPTION
This actually changes the default behavior of the error handlers to json and then if `text/html` is in the `Accept` header then we'll serve up html instead.