### PR TITLE
Add flake8-tidy-imports and ban relative imports

### DIFF
--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -10,12 +10,11 @@ from flask_wtf.csrf import CSRFProtect
 from migrations.migrator import handle_db_upgrade, migration_needed
 from webpack_manifest import webpack_manifest
 
+from app.config_loader import load_config_from_db
 from app.elastic import ElasticInterface
+from app.instrumentation import initialize_opentelemetry
 from app.scope import ScopeManager
 from app.url_converters import register_converters
-
-from .config_loader import load_config_from_db
-from .instrumentation import initialize_opentelemetry
 
 
 class AnonUser(AnonymousUserMixin):

--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -3,10 +3,8 @@ import sentry_sdk
 from flask import request
 
 from app import db
-from app.errors import bp
-
-from .errors import NatlasSearchError, NatlasServiceError
-from .responses import get_response, get_supported_formats
+from app.errors import NatlasSearchError, NatlasServiceError, bp
+from app.errors.responses import get_response, get_supported_formats
 
 
 def build_response(err: NatlasServiceError):

--- a/natlas-server/app/errors/responses.py
+++ b/natlas-server/app/errors/responses.py
@@ -1,6 +1,6 @@
 from flask import Response, render_template
 
-from .errors import NatlasServiceError
+from app.errors import NatlasServiceError
 
 
 def json_response(err: NatlasServiceError) -> Response:

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -10,7 +10,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from .sentryio_middleware import SentryIoContextMiddleware
+from app.instrumentation.sentryio_middleware import SentryIoContextMiddleware
 
 SERVICE_NAME = "natlas-server"
 template_span = threading.local()

--- a/natlas-server/app/scope/scan_group.py
+++ b/natlas-server/app/scope/scan_group.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 from flask import current_app
 
-from .scan_manager import IPScanManager
-from .scope_collection import ScopeCollection
+from app.scope.scan_manager import IPScanManager
+from app.scope.scope_collection import ScopeCollection
 
 
 class ScanGroup:

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -4,8 +4,8 @@ from flask import current_app
 from netaddr import IPAddress
 from netaddr.core import AddrFormatError
 
-from .scan_group import ScanGroup
-from .scan_manager import IPScanManager
+from app.scope.scan_group import ScanGroup
+from app.scope.scan_manager import IPScanManager
 
 
 class ScopeManager:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,9 @@ select = [
     "C4",
     # isort
     "I",
+    # flake8-tidy-imports
+    "TID",
 ]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"


### PR DESCRIPTION
flake8-tidy-imports gives us the ability to ban specific APIs as well as specific module-level imports, which is very handy functionality when we want to disallow certain code paths or encourage the adoption of a new API instead of one we're getting rid of.

Additionally, it allows us to ban relative imports. This might be a little controversial, but for the most part we were using absolute imports already, with only a few relative imports used. Ruff will automatically fix relative imports to absolute imports if it detects them, so this shouldn't really get in anyone's way. Some will argue that it makes the code less portable if you're refactoring, but to that I say use your IDEs refactoring tools, then.