### PR TITLE
feat(sentry)(agent): Improve how exceptions are handled for Sentry in the agent

### DIFF
--- a/natlas-agent/natlas/error_reporting.py
+++ b/natlas-agent/natlas/error_reporting.py
@@ -1,8 +1,9 @@
 from urllib.parse import urlparse
 import sentry_sdk
+from config import Config
 
 
-def initialize_sentryio(config):
+def initialize_sentryio(config: Config):
     if config.sentry_dsn:
         url = urlparse(config.sentry_dsn)
         print(


### PR DESCRIPTION
The natlas agent seems to always report using log statements instead of real errors. I hate the logs because they lose context and aren't multi-threaded correctly, so I did some work to improve how Sentry errors are reported. I'm not enabling tracing yet because Sentry's version is in early testing and I need more time to decide on OpenTelemetry vs Sentry.