### PR TITLE
Change: Speed up bulk import at the cost of some specificity

### DIFF
--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -179,18 +179,16 @@ def import_scope(scopetype=""):
         return abort(404)
     if importForm.validate_on_submit():
         newScopeItems = importForm.scope.data.split("\n")
-        fail, exist, success = ScopeItem.import_scope_list(
-            newScopeItems, importBlacklist
-        )
+        result = ScopeItem.import_scope_list(newScopeItems, importBlacklist)
         db.session.commit()
         current_app.ScopeManager.update()
-        if success:
-            flash(f"{len(success)} targets added to {scopetype}.", "success")
-        if exist:
-            flash(f"{len(exist)} targets already existed.", "info")
-        if fail:
-            flash(f"{len(fail)} targets failed to import!", "danger")
-            for item in fail:
+        if result["success"]:
+            flash(f"{result['success']} targets added to {scopetype}.", "success")
+        if result["exist"]:
+            flash(f"{result['exist']} targets already existed.", "info")
+        if result["fail"]:
+            flash(f"{len(result['fail'])} targets failed to import!", "danger")
+            for item in result["fail"]:
                 flash(f"{item}", "danger")
     else:
         for field, errors in importForm.errors.items():

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -96,12 +96,14 @@ class ScopeItem(db.Model, DictSerializable):
         return ip, tags
 
     @staticmethod
-    def extract_import_tags(import_list: list) -> set:
+    def extract_import_tags(import_list: list) -> set[str]:
         tags = set()
         for line in import_list:
             split = line.split(",")
             if len(split) > 1:
                 for tag in split[1:]:
+                    if tag.strip() == "":
+                        continue
                     tags.add(tag)
         return tags
 

--- a/natlas-server/tests/cli/test_scope_cli.py
+++ b/natlas-server/tests/cli/test_scope_cli.py
@@ -45,16 +45,6 @@ def test_import_items_blacklist_flag(runner):
         assert len(result_dict["blacklist"]) == len(DEFAULT_SCOPE_ITEMS)
 
 
-def test_import_items_verbose(runner):
-    with runner.isolated_filesystem():
-        scope_file = mock_scope_file()
-        result = runner.invoke(import_items, ["--verbose", scope_file])
-        assert result.exit_code == 0
-        result_dict = json.loads(result.output)
-        assert len(result_dict["scope"]) == len(DEFAULT_SCOPE_ITEMS)
-        assert result_dict["summary"]["scope"]["successful"] == len(DEFAULT_SCOPE_ITEMS)
-
-
 def test_export_items_tagged(runner):
     scope_items = ["10.0.0.0/8,a", "192.168.5.0/28"]
     blacklist_items = ["192.168.1.0/24,b"]

--- a/natlas-server/tests/models/test_scope.py
+++ b/natlas-server/tests/models/test_scope.py
@@ -54,10 +54,10 @@ notevenanip
 
 
 def test_import_scope(app):
-    fails, exists, succeeds = ScopeItem.import_scope_list(scopefile.split(), False)
-    assert len(fails) == 1
-    assert len(exists) == 1
-    assert len(succeeds) == 5
+    result = ScopeItem.import_scope_list(scopefile.split(), False)
+    assert len(result["fail"]) == 1
+    assert result["exist"] == 1
+    assert result["success"] == 5
     item = ScopeItem.query.filter_by(target="127.0.0.1/32").first()
     tags = [t.name for t in item.tags]
     assert len(tags) == 3


### PR DESCRIPTION
This closes #471 by breaking bulk imports up into multiple stages - First extracting all tags and ensuring they exist, then parsing each line into ip and tag. Then we bulk insert all of the scope items as a INSERT IGNORE statement, allowing us to import much faster. Then after all the scope imports, we go back and make associations between tags and scope items once the scope items have primary keys.

I fully anticipate a thorough roasting in the CR. But I've looked at this a long time and I think I'm too invested in it to see where to improve it right now. In a sample of importing 200k tagged scope items, this change brings the run time from about 7.5 minutes to about 30 seconds. But since we're using `INSERT IGNORE` logic now, we lose granularity about which scope items already existed and which ones were successfully imported. We still track the failures, where something couldn't be parsed into a ScopeItem, and those are returned in every case now.