### PR TITLE
Enable toml-sort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
             - 'stylelint'
             - 'stylelint-config-standard-scss'
             - 'stylelint-scss'
+  - repo: https://github.com/pappasam/toml-sort
+    rev: v0.24.2
+    hooks:
+      - id: toml-sort
+        args: [--all, --in-place]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.8.4

--- a/natlas-agent/Pipfile
+++ b/natlas-agent/Pipfile
@@ -1,17 +1,17 @@
-[[source]]
-name = "pypi"
-url = "https://pypi.org/simple"
-verify_ssl = true
-
 [dev-packages]
 flake8 = "*"
 
 [packages]
+natlas-libnmap = "*"
+pillow = "*"
 python-dotenv = "~=1.0.1"
 requests = "~=2.31.0"
 sentry-sdk = "~=1.40.6"
-natlas-libnmap = "*"
-pillow = "*"
 
 [requires]
 python_version = "3.11"
+
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true

--- a/natlas-server/Pipfile
+++ b/natlas-server/Pipfile
@@ -1,37 +1,37 @@
-[[source]]
-name = "pypi"
-url = "https://pypi.org/simple"
-verify_ssl = true
-
 [dev-packages]
 flake8 = "*"
 pytest = "*"
 pytest-flask = "*"
 
 [packages]
-elasticsearch = "~=7.17.9"
-email-validator = "~=1.1.2"
 Flask-Login = "~=0.6.3"
 Flask-Mail = "~=0.9.1"
 Flask-Migrate = "~=4.0.7"
 Flask-SQLAlchemy = "~=3.1.1"
 Flask-WTF = "~=1.2.1"
-gunicorn = "~=20.1.0"
-netaddr = "~=0.8.0"
 Pillow = "~=10.2.0"
 PyJWT = "~=2.0.1"
+cyclicprng = "*"
+elasticsearch = "~=7.17.9"
+email-validator = "~=1.1.2"
+gunicorn = "~=20.1.0"
+mysqlclient = "*"
+natlas-libnmap = "*"
+netaddr = "~=0.8.0"
+opentelemetry-exporter-otlp = "~=1.23"
+opentelemetry-instrumentation-flask = "~=0.44b"
+opentelemetry-sdk = "~=1.23"
+python-dateutil = "*"
 python-dotenv = "~=0.17.0"
 semver = "~=2.13.0"
 sentry-sdk = "~=1.14.0"
 sympy = "~=1.8"
 webpack-manifest = "~=2.1.1"
-natlas-libnmap = "*"
-cyclicprng = "*"
-mysqlclient = "*"
-opentelemetry-sdk = "~=1.23"
-opentelemetry-exporter-otlp = "~=1.23"
-opentelemetry-instrumentation-flask = "~=0.44b"
-python-dateutil = "*"
 
 [requires]
 python_version = "3.12"
+
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,36 +5,36 @@ requires-python = "==3.11"
 [tool.ruff]
 
 [tool.ruff.lint]
-select = [
-    # flake8-bugbear
-    "B",
-    # flake8-comprehensions
-    "C4",
-    # pyflakes
-    "F",
-    # flynt
-    "FLY",
-    # isort
-    "I",
-    # pylint
-    "PL",
-    # flake8-return
-    "RET",
-    # Ruff's own rules
-    "RUF",
-    # flake8-simplify
-    "SIM",
-    # flake8-tidy-imports
-    "TID",
-    # pyupgrade
-    "UP",
-]
 ignore = [
-    "PLR2004",
-    "PLR0912",
-    "PLR0911",
-    "PLR0915",
-    "PLC0414"
+  "PLC0414",
+  "PLR0911",
+  "PLR0912",
+  "PLR0915",
+  "PLR2004"
+]
+select = [
+  # flake8-bugbear
+  "B",
+  # flake8-comprehensions
+  "C4",
+  # pyflakes
+  "F",
+  # flynt
+  "FLY",
+  # isort
+  "I",
+  # pylint
+  "PL",
+  # flake8-return
+  "RET",
+  # Ruff's own rules
+  "RUF",
+  # flake8-simplify
+  "SIM",
+  # flake8-tidy-imports
+  "TID",
+  # pyupgrade
+  "UP"
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]


### PR DESCRIPTION
Toml-sort enables the Pipfile (and other toml files) to be consistently ordered. This is especially helpful in cases where someone installs a new package with `pipenv install <package>` -- previously this would just get appended to the end of the list, which was... fine, but its hard to find packages in the list. By sorting, it ensures that the packages are always in a consistent order after a new package is installed.