### PR TITLE
Fixed: Elasticsearch request error bubbles up to show the user what's wrong

### DIFF
--- a/natlas-server/app/errors/__init__.py
+++ b/natlas-server/app/errors/__init__.py
@@ -3,3 +3,6 @@ from flask import Blueprint
 bp = Blueprint("errors", __name__)
 
 from app.errors import handlers  # noqa: F401
+from app.errors.errors import NatlasServiceError, NatlasSearchError
+
+__all__ = ["handlers", "NatlasServiceError", "NatlasSearchError"]

--- a/natlas-server/app/errors/errors.py
+++ b/natlas-server/app/errors/errors.py
@@ -1,7 +1,7 @@
 import json
 
 
-class HTTPError:
+class NatlasServiceError(Exception):
     def __init__(self, status_code: int, message: str, template: str = None):
         self.status_code = status_code
         self.message = message
@@ -15,3 +15,10 @@ class HTTPError:
 
     def get_json(self):
         return json.dumps(self.get_dict(), sort_keys=True, indent=4)
+
+
+class NatlasSearchError(NatlasServiceError):
+    def __init__(self, e):
+        self.status_code = 400
+        self.message = e.info["error"]["root_cause"][0]["reason"]
+        self.template = "errors/search.html"

--- a/natlas-server/app/errors/responses.py
+++ b/natlas-server/app/errors/responses.py
@@ -1,15 +1,15 @@
 from flask import Response, render_template
 
-from .http_error import HTTPError
+from .errors import NatlasServiceError
 
 
-def json_response(err: HTTPError) -> Response:
+def json_response(err: NatlasServiceError) -> Response:
     return Response(
         err.get_json(), err.status_code, content_type="application/json; charset=utf-8"
     )
 
 
-def html_response(err: HTTPError) -> Response:
+def html_response(err: NatlasServiceError) -> Response:
     return Response(render_template(err.template, err=err), err.status_code)
 
 
@@ -17,7 +17,7 @@ def html_response(err: HTTPError) -> Response:
 supported_formats = {"text/html": html_response, "application/json": json_response}
 
 
-def get_response(requested_format: str, err: HTTPError) -> Response:
+def get_response(requested_format: str, err: NatlasServiceError) -> Response:
     return supported_formats.get(requested_format)(err)
 
 

--- a/natlas-server/app/templates/errors/search.html
+++ b/natlas-server/app/templates/errors/search.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% set title = "400 - Bad Request" %}
+{% block content %}
+  <div class="row">
+      <div class="col">
+          <h2>Invalid Search Query</h2>
+      </div>
+  </div>
+  <div class="row">
+    <div class="col">
+        <p><strong>{{ err }}</strong></p>
+    </div>
+  </div>
+  <div class="row">
+      <div class="col">
+        <ul>
+          <li>Need help <a target="_blank" rel="noopener noreferrer" href="https://docs.natlas.io/docs/tasks/searching-natlas/">searching?</a></li>
+          <li>Maybe you'd prefer to go on <a href="{{url_for('host.random_host')}}">an adventure</a>?</li>
+          <li>Or maybe you'd like to <a href="{{ url_for('main.browse') }}">look around</a>.</li>
+        </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/natlas-server/tests/conftest.py
+++ b/natlas-server/tests/conftest.py
@@ -8,10 +8,9 @@ import pytest
 @pytest.fixture
 def app():
     app = create_app(TestConfig)
-    app_context = app.app_context()
-    app_context.push()
-    db.create_all()
-    return app
+    with app.app_context():
+        db.create_all()
+        yield app
 
 
 @pytest.fixture

--- a/natlas-server/tests/test_errors.py
+++ b/natlas-server/tests/test_errors.py
@@ -1,3 +1,5 @@
+from flask import url_for, current_app
+
 json_headers = {"Accept": "application/json"}
 html_headers = {"Accept": "text/html"}
 weighted_headers = {"Accept": "text/html;q=0.8, application/json"}
@@ -36,3 +38,13 @@ def test_html_error(client):
 def test_content_type_matching(client):
     response = client.get(NONEXISTANT_URL, headers=weighted_headers)
     assert response.content_type == "application/json; charset=utf-8"
+
+
+def test_invalid_search(client):
+    invalid_query = "tags:!invalid"
+    current_app.config["LOGIN_REQUIRED"] = False
+    response = client.get(
+        url_for("main.search", query=invalid_query), headers=json_headers
+    )
+    assert response.status_code == 400
+    assert invalid_query in response.get_json()["message"]


### PR DESCRIPTION
Closes #444 by handling elasticsearch.RequestError exceptions with a 400 error instead of 500 (via the custom `NatlasSearchError`, as to not treat all `elasticsearch.RequestError` as search failures)