### PR TITLE
Add basic CI workflow that enforces pre-commit on PRs

### DIFF
--- a/.github/actions/fetch/action.yaml
+++ b/.github/actions/fetch/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: "Fetching"
-      run: git -c protocol.version=2 fetch --no-tags --prune --progress --no-recursive-submodules --depth=1 ${{ inputs.remote }} ${{ inputs.ref }}
+      run: git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse`-submodules --depth=1 ${{ inputs.remote }} ${{ inputs.ref }}
       shell: bash
     - name: Verifying
       run: git rev-parse --verify ${{ inputs.ref }} || git branch ${{ inputs.ref }} ${{ inputs.remote }}/${{ inputs.ref }}

--- a/.github/actions/fetch/action.yaml
+++ b/.github/actions/fetch/action.yaml
@@ -1,0 +1,20 @@
+name: "Fetch"
+description: "Fetch a single git reference"
+inputs:
+  remote:
+    description: "Remote"
+    required: true
+    default: "origin"
+  ref:
+    description: "Commit reference"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Fetching"
+      run: git -c protocol.version=2 fetch --no-tags --prune --progress --no-recursive-submodules --depth=1 ${{ inputs.remote }} ${{ inputs.ref }}
+      shell: bash
+    - name: Verifying
+      run: git rev-parse --verify ${{ inputs.ref }} || git branch ${{ inputs.ref }} ${{ inputs.remote }}/${{ inputs.ref }}
+      shell: bash

--- a/.github/actions/fetch/action.yaml
+++ b/.github/actions/fetch/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: "Fetching"
-      run: git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse`-submodules --depth=1 ${{ inputs.remote }} ${{ inputs.ref }}
+      run: git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 ${{ inputs.remote }} ${{ inputs.ref }}
       shell: bash
     - name: Verifying
       run: git rev-parse --verify ${{ inputs.ref }} || git branch ${{ inputs.ref }} ${{ inputs.remote }}/${{ inputs.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,25 +18,15 @@ env:
   PYTHON_VERSION: 3.11
 
 jobs:
-  check-out-base:
-    runs-on: ubuntu-latest
-    outputs:
-      base-ref: ${{ steps.get-base-ref.outputs.base-ref }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: ./.github/actions/fetch
-        with:
-          ref: ${{ env.DEFAULT_BRANCH }}
-
   pre-commit:
     runs-on: ubuntu-latest
-    needs: check-out-base
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: ./.github/actions/fetch
+        with:
+          ref: ${{ env.DEFAULT_BRANCH }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Merge base branch into PR branch
         run: |
           git fetch origin ${{ needs.check-out-base.outputs.base-ref }} --depth=1
-          git merge --no-commit --no-ff FETCH_HEAD || exit 1
+          git merge --no-commit --no-ff FETCH_HEAD --allow-unrelated-histories || exit 1
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,11 @@ on:
       - reopened
   workflow_dispatch: # Allow manual triggering
 
+env:
+  DEFAULT_BRANCH: main
+  IS_DEFAULT_BRANCH: ${{ github.ref == 'refs/heads/main' }}
+  PYTHON_VERSION: 3.11
+
 jobs:
   check-out-base:
     runs-on: ubuntu-latest
@@ -20,14 +25,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - uses: ./.github/actions/fetch
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
-
-      - name: Get base ref
-        id: get-base-ref
-        run: |
-          echo "base-ref=${{ github.event.pull_request.base.ref }}" >> $GITHUB_OUTPUT
+          ref: ${{ env.DEFAULT_BRANCH }}
 
   pre-commit:
     runs-on: ubuntu-latest
@@ -35,26 +36,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Merge base branch into PR branch
-        run: |
-          git fetch origin ${{ needs.check-out-base.outputs.base-ref }} --depth=1
-          git merge --no-commit --no-ff FETCH_HEAD --allow-unrelated-histories || exit 1
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install pre-commit
         run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
+          pip install --disable-pip-version-check --no-compile pre-commit
 
       - name: Run pre-commit checks
         run: |
-          pre-commit run --all-files
+          pre-commit run --show-diff-on-failure --color=always --from-ref ${{ env.DEFAULT_BRANCH }} --to-ref HEAD
 
   required:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,65 @@
+name: CI
+
+concurrency:
+  group: pr-${{github.event.pull_request.number}}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  check-out-base:
+    runs-on: ubuntu-latest
+    outputs:
+      base-ref: ${{ steps.get-base-ref.outputs.base-ref }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Get base ref
+        id: get-base-ref
+        run: |
+          echo "base-ref=${{ github.event.pull_request.base.ref }}" >> $GITHUB_OUTPUT
+
+  pre-commit:
+    runs-on: ubuntu-latest
+    needs: check-out-base
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Merge base branch into PR branch
+        run: |
+          git fetch origin ${{ needs.check-out-base.outputs.base-ref }} --depth=1
+          git merge --no-commit --no-ff FETCH_HEAD || exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run pre-commit checks
+        run: |
+          pre-commit run --all-files
+
+  required:
+    runs-on: ubuntu-latest
+    needs: [pre-commit]
+    steps:
+      - name: Ensure all jobs required for CI pass
+        run: |
+          echo "All required jobs have passed."


### PR DESCRIPTION
I've gotten rid of all the old cruft CI stuff, now I need to, at the very least, make sure that pre-commit is passing before we can merge a PR. This workflow should enable that while allowing us to expand it to additional required jobs (such as the docker containers must build, the unit tests must pass, etc) in the future.