### PR TITLE
Enable pylint

### DIFF
--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -59,6 +59,7 @@ def scan(target_data, config):
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=int(agentConfig["scanTimeout"]),
+            check=False,
         )  # nosec
     except subprocess.TimeoutExpired:
         add_breadcrumb(level="warn", message="Nmap scan timed out")

--- a/natlas-server/app/api/rescan_handler.py
+++ b/natlas-server/app/api/rescan_handler.py
@@ -9,7 +9,6 @@ def mark_scan_dispatched(rescan):
     db.session.commit()
     current_app.ScopeManager.update_pending_rescans()
     current_app.ScopeManager.update_dispatched_rescans()
-    return
 
 
 def mark_scan_completed(ip, scan_id):

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -64,9 +64,7 @@ class UserInvitation(db.Model, DictSerializable):
 
     # If a token is expired, mark it as such
     def expire_invite(self, timestamp):
-        if self.expiration_date >= timestamp:
-            # Mark now as the expiration because it's been redeemed
-            self.expiration_date = timestamp
+        self.expiration_date = min(timestamp, self.expiration_date)
 
         # Leave original expiration date intact since it's already past
         self.is_expired = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ select = [
     "FLY",
     # isort
     "I",
+    # pylint
+    "PL",
     # Ruff's own rules
     "RUF",
     # flake8-simplify
@@ -24,6 +26,13 @@ select = [
     "TID",
     # pyupgrade
     "UP",
+]
+ignore = [
+    "PLR2004",
+    "PLR0912",
+    "PLR0911",
+    "PLR0915",
+    "PLC0414"
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]


### PR DESCRIPTION
Pylint provides a bunch of useful rules as well, but a bunch of the rules are currently being violated due to my poor coding practices once upon a time. To get the linter in, I've marked the common issues as ignored for now, and I will revisit in the future to do things like reduce branching, reduce return statements, and reduce function size.