### PR TITLE
Add precommit update workflow

### DIFF
--- a/.github/workflows/update-precommit.yaml
+++ b/.github/workflows/update-precommit.yaml
@@ -1,0 +1,54 @@
+name: Update Pre-commit Hooks
+
+on:
+  schedule:
+    # Run every Monday at 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  update-precommit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Update pre-commit hooks
+        run: |
+          pre-commit autoupdate | sed 's/\[INFO\] .*\.//g' | tee /tmp/pre-commit-update.log
+      - name: Run pre-commit on all files
+        run: |
+          pre-commit run --all-files || true
+      - name: Build PR Body
+        id: get-pr-body
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "body<<$EOF" >> $GITHUB_OUTPUT
+          cat /tmp/pre-commit-update.log >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.NATLAS_ACTIONS_PAT }}
+          commit-message: "Automated weekly pre-commit hook update"
+          branch: pre-commit-update
+          delete-branch: true
+          branch-suffix: short-commit-hash
+          title: Weekly pre-commit hooks update
+          body: |
+            This is an automatic update created by the `.github/workflows/update-precommit.yaml` workflow.
+
+            ${{ steps.get-pr-body.outputs.body }}
+          labels: dependencies
+          reviewers: 0xdade


### PR DESCRIPTION
This workflow should automatically open a PR for any pending pre-commit updates once a week. This ensures that hooks stay up to date.