### PR TITLE
Fix: Handle a nonexistant xml_data in the case of timed_out: True

### DIFF
--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -102,7 +102,7 @@ def submit():
         mark_scan_completed(newhost["ip"], newhost["scan_id"])
 
     try:
-        nmap = NmapParser.parse(newhost["xml_data"])
+        nmap = NmapParser.parse(newhost.get("xml_data", None))
         # If there's more or less than 1 host in the xml data, reject it (for now)
         if nmap.hosts_total != 1:
             status_code = 400


### PR DESCRIPTION
Fixes #441 by using the dict getter rather than referencing by key. This is as small a change necessary to fix the bug, with a complete overhaul coming in line with the agent rework. The "Fix" is that when we pass None to the NmapParser, it will throw `libnmap.parser.NmapParserException: No report data to parse: please provide a valid XML nmap report`, which we have a catch block for. It won't store the data for now, which maybe isn't ideal behavior but it's also no different than the previous behavior so at least it's not worse.

I mostly don't want to invest a lot of time into rebuilding the way scans are handled by the server on submission just to have to change them completely again with the agent rework. It's currently a mess because the api submissions themselves are a mess.