### PR TITLE
Add flake8-comprehension

### DIFF
--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -124,7 +124,7 @@ class ElasticClient:
         return results["hits"]["total"], results["hits"]["hits"][0]["_source"]
 
     def collate_source(self, documents):
-        return list(map(lambda doc: doc["_source"], documents))
+        return [doc["_source"] for doc in documents]
 
     # Mid-level query executor abstraction.
     def execute_search(self, **kwargs):

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -178,7 +178,7 @@ class ScopeItem(db.Model, DictSerializable):
         tags_to_import = []
         for k, v in scope_tag_import.items():
             for tag in v:
-                tags_to_import.append(dict(scope_id=all_scope[k], tag_id=tag.id))
+                tags_to_import.append({"scope_id": all_scope[k], "tag_id": tag.id})
         import_chunks = [
             tags_to_import[i : i + chunk_size]
             for i in range(0, len(tags_to_import), chunk_size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ requires-python = "==3.11"
 select = [
     # flake8-bugbear
     "B",
+    # flake8-comprehensions
+    "C4",
     # isort
     "I",
 ]


### PR DESCRIPTION
Enable the flake8-comprehension ruleset, which looks for optimizations / idiomatic improvements like using list/dict comprehensions where appropriate, as well as using literals instead of dict()/set(), etc.