### PR TITLE
Add pyupgrade ruf rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,6 @@ repos:
             - 'stylelint'
             - 'stylelint-config-standard-scss'
             - 'stylelint-scss'
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-      - id: pyupgrade
-        args: [--py311-plus, --keep-runtime-typing]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.8.4

--- a/natlas-agent/natlas/net.py
+++ b/natlas-agent/natlas/net.py
@@ -56,19 +56,18 @@ class NatlasNetworkServices:
                         os._exit(403)
                 if req.status_code == 400:
                     if "message" in req.json():
-                        self.netlogger.warn("[Server] " + req.json()["message"])
+                        self.netlogger.warning("[Server] " + req.json()["message"])
                     return req
                 if req.status_code != statusCode:
                     self.netlogger.error(
                         f"Expected {statusCode}, received {req.status_code}"
                     )
                     if "message" in req.json():
-                        self.netlogger.warn("[Server] " + req.json()["message"])
+                        self.netlogger.warning("[Server] " + req.json()["message"])
                     return req
                 if req.headers["content-type"] != contentType:
-                    self.netlogger.warn(
-                        "Expected %s, received %s"
-                        % (contentType, req.headers["content-type"])
+                    self.netlogger.warning(
+                        f'Expected {contentType}, received {req.headers["content-type"]}'
                     )
                     return False
             elif reqType == "POST" and postData:
@@ -85,20 +84,22 @@ class NatlasNetworkServices:
                         os._exit(403)
                 if req.status_code == 400:
                     if "message" in req.json():
-                        self.netlogger.warn("[Server] " + req.json()["message"])
+                        self.netlogger.warning("[Server] " + req.json()["message"])
                     return req
                 if req.status_code != statusCode:
-                    self.netlogger.warn(
+                    self.netlogger.warning(
                         f"Expected {statusCode}, received {req.status_code}"
                     )
                     if "message" in req.json():
-                        self.netlogger.warn("[Server] " + req.json()["message"])
+                        self.netlogger.warning("[Server] " + req.json()["message"])
                     return req
         except requests.ConnectionError:
-            self.netlogger.warn(f"Connection Error connecting to {self.config.server}")
+            self.netlogger.warning(
+                f"Connection Error connecting to {self.config.server}"
+            )
             return False
         except requests.Timeout:
-            self.netlogger.warn(
+            self.netlogger.warning(
                 f"Request timed out after {self.config.request_timeout} seconds."
             )
             return False
@@ -133,9 +134,8 @@ class NatlasNetworkServices:
             if RETRY:
                 attempt += 1
                 if giveup and attempt == self.config.max_retries:
-                    self.netlogger.warn(
-                        "Request to %s failed %s times. Giving up"
-                        % (self.config.server, self.config.max_retries)
+                    self.netlogger.warning(
+                        f"Request to {self.config.server} failed {self.config.max_retries} times. Giving up"
                     )
                     return False
                 jitter = (
@@ -145,9 +145,8 @@ class NatlasNetworkServices:
                     min(self.config.backoff_max, self.config.backoff_base * 2**attempt)
                     + jitter
                 )
-                self.netlogger.warn(
-                    "Request to %s failed. Waiting %s seconds before retrying."
-                    % (self.config.server, current_sleep)
+                self.netlogger.warning(
+                    f"Request to {self.config.server} failed. Waiting {current_sleep} seconds before retrying."
                 )
                 time.sleep(current_sleep)
         return result
@@ -168,8 +167,7 @@ class NatlasNetworkServices:
                 != serviceData["sha256"]
             ):
                 self.netlogger.error(
-                    "hash provided by %s doesn't match locally computed hash of services"
-                    % self.config.server
+                    f"hash provided by {self.config.server} doesn't match locally computed hash of services"
                 )
                 return False
             with open(services_path, "w") as f:
@@ -219,8 +217,7 @@ class NatlasNetworkServices:
             and results.result["port_count"] >= 0
         ):
             self.netlogger.info(
-                "Submitting %s ports for %s"
-                % (results.result["port_count"], results.result["ip"])
+                f"Submitting {results.result['port_count']} ports for {results.result['ip']}"
             )
         elif not results.result["is_up"]:
             self.netlogger.info(

--- a/natlas-agent/natlas/scanresult.py
+++ b/natlas-agent/natlas/scanresult.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 
 class ScanResult:
@@ -10,14 +10,14 @@ class ScanResult:
             "scan_id": target_data["scan_id"],
             "agent_version": config.NATLAS_VERSION,
             "agent": config.agent_id if config.agent_id else "anonymous",
-            "scan_start": datetime.now(timezone.utc).isoformat(),
+            "scan_start": datetime.now(UTC).isoformat(),
         }
 
     def add_item(self, name, value):
         self.result[name] = value
 
     def scan_stop(self):
-        self.result["scan_stop"] = datetime.now(timezone.utc).isoformat()
+        self.result["scan_stop"] = datetime.now(UTC).isoformat()
 
     def is_up(self, status):
         self.result["is_up"] = status

--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -175,7 +175,7 @@ class ThreadScan(threading.Thread):
                 scope.set_extra("natlas_scan_id", work_item.target_data["scan_id"])
                 add_breadcrumb(
                     category="scan_workflow",
-                    message="Starting scan for %s" % work_item.target_data["target"],
+                    message=f"Starting scan for {work_item.target_data['target']}",
                     level="info",
                 )
                 try:

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC
 from datetime import datetime as dt
 from datetime import timezone as tz
 
@@ -98,7 +99,7 @@ def submit():
     data = request.get_json()
     newhost = {}
     newhost = json.loads(data)
-    newhost["ctime"] = dt.now(tz.utc)
+    newhost["ctime"] = dt.now(UTC)
     if newhost["scan_reason"] == "requested":
         mark_scan_completed(newhost["ip"], newhost["scan_id"])
 

--- a/natlas-server/app/util.py
+++ b/natlas-server/app/util.py
@@ -1,9 +1,9 @@
 import secrets
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 
 def utcnow_tz():
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def generate_hex_16():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,6 @@ select = [
     "C4",
     # isort
     "I",
+    # pyupgrade
+    "UP",
 ]


### PR DESCRIPTION
Pyupgrade helps to automatically update old idioms and patterns into more modern code. We can run the rules as part of ruff instead of as a separate hook, which is apparently good because it caught several upgrades that were previously being missed, apparently.