### PR TITLE
Ensure flynt is used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ select = [
     "B",
     # flake8-comprehensions
     "C4",
+    # flynt
+    "FLY",
     # isort
     "I",
     # Ruff's own rules


### PR DESCRIPTION
Flynt is a useful tool that encourages the use of f-strings. The FLY rule(s) as they stand are just a static string join fixer, but it's still valuable and given the speed of ruff, it's fine to enable.