### PR TITLE
Add mypy, mypy config, and bulk mark ignores

### DIFF
--- a/natlas-agent/Pipfile
+++ b/natlas-agent/Pipfile
@@ -1,5 +1,6 @@
 [dev-packages]
 flake8 = "*"
+mypy = "~=1.14"
 
 [packages]
 natlas-libnmap = "*"

--- a/natlas-agent/Pipfile.lock
+++ b/natlas-agent/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c194110136c2800d487c35bf682acbb027e724bd3d37b51c58ffac687cc4b94a"
+            "sha256": "234b7d5a9796b0fa8e411ffeba5ed1dde85e5d68122802e9173dc4a670e95aa8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -284,6 +284,59 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.7.0"
         },
+        "mypy": {
+            "hashes": [
+                "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c",
+                "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd",
+                "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f",
+                "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0",
+                "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9",
+                "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b",
+                "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14",
+                "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35",
+                "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319",
+                "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc",
+                "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb",
+                "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb",
+                "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e",
+                "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60",
+                "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31",
+                "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f",
+                "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6",
+                "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107",
+                "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11",
+                "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a",
+                "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837",
+                "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6",
+                "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b",
+                "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d",
+                "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255",
+                "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae",
+                "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1",
+                "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8",
+                "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b",
+                "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac",
+                "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9",
+                "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9",
+                "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1",
+                "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34",
+                "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427",
+                "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1",
+                "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c",
+                "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.14.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
         "pycodestyle": {
             "hashes": [
                 "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3",
@@ -299,6 +352,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.2.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.12.2"
         }
     }
 }

--- a/natlas-agent/config.py
+++ b/natlas-agent/config.py
@@ -10,13 +10,13 @@ class Config:
     BASEDIR = os.path.abspath(os.path.dirname(__file__))
     load_dotenv(os.path.join(BASEDIR, ".env"))
 
-    def get_int(self, varname):
+    def get_int(self, varname):  # type: ignore[no-untyped-def]
         tmp = os.environ.get(varname)
         if tmp:
             return int(tmp)
         return None
 
-    def get_bool(self, varname):
+    def get_bool(self, varname):  # type: ignore[no-untyped-def]
         tmp = os.environ.get(varname)
         if tmp and tmp.upper() == "TRUE":
             return True
@@ -24,7 +24,7 @@ class Config:
             return False
         return None
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         # url of server to get/submit work from/to
         self.server = os.environ.get("NATLAS_SERVER_ADDRESS") or "http://127.0.0.1:5000"
 

--- a/natlas-agent/natlas-agent.py
+++ b/natlas-agent/natlas-agent.py
@@ -25,7 +25,7 @@ global_logger = logging.get_logger("MainThread")
 netsrv = NatlasNetworkServices(config)
 
 
-def add_targets_to_queue(target, q):
+def add_targets_to_queue(target, q):  # type: ignore[no-untyped-def]
     targetNetwork = ipaddress.ip_network(target.strip())
     if targetNetwork.num_addresses == 1:
         target_data = netsrv.get_work(target=str(targetNetwork.network_address))
@@ -41,7 +41,7 @@ def add_targets_to_queue(target, q):
             q.put(target_data)
 
 
-def main():
+def main():  # type: ignore[no-untyped-def]
     PARSER_DESC = "Scan hosts and report data to a configured server. The server will reject your findings if they are deemed not in scope."
     PARSER_EPILOG = "Report problems to https://github.com/natlas/natlas"
     parser = argparse.ArgumentParser(
@@ -91,7 +91,7 @@ def main():
 
     # Initialize SentryIo after basic environment checks complete
     error_reporting.initialize_sentryio(config)
-    q = queue.Queue(maxsize=MAX_QUEUE_SIZE)
+    q = queue.Queue(maxsize=MAX_QUEUE_SIZE)  # type: ignore[var-annotated]
 
     servicesSha = ""
     SERVICESPATH = utils.get_services_path()

--- a/natlas-agent/natlas/error_reporting.py
+++ b/natlas-agent/natlas/error_reporting.py
@@ -4,7 +4,7 @@ import sentry_sdk
 from config import Config
 
 
-def initialize_sentryio(config: Config):
+def initialize_sentryio(config: Config):  # type: ignore[no-untyped-def]
     if config.sentry_dsn:
         url = urlparse(config.sentry_dsn)
         print(

--- a/natlas-agent/natlas/logging.py
+++ b/natlas-agent/natlas/logging.py
@@ -12,26 +12,26 @@ logging.Formatter.converter = time.gmtime  # Always log in GMT
 conf = Config()
 
 
-def setup_logging_dir():
+def setup_logging_dir():  # type: ignore[no-untyped-def]
     log_dir = os.path.join(conf.data_dir, "logs")
     Path(log_dir).mkdir(parents=True, exist_ok=True)
     return log_dir
 
 
-def get_console_handler():
+def get_console_handler():  # type: ignore[no-untyped-def]
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(FORMATTER)
     return console_handler
 
 
-def get_file_handler(log_dir):
+def get_file_handler(log_dir):  # type: ignore[no-untyped-def]
     log_file = os.path.join(log_dir, "agent.log")
     file_handler = RotatingFileHandler(log_file, maxBytes=1024 * 1024, backupCount=5)
     file_handler.setFormatter(FORMATTER)
     return file_handler
 
 
-def get_logger(name):
+def get_logger(name):  # type: ignore[no-untyped-def]
     log_dir = setup_logging_dir()
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)

--- a/natlas-agent/natlas/net.py
+++ b/natlas-agent/natlas/net.py
@@ -6,12 +6,13 @@ import time
 from typing import ClassVar
 
 import requests
-from natlas import logging, utils
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
+
+from natlas import logging, utils
 
 
 class NatlasNetworkServices:
-    config = None
+    config = None  # type: ignore[var-annotated]
     netlogger = logging.get_logger("NetworkServices")
 
     api_endpoints: ClassVar = {
@@ -20,13 +21,13 @@ class NatlasNetworkServices:
         "SUBMIT": "/api/submit",
     }
 
-    def __init__(self, config):
+    def __init__(self, config):  # type: ignore[no-untyped-def]
         self.config = config
 
         if self.config.ignore_ssl_warn:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-    def make_request(
+    def make_request(  # type: ignore[no-untyped-def]
         self,
         endpoint,
         reqType="GET",
@@ -34,18 +35,18 @@ class NatlasNetworkServices:
         contentType="application/json",
         statusCode=200,
     ):
-        headers = {"user-agent": f"natlas-agent/{self.config.NATLAS_VERSION}"}
-        if self.config.agent_id and self.config.auth_token:
-            authheader = self.config.agent_id + ":" + self.config.auth_token
+        headers = {"user-agent": f"natlas-agent/{self.config.NATLAS_VERSION}"}  # type: ignore[union-attr]
+        if self.config.agent_id and self.config.auth_token:  # type: ignore[union-attr]
+            authheader = self.config.agent_id + ":" + self.config.auth_token  # type: ignore[union-attr]
             headers["Authorization"] = f"Bearer {authheader}"
         args = {
-            "timeout": self.config.request_timeout,
+            "timeout": self.config.request_timeout,  # type: ignore[union-attr]
             "headers": headers,
-            "verify": not self.config.ignore_ssl_warn,
+            "verify": not self.config.ignore_ssl_warn,  # type: ignore[union-attr]
         }
         try:
             if reqType == "GET":
-                req = requests.get(self.config.server + endpoint, **args)
+                req = requests.get(self.config.server + endpoint, **args)  # type: ignore[union-attr]
                 if req.status_code == 200:
                     if "message" in req.json():
                         self.netlogger.info("[Server] " + req.json()["message"])
@@ -73,7 +74,7 @@ class NatlasNetworkServices:
                     return False
             elif reqType == "POST" and postData:
                 args["json"] = postData
-                req = requests.post(self.config.server + endpoint, **args)
+                req = requests.post(self.config.server + endpoint, **args)  # type: ignore[union-attr]
                 if req.status_code == 200:
                     if "message" in req.json():
                         self.netlogger.info("[Server] " + req.json()["message"])
@@ -96,21 +97,21 @@ class NatlasNetworkServices:
                     return req
         except requests.ConnectionError:
             self.netlogger.warning(
-                f"Connection Error connecting to {self.config.server}"
+                f"Connection Error connecting to {self.config.server}"  # type: ignore[union-attr]
             )
             return False
         except requests.Timeout:
             self.netlogger.warning(
-                f"Request timed out after {self.config.request_timeout} seconds."
+                f"Request timed out after {self.config.request_timeout} seconds."  # type: ignore[union-attr]
             )
             return False
         except ValueError as e:
             self.netlogger.error(f"Error: {e}")
             return False
 
-        return req
+        return req  # type: ignore[possibly-undefined]
 
-    def backoff_request(self, giveup=False, *args, **kwargs):
+    def backoff_request(self, giveup=False, *args, **kwargs):  # type: ignore[no-untyped-def]
         attempt = 0
         result = None
         while not result:
@@ -134,33 +135,33 @@ class NatlasNetworkServices:
 
             if RETRY:
                 attempt += 1
-                if giveup and attempt == self.config.max_retries:
+                if giveup and attempt == self.config.max_retries:  # type: ignore[union-attr]
                     self.netlogger.warning(
-                        f"Request to {self.config.server} failed {self.config.max_retries} times. Giving up"
+                        f"Request to {self.config.server} failed {self.config.max_retries} times. Giving up"  # type: ignore[union-attr]
                     )
                     return False
                 jitter = (
                     random.randint(0, 1000) / 1000
                 )  # jitter to reduce chance of locking
                 current_sleep = (
-                    min(self.config.backoff_max, self.config.backoff_base * 2**attempt)
+                    min(self.config.backoff_max, self.config.backoff_base * 2**attempt)  # type: ignore[union-attr]
                     + jitter
                 )
                 self.netlogger.warning(
-                    f"Request to {self.config.server} failed. Waiting {current_sleep} seconds before retrying."
+                    f"Request to {self.config.server} failed. Waiting {current_sleep} seconds before retrying."  # type: ignore[union-attr]
                 )
                 time.sleep(current_sleep)
-        return result
+        return result  # type: ignore[unreachable]
 
-    def get_services_file(self):
-        self.netlogger.info(f"Fetching natlas-services file from {self.config.server}")
+    def get_services_file(self):  # type: ignore[no-untyped-def]
+        self.netlogger.info(f"Fetching natlas-services file from {self.config.server}")  # type: ignore[union-attr]
         services_path = utils.get_services_path()
         response = self.backoff_request(endpoint=self.api_endpoints["GETSERVICES"])
         if response:
             serviceData = response.json()
             if serviceData["id"] == "None":
                 self.netlogger.error(
-                    f"{self.config.server} doesn't have a service file for us"
+                    f"{self.config.server} doesn't have a service file for us"  # type: ignore[union-attr]
                 )
                 return False
             if (
@@ -168,7 +169,7 @@ class NatlasNetworkServices:
                 != serviceData["sha256"]
             ):
                 self.netlogger.error(
-                    f"hash provided by {self.config.server} doesn't match locally computed hash of services"
+                    f"hash provided by {self.config.server} doesn't match locally computed hash of services"  # type: ignore[union-attr]
                 )
                 return False
             with open(services_path, "w") as f:
@@ -188,14 +189,14 @@ class NatlasNetworkServices:
             "sha256"
         ]  # return True if we got a response and everything checks out
 
-    def get_work(self, target=None):
+    def get_work(self, target=None):  # type: ignore[no-untyped-def]
         if target:
             self.netlogger.info(
-                f"Getting work config for {target} from {self.config.server}"
+                f"Getting work config for {target} from {self.config.server}"  # type: ignore[union-attr]
             )
             get_work_endpoint = self.api_endpoints["GETWORK"] + "?target=" + target
         else:
-            self.netlogger.info(f"Getting work from {self.config.server}")
+            self.netlogger.info(f"Getting work from {self.config.server}")  # type: ignore[union-attr]
             get_work_endpoint = self.api_endpoints["GETWORK"]
 
         response = self.backoff_request(endpoint=get_work_endpoint)
@@ -206,7 +207,7 @@ class NatlasNetworkServices:
         return work
 
     # Results is a ScanResult object
-    def submit_results(self, results):
+    def submit_results(self, results):  # type: ignore[no-untyped-def]
         if results.result.get("timed_out"):
             self.netlogger.info(
                 f"Submitting scan timeout notice for {results.result['ip']}"

--- a/natlas-agent/natlas/scanresult.py
+++ b/natlas-agent/natlas/scanresult.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 
 
 class ScanResult:
-    def __init__(self, target_data, config):
+    def __init__(self, target_data, config):  # type: ignore[no-untyped-def]
         self.result = {
             "ip": target_data["target"],
             "scan_reason": target_data["scan_reason"],
@@ -13,16 +13,16 @@ class ScanResult:
             "scan_start": datetime.now(UTC).isoformat(),
         }
 
-    def add_item(self, name, value):
+    def add_item(self, name, value):  # type: ignore[no-untyped-def]
         self.result[name] = value
 
-    def scan_stop(self):
+    def scan_stop(self):  # type: ignore[no-untyped-def]
         self.result["scan_stop"] = datetime.now(UTC).isoformat()
 
-    def is_up(self, status):
+    def is_up(self, status):  # type: ignore[no-untyped-def]
         self.result["is_up"] = status
 
-    def add_screenshot(self, screenshot):
+    def add_screenshot(self, screenshot):  # type: ignore[no-untyped-def]
         if "screenshots" not in self.result:
             self.result["screenshots"] = []
         self.result["screenshots"].append(screenshot)

--- a/natlas-agent/natlas/screenshots.py
+++ b/natlas-agent/natlas/screenshots.py
@@ -7,8 +7,9 @@ import subprocess
 import time
 from urllib.parse import urlparse
 
-from natlas import logging, utils
 from PIL import Image, UnidentifiedImageError
+
+from natlas import logging, utils
 
 logger = logging.get_logger("ScreenshotUtils")
 
@@ -26,14 +27,14 @@ def is_valid_image(path: str) -> bool:
         return False
 
 
-def parse_url(url: str) -> tuple:
+def parse_url(url: str) -> tuple:  # type: ignore[type-arg]
     urlp = urlparse(url)
     port = (80 if urlp.scheme == "http" else 443) if not urlp.port else urlp.port
 
     return urlp.scheme.upper(), port
 
 
-def parse_aquatone_page(page: dict, file_path: str) -> dict:
+def parse_aquatone_page(page: dict, file_path: str) -> dict:  # type: ignore[type-arg]
     if not (page["hasScreenshot"] and is_valid_image(file_path)):
         return {}
     scheme, port = parse_url(page["url"])
@@ -46,7 +47,7 @@ def parse_aquatone_page(page: dict, file_path: str) -> dict:
     }
 
 
-def get_aquatone_session(base_dir: str) -> dict:
+def get_aquatone_session(base_dir: str) -> dict:  # type: ignore[type-arg]
     session_path = os.path.join(base_dir, "aquatone_session.json")
     if not os.path.isfile(session_path):
         return {}
@@ -56,10 +57,10 @@ def get_aquatone_session(base_dir: str) -> dict:
 
     if session["stats"]["screenshotSuccessful"] == 0:
         return {}
-    return session
+    return session  # type: ignore[no-any-return]
 
 
-def parse_aquatone_session(base_dir: str) -> list:
+def parse_aquatone_session(base_dir: str) -> list:  # type: ignore[type-arg]
     session = get_aquatone_session(base_dir)
     if not session:
         return []
@@ -75,7 +76,7 @@ def parse_aquatone_session(base_dir: str) -> list:
     return output
 
 
-def get_web_screenshots(target, scan_id, proctimeout):
+def get_web_screenshots(target, scan_id, proctimeout):  # type: ignore[no-untyped-def]
     scan_dir = utils.get_scan_dir(scan_id)
     xml_file = os.path.join(scan_dir, f"nmap.{scan_id}.xml")
     output_dir = os.path.join(scan_dir, f"aquatone.{scan_id}")
@@ -107,7 +108,7 @@ def get_web_screenshots(target, scan_id, proctimeout):
     return parse_aquatone_session(output_dir)
 
 
-def get_vnc_screenshots(target, scan_id, proctimeout):
+def get_vnc_screenshots(target, scan_id, proctimeout):  # type: ignore[no-untyped-def]
     scan_dir = utils.get_scan_dir(scan_id)
     output_file = os.path.join(scan_dir, f"vncsnapshot.{scan_id}.jpg")
 

--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -5,16 +5,17 @@ import threading
 
 from config import Config
 from libnmap.parser import NmapParser, NmapParserException
+from sentry_sdk import add_breadcrumb, capture_exception, push_scope
+
 from natlas import logging, screenshots, utils
 from natlas.net import NatlasNetworkServices
 from natlas.scanresult import ScanResult
-from sentry_sdk import add_breadcrumb, capture_exception, push_scope
 
 logger = logging.get_logger("AgentThread")
 conf = Config()
 
 
-def command_builder(scan_id, agentConfig, target):
+def command_builder(scan_id, agentConfig, target):  # type: ignore[no-untyped-def]
     outFiles = os.path.join(utils.get_scan_dir(scan_id), f"nmap.{scan_id}")
     servicepath = utils.get_services_path()
     command = ["nmap", "--privileged", "-oA", outFiles, "--servicedb", servicepath]
@@ -40,7 +41,7 @@ def command_builder(scan_id, agentConfig, target):
     return command
 
 
-def scan(target_data, config):
+def scan(target_data, config):  # type: ignore[no-untyped-def]
     if not utils.validate_target(target_data["target"], config):
         return False
     target = target_data["target"]
@@ -117,25 +118,25 @@ def scan(target_data, config):
 
 
 class ScanWorkItem:
-    def __init__(self, target_data):
+    def __init__(self, target_data):  # type: ignore[no-untyped-def]
         self.target_data = target_data
 
-    def complete(self):
+    def complete(self):  # type: ignore[no-untyped-def]
         pass
 
 
 class ManualScanWorkItem(ScanWorkItem):
-    def __init__(self, queue, target_data):
+    def __init__(self, queue, target_data):  # type: ignore[no-untyped-def]
         super().__init__(target_data)
         self.queue = queue
 
-    def complete(self):
+    def complete(self):  # type: ignore[no-untyped-def]
         super()
         self.queue.task_done()
 
 
 class ThreadScan(threading.Thread):
-    def __init__(self, queue, config, auto=False, servicesSha=""):
+    def __init__(self, queue, config, auto=False, servicesSha=""):  # type: ignore[no-untyped-def]
         threading.Thread.__init__(self)
         self.queue = queue
         self.auto = auto
@@ -143,7 +144,7 @@ class ThreadScan(threading.Thread):
         self.config = config
         self.netsrv = NatlasNetworkServices(self.config)
 
-    def execute_scan(self, work_item):
+    def execute_scan(self, work_item):  # type: ignore[no-untyped-def]
         target_data = work_item.target_data
         utils.create_scan_dir(target_data["scan_id"])
         # setting this here ensures the finally block won't error if we don't submit data
@@ -162,7 +163,7 @@ class ThreadScan(threading.Thread):
                 target_data["scan_id"], failed=didFail, saveFails=self.config.save_fails
             )
 
-    def run(self):
+    def run(self):  # type: ignore[no-untyped-def]
         while True:
             with push_scope() as scope:
                 add_breadcrumb(
@@ -192,7 +193,7 @@ class ThreadScan(threading.Thread):
                         f"Failed to process work item: {e}. Sentry event id: {event_id}"
                     )
 
-    def get_work(self):
+    def get_work(self):  # type: ignore[no-untyped-def]
         # If we're in auto mode, the threads handle getting work from the server
         if self.auto:
             target_data = self.netsrv.get_work()

--- a/natlas-agent/natlas/utils.py
+++ b/natlas-agent/natlas/utils.py
@@ -4,13 +4,14 @@ import shutil
 from pathlib import Path
 
 from config import Config
+
 from natlas import logging
 
 utillogger = logging.get_logger("Utilities")
 conf = Config()
 
 
-def validate_target(target, config):
+def validate_target(target, config):  # type: ignore[no-untyped-def]
     try:
         iptarget = ipaddress.ip_address(target)
         if iptarget.is_private and not config.scan_local:
@@ -22,29 +23,29 @@ def validate_target(target, config):
     return True
 
 
-def get_conf_dir():
+def get_conf_dir():  # type: ignore[no-untyped-def]
     return os.path.join(conf.data_dir, "conf")
 
 
-def get_services_path():
+def get_services_path():  # type: ignore[no-untyped-def]
     return os.path.join(get_conf_dir(), "natlas-services")
 
 
-def get_scan_dir(scan_id):
+def get_scan_dir(scan_id):  # type: ignore[no-untyped-def]
     return os.path.join(conf.data_dir, "scans", f"natlas.{scan_id}")
 
 
-def create_scan_dir(scan_id):
+def create_scan_dir(scan_id):  # type: ignore[no-untyped-def]
     Path(get_scan_dir(scan_id)).mkdir(parents=True, exist_ok=True)
 
 
-def delete_files(scan_id):
+def delete_files(scan_id):  # type: ignore[no-untyped-def]
     scan_dir = get_scan_dir(scan_id)
     if os.path.isdir(scan_dir):
         shutil.rmtree(scan_dir)
 
 
-def save_files(scan_id):
+def save_files(scan_id):  # type: ignore[no-untyped-def]
     failroot = os.path.join(conf.data_dir, "scans", "failures")
     scan_dir = get_scan_dir(scan_id)
     Path(failroot).mkdir(parents=True, exist_ok=True)
@@ -54,7 +55,7 @@ def save_files(scan_id):
         shutil.move(src, dst)
 
 
-def cleanup_files(scan_id, failed=False, saveFails=False):
+def cleanup_files(scan_id, failed=False, saveFails=False):  # type: ignore[no-untyped-def]
     utillogger.info(f"Cleaning up files for {scan_id}")
     if saveFails and failed:
         save_files(scan_id)

--- a/natlas-server/Pipfile
+++ b/natlas-server/Pipfile
@@ -1,5 +1,5 @@
 [dev-packages]
-flake8 = "*"
+mypy = "~=1.14"
 pytest = "*"
 pytest-flask = "*"
 

--- a/natlas-server/Pipfile.lock
+++ b/natlas-server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a150158f429a6e888b76b029ddf49faa026092e9c7fd3e7798726578014e700"
+            "sha256": "5848210305fa9daf848bccf3ab9b53f1735d138b326e681e127e10a732812859"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,131 +18,133 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:2edcc97bed0bd3272611ce3a98d98279e9c209e7186e43e75bbb1b2bdfdbcc43",
-                "sha256:4932c8558bf68f2ee92b9bbcb8218671c627064d5b08939437af6d77dc05e595"
+                "sha256:99bd884ca390466db5e27ffccff1d179ec5c05c965cfefc0607e69f9e411cb25",
+                "sha256:b00892b53b3642d0b8dbedba234dbf1924b69be83a9a769d5a624b01094e304b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.13.1"
+            "version": "==1.14.0"
         },
         "blinker": {
             "hashes": [
-                "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9",
-                "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182"
+                "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf",
+                "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.7.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
-                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.2.2"
+            "version": "==2024.12.14"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027",
-                "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087",
-                "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786",
-                "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8",
-                "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09",
-                "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185",
-                "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574",
-                "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e",
-                "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519",
-                "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898",
-                "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269",
-                "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3",
-                "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f",
-                "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6",
-                "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8",
-                "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a",
-                "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73",
-                "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc",
-                "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714",
-                "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2",
-                "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc",
-                "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce",
-                "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d",
-                "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e",
-                "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6",
-                "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269",
-                "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96",
-                "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d",
-                "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a",
-                "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4",
-                "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77",
-                "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d",
-                "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0",
-                "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed",
-                "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068",
-                "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac",
-                "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25",
-                "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8",
-                "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab",
-                "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26",
-                "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2",
-                "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db",
-                "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f",
-                "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5",
-                "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99",
-                "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c",
-                "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d",
-                "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811",
-                "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa",
-                "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a",
-                "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03",
-                "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b",
-                "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04",
-                "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c",
-                "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001",
-                "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458",
-                "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389",
-                "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99",
-                "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985",
-                "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537",
-                "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238",
-                "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f",
-                "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d",
-                "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796",
-                "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a",
-                "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143",
-                "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8",
-                "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c",
-                "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5",
-                "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5",
-                "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711",
-                "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4",
-                "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6",
-                "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c",
-                "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7",
-                "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4",
-                "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b",
-                "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae",
-                "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12",
-                "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c",
-                "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae",
-                "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8",
-                "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887",
-                "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b",
-                "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4",
-                "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f",
-                "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5",
-                "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33",
-                "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519",
-                "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"
+                "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537",
+                "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa",
+                "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a",
+                "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294",
+                "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b",
+                "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd",
+                "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601",
+                "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd",
+                "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4",
+                "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d",
+                "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2",
+                "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313",
+                "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd",
+                "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa",
+                "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8",
+                "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1",
+                "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2",
+                "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496",
+                "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d",
+                "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b",
+                "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e",
+                "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a",
+                "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4",
+                "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca",
+                "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78",
+                "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408",
+                "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5",
+                "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3",
+                "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f",
+                "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a",
+                "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765",
+                "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6",
+                "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146",
+                "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6",
+                "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9",
+                "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd",
+                "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c",
+                "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f",
+                "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545",
+                "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176",
+                "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770",
+                "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824",
+                "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f",
+                "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf",
+                "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487",
+                "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d",
+                "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd",
+                "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b",
+                "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534",
+                "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f",
+                "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b",
+                "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9",
+                "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd",
+                "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125",
+                "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9",
+                "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de",
+                "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11",
+                "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d",
+                "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35",
+                "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f",
+                "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda",
+                "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7",
+                "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a",
+                "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971",
+                "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8",
+                "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41",
+                "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d",
+                "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f",
+                "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757",
+                "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a",
+                "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886",
+                "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77",
+                "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76",
+                "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247",
+                "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85",
+                "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb",
+                "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7",
+                "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e",
+                "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6",
+                "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037",
+                "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1",
+                "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e",
+                "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807",
+                "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407",
+                "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c",
+                "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12",
+                "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3",
+                "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089",
+                "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd",
+                "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e",
+                "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00",
+                "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"
             ],
-            "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.3.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.1"
         },
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
+            "version": "==8.1.8"
         },
         "cyclicprng": {
             "hashes": [
@@ -162,28 +164,28 @@
         },
         "deprecated": {
             "hashes": [
-                "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c",
-                "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"
+                "sha256:353bc4a8ac4bfc96800ddab349d89c25dec1079f65fd53acdcc1e0b975b21320",
+                "sha256:683e561a90de76239796e6b6feac66b99030d2dd3fcf61ef996330f14bbb9b0d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.2.14"
+            "version": "==1.2.15"
         },
         "dnspython": {
             "hashes": [
-                "sha256:5ef3b9680161f6fa89daf8ad451b5f1a33b18ae8a1c6778cdf4b43f08c0a6e50",
-                "sha256:e8f0f9c23a7b7cb99ded64e6c3a6f3e701d78f50c55e002b839dea7225cff7cc"
+                "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86",
+                "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.6.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.7.0"
         },
         "elasticsearch": {
             "hashes": [
-                "sha256:0e2454645dc00517dee4c6de3863411a9c5f1955d013c5fefa29123dadc92f98",
-                "sha256:66c4ece2adfe7cc120e2b6a6798a1fd5c777aecf82eec39bb95cef7cfc7ea2b3"
+                "sha256:468fd5eef703c0d9238e29bcaf3a6fe4d6b092f917959fbf41f48f8fea3df2f8",
+                "sha256:a1f5733ae8cf1dbf0a78593389f2503c87dd97429976099832bf0626cdfaac8b"
             ],
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
-            "version": "==7.17.9"
+            "version": "==7.17.12"
         },
         "email-validator": {
             "hashes": [
@@ -196,11 +198,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e",
-                "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d"
+                "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac",
+                "sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.0"
         },
         "flask-login": {
             "hashes": [
@@ -238,144 +240,160 @@
         },
         "flask-wtf": {
             "hashes": [
-                "sha256:8bb269eb9bb46b87e7c8233d7e7debdf1f8b74bf90cc1789988c29b37a97b695",
-                "sha256:fa6793f2fb7e812e0fe9743b282118e581fb1b6c45d414b8af05e659bd653287"
+                "sha256:79d2ee1e436cf570bccb7d916533fa18757a2f18c290accffab1b9a0b684666b",
+                "sha256:e93160c5c5b6b571cf99300b6e01b72f9a101027cab1579901f8b10c5daf0b70"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==1.2.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.2.2"
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e",
-                "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"
+                "sha256:c3e7b33d15fdca5374cc0a7346dd92ffa847425cc4ea941d970f13680052ec8c",
+                "sha256:d7abcd75fabb2e0ec9f74466401f6c119a0b498e27370e9be4c94cb7e382b8ed"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.63.0"
+            "version": "==1.66.0"
         },
         "greenlet": {
             "hashes": [
-                "sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67",
-                "sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6",
-                "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257",
-                "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4",
-                "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676",
-                "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61",
-                "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc",
-                "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca",
-                "sha256:1a7191e42732df52cb5f39d3527217e7ab73cae2cb3694d241e18f53d84ea9a7",
-                "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728",
-                "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305",
-                "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
-                "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379",
-                "sha256:2dd6e660effd852586b6a8478a1d244b8dc90ab5b1321751d2ea15deb49ed414",
-                "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04",
-                "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a",
-                "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf",
-                "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491",
-                "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559",
-                "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e",
-                "sha256:5b51e85cb5ceda94e79d019ed36b35386e8c37d22f07d6a751cb659b180d5274",
-                "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb",
-                "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b",
-                "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9",
-                "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b",
-                "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be",
-                "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506",
-                "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405",
-                "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113",
-                "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f",
-                "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5",
-                "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230",
-                "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d",
-                "sha256:99bf650dc5d69546e076f413a87481ee1d2d09aaaaaca058c9251b6d8c14783f",
-                "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a",
-                "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e",
-                "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61",
-                "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6",
-                "sha256:b542be2440edc2d48547b5923c408cbe0fc94afb9f18741faa6ae970dbcb9b6d",
-                "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71",
-                "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22",
-                "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2",
-                "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3",
-                "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067",
-                "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc",
-                "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881",
-                "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3",
-                "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e",
-                "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac",
-                "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53",
-                "sha256:daf3cb43b7cf2ba96d614252ce1684c1bccee6b2183a01328c98d36fcd7d5cb0",
-                "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b",
-                "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83",
-                "sha256:e1f145462f1fa6e4a4ae3c0f782e580ce44d57c8f2c7aae1b6fa88c0b2efdb41",
-                "sha256:e3391d1e16e2a5a1507d83e4a8b100f4ee626e8eca43cf2cadb543de69827c4c",
-                "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf",
-                "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da",
-                "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"
+                "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e",
+                "sha256:03a088b9de532cbfe2ba2034b2b85e82df37874681e8c470d6fb2f8c04d7e4b7",
+                "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01",
+                "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1",
+                "sha256:09fc016b73c94e98e29af67ab7b9a879c307c6731a2c9da0db5a7d9b7edd1159",
+                "sha256:0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563",
+                "sha256:0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83",
+                "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9",
+                "sha256:1776fd7f989fc6b8d8c8cb8da1f6b82c5814957264d1f6cf818d475ec2bf6395",
+                "sha256:1d3755bcb2e02de341c55b4fca7a745a24a9e7212ac953f6b3a48d117d7257aa",
+                "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942",
+                "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1",
+                "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441",
+                "sha256:3319aa75e0e0639bc15ff54ca327e8dc7a6fe404003496e3c6925cd3142e0e22",
+                "sha256:346bed03fe47414091be4ad44786d1bd8bef0c3fcad6ed3dee074a032ab408a9",
+                "sha256:36b89d13c49216cadb828db8dfa6ce86bbbc476a82d3a6c397f0efae0525bdd0",
+                "sha256:37b9de5a96111fc15418819ab4c4432e4f3c2ede61e660b1e33971eba26ef9ba",
+                "sha256:396979749bd95f018296af156201d6211240e7a23090f50a8d5d18c370084dc3",
+                "sha256:3b2813dc3de8c1ee3f924e4d4227999285fd335d1bcc0d2be6dc3f1f6a318ec1",
+                "sha256:411f015496fec93c1c8cd4e5238da364e1da7a124bcb293f085bf2860c32c6f6",
+                "sha256:47da355d8687fd65240c364c90a31569a133b7b60de111c255ef5b606f2ae291",
+                "sha256:48ca08c771c268a768087b408658e216133aecd835c0ded47ce955381105ba39",
+                "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d",
+                "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467",
+                "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475",
+                "sha256:54558ea205654b50c438029505def3834e80f0869a70fb15b871c29b4575ddef",
+                "sha256:5e06afd14cbaf9e00899fae69b24a32f2196c19de08fcb9f4779dd4f004e5e7c",
+                "sha256:62ee94988d6b4722ce0028644418d93a52429e977d742ca2ccbe1c4f4a792511",
+                "sha256:63e4844797b975b9af3a3fb8f7866ff08775f5426925e1e0bbcfe7932059a12c",
+                "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822",
+                "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a",
+                "sha256:6ef9ea3f137e5711f0dbe5f9263e8c009b7069d8a1acea822bd5e9dae0ae49c8",
+                "sha256:7017b2be767b9d43cc31416aba48aab0d2309ee31b4dbf10a1d38fb7972bdf9d",
+                "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01",
+                "sha256:73aaad12ac0ff500f62cebed98d8789198ea0e6f233421059fa68a5aa7220145",
+                "sha256:77c386de38a60d1dfb8e55b8c1101d68c79dfdd25c7095d51fec2dd800892b80",
+                "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13",
+                "sha256:7939aa3ca7d2a1593596e7ac6d59391ff30281ef280d8632fa03d81f7c5f955e",
+                "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b",
+                "sha256:85f3ff71e2e60bd4b4932a043fbbe0f499e263c628390b285cb599154a3b03b1",
+                "sha256:8b8b36671f10ba80e159378df9c4f15c14098c4fd73a36b9ad715f057272fbef",
+                "sha256:93147c513fac16385d1036b7e5b102c7fbbdb163d556b791f0f11eada7ba65dc",
+                "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff",
+                "sha256:94b6150a85e1b33b40b1464a3f9988dcc5251d6ed06842abff82e42632fac120",
+                "sha256:94ebba31df2aa506d7b14866fed00ac141a867e63143fe5bca82a8e503b36437",
+                "sha256:95ffcf719966dd7c453f908e208e14cde192e09fde6c7186c8f1896ef778d8cd",
+                "sha256:98884ecf2ffb7d7fe6bd517e8eb99d31ff7855a840fa6d0d63cd07c037f6a981",
+                "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36",
+                "sha256:9e8f8c9cb53cdac7ba9793c276acd90168f416b9ce36799b9b885790f8ad6c0a",
+                "sha256:a0dfc6c143b519113354e780a50381508139b07d2177cb6ad6a08278ec655798",
+                "sha256:b2795058c23988728eec1f36a4e5e4ebad22f8320c85f3587b539b9ac84128d7",
+                "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761",
+                "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0",
+                "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e",
+                "sha256:b8da394b34370874b4572676f36acabac172602abf054cbc4ac910219f3340af",
+                "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa",
+                "sha256:c4aab7f6381f38a4b42f269057aee279ab0fc7bf2e929e3d4abfae97b682a12c",
+                "sha256:ca9d0ff5ad43e785350894d97e13633a66e2b50000e8a183a50a88d834752d42",
+                "sha256:d0028e725ee18175c6e422797c407874da24381ce0690d6b9396c204c7f7276e",
+                "sha256:d21e10da6ec19b457b82636209cbe2331ff4306b54d06fa04b7c138ba18c8a81",
+                "sha256:d5e975ca70269d66d17dd995dafc06f1b06e8cb1ec1e9ed54c1d1e4a7c4cf26e",
+                "sha256:da7a9bff22ce038e19bf62c4dd1ec8391062878710ded0a845bcf47cc0200617",
+                "sha256:db32b5348615a04b82240cc67983cb315309e88d444a288934ee6ceaebcad6cc",
+                "sha256:dcc62f31eae24de7f8dce72134c8651c58000d3b1868e01392baea7c32c247de",
+                "sha256:dfc59d69fc48664bc693842bd57acfdd490acafda1ab52c7836e3fc75c90a111",
+                "sha256:e347b3bfcf985a05e8c0b7d462ba6f15b1ee1c909e2dcad795e49e91b152c383",
+                "sha256:e4d333e558953648ca09d64f13e6d8f0523fa705f51cae3f03b5983489958c70",
+                "sha256:ed10eac5830befbdd0c32f83e8aa6288361597550ba669b04c48f0f9a2c843c6",
+                "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4",
+                "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011",
+                "sha256:f1d4aeb8891338e60d1ab6127af1fe45def5259def8094b9c7e34690c8858803",
+                "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79",
+                "sha256:f6ff3b14f2df4c41660a7dec01045a045653998784bf8cfcb5a525bdffffbc8f"
             ],
-            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
-            "version": "==3.0.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.1"
         },
         "grpcio": {
             "hashes": [
-                "sha256:12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4",
-                "sha256:1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505",
-                "sha256:179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e",
-                "sha256:1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49",
-                "sha256:1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c",
-                "sha256:22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362",
-                "sha256:23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f",
-                "sha256:3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b",
-                "sha256:359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31",
-                "sha256:3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41",
-                "sha256:407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de",
-                "sha256:4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f",
-                "sha256:482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db",
-                "sha256:48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea",
-                "sha256:48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660",
-                "sha256:4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f",
-                "sha256:58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243",
-                "sha256:5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc",
-                "sha256:60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd",
-                "sha256:6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d",
-                "sha256:6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947",
-                "sha256:71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a",
-                "sha256:73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483",
-                "sha256:77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3",
-                "sha256:833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2",
-                "sha256:83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f",
-                "sha256:83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22",
-                "sha256:844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66",
-                "sha256:882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec",
-                "sha256:8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9",
-                "sha256:9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407",
-                "sha256:960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9",
-                "sha256:973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585",
-                "sha256:978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7",
-                "sha256:9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369",
-                "sha256:a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1",
-                "sha256:a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9",
-                "sha256:a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4",
-                "sha256:b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b",
-                "sha256:b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d",
-                "sha256:b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1",
-                "sha256:b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70",
-                "sha256:b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332",
-                "sha256:bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06",
-                "sha256:be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f",
-                "sha256:c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7",
-                "sha256:c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d",
-                "sha256:d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037",
-                "sha256:d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd",
-                "sha256:e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a",
-                "sha256:e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b",
-                "sha256:f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de",
-                "sha256:fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698",
-                "sha256:fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5"
+                "sha256:025f790c056815b3bf53da850dd70ebb849fd755a4b1ac822cb65cd631e37d43",
+                "sha256:04cfd68bf4f38f5bb959ee2361a7546916bd9a50f78617a346b3aeb2b42e2161",
+                "sha256:0feb02205a27caca128627bd1df4ee7212db051019a9afa76f4bb6a1a80ca95e",
+                "sha256:1098f03dedc3b9810810568060dea4ac0822b4062f537b0f53aa015269be0a76",
+                "sha256:12941d533f3cd45d46f202e3667be8ebf6bcb3573629c7ec12c3e211d99cfccf",
+                "sha256:255b1635b0ed81e9f91da4fcc8d43b7ea5520090b9a9ad9340d147066d1d3613",
+                "sha256:298ee7f80e26f9483f0b6f94cc0a046caf54400a11b644713bb5b3d8eb387600",
+                "sha256:2c4cec6177bf325eb6faa6bd834d2ff6aa8bb3b29012cceb4937b86f8b74323c",
+                "sha256:2cc1fd04af8399971bcd4f43bd98c22d01029ea2e56e69c34daf2bf8470e47f5",
+                "sha256:334ab917792904245a028f10e803fcd5b6f36a7b2173a820c0b5b076555825e1",
+                "sha256:3522c77d7e6606d6665ec8d50e867f13f946a4e00c7df46768f1c85089eae515",
+                "sha256:37ea3be171f3cf3e7b7e412a98b77685eba9d4fd67421f4a34686a63a65d99f9",
+                "sha256:390eee4225a661c5cd133c09f5da1ee3c84498dc265fd292a6912b65c421c78c",
+                "sha256:3aed6544e4d523cd6b3119b0916cef3d15ef2da51e088211e4d1eb91a6c7f4f1",
+                "sha256:3ceb56c4285754e33bb3c2fa777d055e96e6932351a3082ce3559be47f8024f0",
+                "sha256:44a8502dd5de653ae6a73e2de50a401d84184f0331d0ac3daeb044e66d5c5054",
+                "sha256:4b177f5547f1b995826ef529d2eef89cca2f830dd8b2c99ffd5fde4da734ba73",
+                "sha256:4efac5481c696d5cb124ff1c119a78bddbfdd13fc499e3bc0ca81e95fc573684",
+                "sha256:52fbf85aa71263380d330f4fce9f013c0798242e31ede05fcee7fbe40ccfc20d",
+                "sha256:55857c71641064f01ff0541a1776bfe04a59db5558e82897d35a7793e525774c",
+                "sha256:66a24f3d45c33550703f0abb8b656515b0ab777970fa275693a2f6dc8e35f1c1",
+                "sha256:6ab2d912ca39c51f46baf2a0d92aa265aa96b2443266fc50d234fa88bf877d8e",
+                "sha256:77d65165fc35cff6e954e7fd4229e05ec76102d4406d4576528d3a3635fc6172",
+                "sha256:7dfc914cc31c906297b30463dde0b9be48e36939575eaf2a0a22a8096e69afe5",
+                "sha256:7f20ebec257af55694d8f993e162ddf0d36bd82d4e57f74b31c67b3c6d63d8b2",
+                "sha256:80af6f1e69c5e68a2be529990684abdd31ed6622e988bf18850075c81bb1ad6e",
+                "sha256:83bbf5807dc3ee94ce1de2dfe8a356e1d74101e4b9d7aa8c720cc4818a34aded",
+                "sha256:8720c25cd9ac25dd04ee02b69256d0ce35bf8a0f29e20577427355272230965a",
+                "sha256:8829924fffb25386995a31998ccbbeaa7367223e647e0122043dfc485a87c666",
+                "sha256:8a3869a6661ec8f81d93f4597da50336718bde9eb13267a699ac7e0a1d6d0bea",
+                "sha256:8cb620037a2fd9eeee97b4531880e439ebfcd6d7d78f2e7dcc3726428ab5ef63",
+                "sha256:919d7f18f63bcad3a0f81146188e90274fde800a94e35d42ffe9eadf6a9a6330",
+                "sha256:95c87ce2a97434dffe7327a4071839ab8e8bffd0054cc74cbe971fba98aedd60",
+                "sha256:963cc8d7d79b12c56008aabd8b457f400952dbea8997dd185f155e2f228db079",
+                "sha256:96f473cdacfdd506008a5d7579c9f6a7ff245a9ade92c3c0265eb76cc591914f",
+                "sha256:9d1fae6bbf0816415b81db1e82fb3bf56f7857273c84dcbe68cbe046e58e1ccd",
+                "sha256:a0c8ddabef9c8f41617f213e527254c41e8b96ea9d387c632af878d05db9229c",
+                "sha256:a1b988b40f2fd9de5c820f3a701a43339d8dcf2cb2f1ca137e2c02671cc83ac1",
+                "sha256:a47faedc9ea2e7a3b6569795c040aae5895a19dde0c728a48d3c5d7995fda385",
+                "sha256:a8040f85dcb9830d8bbb033ae66d272614cec6faceee88d37a88a9bd1a7a704e",
+                "sha256:b33bd114fa5a83f03ec6b7b262ef9f5cac549d4126f1dc702078767b10c46ed9",
+                "sha256:c08079b4934b0bf0a8847f42c197b1d12cba6495a3d43febd7e99ecd1cdc8d54",
+                "sha256:c28848761a6520c5c6071d2904a18d339a796ebe6b800adc8b3f474c5ce3c3ad",
+                "sha256:cb400138e73969eb5e0535d1d06cae6a6f7a15f2cc74add320e2130b8179211a",
+                "sha256:cbb5780e2e740b6b4f2d208e90453591036ff80c02cc605fea1af8e6fc6b1bbe",
+                "sha256:ccf2ebd2de2d6661e2520dae293298a3803a98ebfc099275f113ce1f6c2a80f1",
+                "sha256:d35740e3f45f60f3c37b1e6f2f4702c23867b9ce21c6410254c9c682237da68d",
+                "sha256:d99abcd61760ebb34bdff37e5a3ba333c5cc09feda8c1ad42547bea0416ada78",
+                "sha256:ddda1aa22495d8acd9dfbafff2866438d12faec4d024ebc2e656784d96328ad0",
+                "sha256:dffd29a2961f3263a16d73945b57cd44a8fd0b235740cb14056f0612329b345e",
+                "sha256:e4842e4872ae4ae0f5497bf60a0498fa778c192cc7a9e87877abd2814aca9475",
+                "sha256:e8dbe3e00771bfe3d04feed8210fc6617006d06d9a2679b74605b9fed3e8362c",
+                "sha256:ee2e743e51cb964b4975de572aa8fb95b633f496f9fcb5e257893df3be854746",
+                "sha256:eeb38ff04ab6e5756a2aef6ad8d94e89bb4a51ef96e20f45c44ba190fa0bcaad",
+                "sha256:f8261fa2a5f679abeb2a0a93ad056d765cdca1c47745eda3f2d87f874ff4b8c9"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.62.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.68.1"
         },
         "gunicorn": {
             "hashes": [
@@ -388,109 +406,110 @@
         },
         "idna": {
             "hashes": [
-                "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca",
-                "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.6"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.10"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:1231cf92d825c9e03cfc4da076a16de6422c863558229ea0b22b675657463443",
-                "sha256:f0afba6205ad8f8947c7d338b5342d5db2afbfd82f9cbef7879a9539cc12eb9b"
+                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==6.11.0"
+            "version": "==8.5.0"
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
-                "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"
+                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
-                "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
+                "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
+                "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.3"
+            "version": "==3.1.5"
         },
         "mako": {
             "hashes": [
-                "sha256:2a0c8ad7f6274271b3bb7467dd37cf9cc6dab4bc19cb69a4ef10669402de698e",
-                "sha256:32a99d70754dfce237019d17ffe4a282d2d3351b9c476e90d8a60e63f133b80c"
+                "sha256:42f48953c7eb91332040ff567eb7eea69b22e7a4affbc5ba8e845e8f730f6627",
+                "sha256:577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.3.2"
+            "version": "==1.3.8"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
-                "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
-                "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
-                "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
-                "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
-                "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
-                "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
-                "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
-                "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
-                "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
-                "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
-                "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
-                "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
-                "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
-                "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
-                "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
-                "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
-                "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
-                "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
-                "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
-                "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
-                "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
-                "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
-                "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
-                "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
-                "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
-                "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
-                "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
-                "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
-                "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
-                "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
-                "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
-                "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
-                "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
-                "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
-                "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
-                "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
-                "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
-                "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
-                "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
-                "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
-                "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
-                "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
-                "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
-                "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
-                "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
-                "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
-                "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
-                "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
-                "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
-                "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
-                "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
-                "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
-                "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
-                "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
-                "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
-                "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
-                "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
-                "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
-                "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
+                "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4",
+                "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30",
+                "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0",
+                "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9",
+                "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396",
+                "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13",
+                "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028",
+                "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca",
+                "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557",
+                "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832",
+                "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0",
+                "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b",
+                "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579",
+                "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a",
+                "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c",
+                "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff",
+                "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c",
+                "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22",
+                "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094",
+                "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb",
+                "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e",
+                "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5",
+                "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a",
+                "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d",
+                "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a",
+                "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b",
+                "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8",
+                "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225",
+                "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c",
+                "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144",
+                "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f",
+                "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87",
+                "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d",
+                "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93",
+                "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf",
+                "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158",
+                "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84",
+                "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb",
+                "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48",
+                "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171",
+                "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c",
+                "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6",
+                "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd",
+                "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d",
+                "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1",
+                "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d",
+                "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca",
+                "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a",
+                "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29",
+                "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe",
+                "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798",
+                "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c",
+                "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8",
+                "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f",
+                "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f",
+                "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a",
+                "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178",
+                "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0",
+                "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79",
+                "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430",
+                "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.5"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.0.2"
         },
         "mpmath": {
             "hashes": [
@@ -501,19 +520,18 @@
         },
         "mysqlclient": {
             "hashes": [
-                "sha256:329e4eec086a2336fe3541f1ce095d87a6f169d1cc8ba7b04ac68bcb234c9711",
-                "sha256:33bc9fb3464e7d7c10b1eaf7336c5ff8f2a3d3b88bab432116ad2490beb3bf41",
-                "sha256:3c318755e06df599338dad7625f884b8a71fcf322a9939ef78c9b3db93e1de7a",
-                "sha256:4e80dcad884dd6e14949ac6daf769123223a52a6805345608bf49cdaf7bc8b3a",
-                "sha256:9d3310295cb682232cadc28abd172f406c718b9ada41d2371259098ae37779d3",
-                "sha256:9d4c015480c4a6b2b1602eccd9846103fc70606244788d04aa14b31c4bd1f0e2",
-                "sha256:ac44777eab0a66c14cb0d38965572f762e193ec2e5c0723bcd11319cc5b693c5",
-                "sha256:d43987bb9626096a302ca6ddcdd81feaeca65ced1d5fe892a6a66b808326aa54",
-                "sha256:e1ebe3f41d152d7cb7c265349fdb7f1eca86ccb0ca24a90036cde48e00ceb2ab"
+                "sha256:3da70a07753ba6be881f7d75e795e254f6a0c12795778034acc69769b0649d37",
+                "sha256:43c5b30be0675080b9c815f457d73397f0442173e7be83d089b126835e2617ae",
+                "sha256:794857bce4f9a1903a99786dd29ad7887f45a870b3d11585b8c51c4a753c4174",
+                "sha256:b0a5cddf1d3488b254605041070086cac743401d876a659a72d706a0d89c8ebb",
+                "sha256:c0b46d9b78b461dbb62482089ca8040fa916595b1b30f831ebbd1b0a82b43d53",
+                "sha256:e940b41d85dfd7b190fa47d52f525f878cfa203d4653bf6a35b271b3c3be125b",
+                "sha256:e94a92858203d97fd584bdb6d7ee8c56f2590db8d77fd44215c0dcf5e739bc37",
+                "sha256:f3efb849d6f7ef4b9788a0eda2e896b975e0ebf1d6bf3dcabea63fd698e5b0b5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.4"
+            "version": "==2.2.6"
         },
         "natlas-libnmap": {
             "hashes": [
@@ -533,110 +551,110 @@
         },
         "opentelemetry-api": {
             "hashes": [
-                "sha256:14a766548c8dd2eb4dfc349739eb4c3893712a0daa996e5dbf945f9da665da9d",
-                "sha256:cc03ea4025353048aadb9c64919099663664672ea1c6be6ddd8fee8e4cd5e774"
+                "sha256:5fcd94c4141cc49c736271f3e1efb777bebe9cc535759c54c936cca4f1b312b8",
+                "sha256:d04a6cf78aad09614f52964ecb38021e248f5714dc32c2e0d8fd99517b4d69cf"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-exporter-otlp": {
             "hashes": [
-                "sha256:4af8798f9bc3bddb92fcbb5b4aa9d0e955d962aa1d9bceaab08891c355a9f907",
-                "sha256:92371fdc8d7803465a45801fe30cd8c522ef355a385b0a1d5346d32f77511ea2"
+                "sha256:b8da6e20f5b0ffe604154b1e16a407eade17ce310c42fb85bb4e1246fc3688ad",
+                "sha256:ee7dfcccbb5e87ad9b389908452e10b7beeab55f70a83f41ce5b8c4efbde6544"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-exporter-otlp-proto-common": {
             "hashes": [
-                "sha256:2a9e7e9d5a8b026b572684b6b24dcdefcaa58613d5ce3d644130b0c373c056c1",
-                "sha256:35e4ea909e7a0b24235bd0aaf17fba49676527feb1823b46565ff246d5a1ab18"
+                "sha256:a9d7376c06b4da9cf350677bcddb9618ed4b8255c3f6476975f5e38274ecd3aa",
+                "sha256:e7c39b5dbd1b78fe199e40ddfe477e6983cb61aa74ba836df09c3869a3e3e163"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-exporter-otlp-proto-grpc": {
             "hashes": [
-                "sha256:40f9e3e7761eb34f2a1001f4543028783ac26e2db27e420d5374f2cca0182dad",
-                "sha256:aa1a012eea5342bfef51fcf3f7f22601dcb0f0984a07ffe6025b2fbb6d91a2a9"
+                "sha256:3d324d07d64574d72ed178698de3d717f62a059a93b6b7685ee3e303384e73ea",
+                "sha256:5a2a3a741a2543ed162676cf3eefc2b4150e6f4f0a193187afb0d0e65039c69c"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-exporter-otlp-proto-http": {
             "hashes": [
-                "sha256:088eac2320f4a604e2d9ff71aced71fdae601ac6457005fb0303d6bbbf44e6ca",
-                "sha256:ad853b58681df8efcb2cfc93be2b5fd86351c99ff4ab47dc917da384b8650d91"
+                "sha256:b10d174e3189716f49d386d66361fbcf6f2b9ad81e05404acdee3f65c8214204",
+                "sha256:b228bdc0f0cfab82eeea834a7f0ffdd2a258b26aa33d89fb426c29e8e934d9d0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-instrumentation": {
             "hashes": [
-                "sha256:79560f386425176bcc60c59190064597096114c4a8e5154f1cb281bb4e47d2fc",
-                "sha256:8213d02d8c0987b9b26386ae3e091e0477d6331673123df736479322e1a50b48"
+                "sha256:7d98af72de8dec5323e5202e46122e5f908592b22c6d24733aad619f07d82979",
+                "sha256:b8f9fc8812de36e1c6dffa5bfc6224df258841fb387b6dfe5df15099daa10630"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.44b0"
+            "version": "==0.50b0"
         },
         "opentelemetry-instrumentation-flask": {
             "hashes": [
-                "sha256:01c99415e199bb68abd21b03ffe9d2ee1cb359c269f81c2d1d9aaba260cefe91",
-                "sha256:8edd3caba8c9c850578ac69a53ed1d3e0cb9d0a150ba4001edfd353f3a3ec9a4"
+                "sha256:db7fb40191145f4356a793922c3fc80a33689e6a7c7c4c6def8aa1eedb0ac42a",
+                "sha256:e56a820b1d43fdd5a57f7b481c4d6365210a48a1312c83af4185bc636977755f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==0.44b0"
+            "version": "==0.50b0"
         },
         "opentelemetry-instrumentation-wsgi": {
             "hashes": [
-                "sha256:8d2adc1183ccd17f1329db39b15c1cb759095da10ac1de70c64a653c0acdc9af",
-                "sha256:b0fe5568de3847f1eb851a4cd2e226ac0a2f6c4d93c7a94766754c4673e8b758"
+                "sha256:4bc0fdf52b603507d6170a25504f0ceea358d7e90a2c0e8794b7b7eca5ea355c",
+                "sha256:c25b5f1b664d984a41546a34cf2f893dcde6cf56922f88c475864e7df37edf4a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.44b0"
+            "version": "==0.50b0"
         },
         "opentelemetry-proto": {
             "hashes": [
-                "sha256:4c017deca052cb287a6003b7c989ed8b47af65baeb5d57ebf93dde0793f78509",
-                "sha256:e6aaf8b7ace8d021942d546161401b83eed90f9f2cc6f13275008cea730e4651"
+                "sha256:3c136aa293782e9b44978c738fff72877a4b78b5d21a64e879898db7b2d93e5d",
+                "sha256:495069c6f5495cbf732501cdcd3b7f60fda2b9d3d4255706ca99b7ca8dec53ff"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-sdk": {
             "hashes": [
-                "sha256:9ddf60195837b59e72fd2033d6a47e2b59a0f74f0ec37d89387d89e3da8cab7f",
-                "sha256:a93c96990ac0f07c6d679e2f1015864ff7a4f5587122dd5af968034436efb1fd"
+                "sha256:173be3b5d3f8f7d671f20ea37056710217959e774e2749d984355d1f9391a30a",
+                "sha256:b0787ce6aade6ab84315302e72bd7a7f2f014b0fb1b7c3295b88afe014ed0643"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.23.0"
+            "version": "==1.29.0"
         },
         "opentelemetry-semantic-conventions": {
             "hashes": [
-                "sha256:2e997cb28cd4ca81a25a9a43365f593d0c2b76be0685015349a89abdf1aa4ffa",
-                "sha256:7c434546c9cbd797ab980cc88bf9ff3f4a5a28f941117cad21694e43d5d92019"
+                "sha256:02dc6dbcb62f082de9b877ff19a3f1ffaa3c306300fa53bfac761c4567c83d38",
+                "sha256:e87efba8fdb67fb38113efea6a349531e75ed7ffc01562f65b802fcecb5e115e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.44b0"
+            "version": "==0.50b0"
         },
         "opentelemetry-util-http": {
             "hashes": [
-                "sha256:75896dffcbbeb5df5429ad4526e22307fc041a27114e0c5bfd90bb219381e68f",
-                "sha256:ff018ab6a2fa349537ff21adcef99a294248b599be53843c44f367aef6bccea5"
+                "sha256:21f8aedac861ffa3b850f8c0a6c373026189eb8630ac6e14a2bf8c55695cc090",
+                "sha256:dc4606027e1bc02aabb9533cc330dd43f874fca492e4175c31d7154f341754af"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.44b0"
+            "version": "==0.50b0"
         },
         "packaging": {
             "hashes": [
-                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
         },
         "pillow": {
             "hashes": [
@@ -715,20 +733,20 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:19b270aeaa0099f16d3ca02628546b8baefe2955bbe23224aaf856134eccf1e4",
-                "sha256:209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8",
-                "sha256:25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c",
-                "sha256:7c8daa26095f82482307bc717364e7c13f4f1c99659be82890dcfc215194554d",
-                "sha256:c053062984e61144385022e53678fbded7aea14ebb3e0305ae3592fb219ccfa4",
-                "sha256:d4198877797a83cbfe9bffa3803602bbe1625dc30d8a097365dbc762e5790faa",
-                "sha256:e3c97a1555fd6388f857770ff8b9703083de6bf1f9274a002a332d65fbb56c8c",
-                "sha256:e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019",
-                "sha256:f0700d54bcf45424477e46a9f0944155b46fb0639d69728739c0e47bab83f2b9",
-                "sha256:f1279ab38ecbfae7e456a108c5c0681e4956d5b1090027c1de0f934dfdb4b35c",
-                "sha256:f4f118245c4a087776e0a8408be33cf09f6c547442c00395fbfb116fac2f8ac2"
+                "sha256:13d6d617a2a9e0e82a88113d7191a1baa1e42c2cc6f5f1398d3b054c8e7e714a",
+                "sha256:2d2e674c58a06311c8e99e74be43e7f3a8d1e2b2fdf845eaa347fbd866f23355",
+                "sha256:36000f97ea1e76e8398a3f02936aac2a5d2b111aae9920ec1b769fc4a222c4d9",
+                "sha256:494229ecd8c9009dd71eda5fd57528395d1eacdf307dbece6c12ad0dd09e912e",
+                "sha256:842de6d9241134a973aab719ab42b008a18a90f9f07f06ba480df268f86432f9",
+                "sha256:a0c53d78383c851bfa97eb42e3703aefdc96d2036a41482ffd55dc5f529466eb",
+                "sha256:b2cc8e8bb7c9326996f0e160137b0861f1a82162502658df2951209d0cb0309e",
+                "sha256:b6b0d416bbbb9d4fbf9d0561dbfc4e324fd522f61f7af0fe0f282ab67b22477e",
+                "sha256:c12ba8249f5624300cf51c3d0bfe5be71a60c63e4dcf51ffe9a68771d958c851",
+                "sha256:e621a98c0201a7c8afe89d9646859859be97cb22b8bf1d8eacfd90d5bda2eb19",
+                "sha256:fde4554c0e578a5a0bcc9a276339594848d1e89f9ea47b4427c80e5d72f90181"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.25.3"
+            "version": "==5.29.2"
         },
         "pyjwt": {
             "hashes": [
@@ -758,11 +776,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f",
-                "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.31.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.32.3"
         },
         "semver": {
             "hashes": [
@@ -783,99 +801,107 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56",
-                "sha256:5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
+                "sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6",
+                "sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==69.1.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==75.6.0"
         },
         "six": {
             "hashes": [
-                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
-                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==1.16.0"
+            "version": "==1.17.0"
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:0315d9125a38026227f559488fe7f7cee1bd2fbc19f9fd637739dc50bb6380b2",
-                "sha256:0d3dd67b5d69794cfe82862c002512683b3db038b99002171f624712fa71aeaa",
-                "sha256:124202b4e0edea7f08a4db8c81cc7859012f90a0d14ba2bf07c099aff6e96462",
-                "sha256:1ee8bd6d68578e517943f5ebff3afbd93fc65f7ef8f23becab9fa8fb315afb1d",
-                "sha256:243feb6882b06a2af68ecf4bec8813d99452a1b62ba2be917ce6283852cf701b",
-                "sha256:2858bbab1681ee5406650202950dc8f00e83b06a198741b7c656e63818633526",
-                "sha256:2f60843068e432311c886c5f03c4664acaef507cf716f6c60d5fde7265be9d7b",
-                "sha256:328529f7c7f90adcd65aed06a161851f83f475c2f664a898af574893f55d9e53",
-                "sha256:33157920b233bc542ce497a81a2e1452e685a11834c5763933b440fedd1d8e2d",
-                "sha256:3eba73ef2c30695cb7eabcdb33bb3d0b878595737479e152468f3ba97a9c22a4",
-                "sha256:426f2fa71331a64f5132369ede5171c52fd1df1bd9727ce621f38b5b24f48750",
-                "sha256:45c7b78dfc7278329f27be02c44abc0d69fe235495bb8e16ec7ef1b1a17952db",
-                "sha256:46a3d4e7a472bfff2d28db838669fc437964e8af8df8ee1e4548e92710929adc",
-                "sha256:4a5adf383c73f2d49ad15ff363a8748319ff84c371eed59ffd0127355d6ea1da",
-                "sha256:4b6303bfd78fb3221847723104d152e5972c22367ff66edf09120fcde5ddc2e2",
-                "sha256:56856b871146bfead25fbcaed098269d90b744eea5cb32a952df00d542cdd368",
-                "sha256:5da98815f82dce0cb31fd1e873a0cb30934971d15b74e0d78cf21f9e1b05953f",
-                "sha256:5df5d1dafb8eee89384fb7a1f79128118bc0ba50ce0db27a40750f6f91aa99d5",
-                "sha256:68722e6a550f5de2e3cfe9da6afb9a7dd15ef7032afa5651b0f0c6b3adb8815d",
-                "sha256:78bb7e8da0183a8301352d569900d9d3594c48ac21dc1c2ec6b3121ed8b6c986",
-                "sha256:81ba314a08c7ab701e621b7ad079c0c933c58cdef88593c59b90b996e8b58fa5",
-                "sha256:843a882cadebecc655a68bd9a5b8aa39b3c52f4a9a5572a3036fb1bb2ccdc197",
-                "sha256:87724e7ed2a936fdda2c05dbd99d395c91ea3c96f029a033a4a20e008dd876bf",
-                "sha256:8c7f10720fc34d14abad5b647bc8202202f4948498927d9f1b4df0fb1cf391b7",
-                "sha256:8e91b5e341f8c7f1e5020db8e5602f3ed045a29f8e27f7f565e0bdee3338f2c7",
-                "sha256:943aa74a11f5806ab68278284a4ddd282d3fb348a0e96db9b42cb81bf731acdc",
-                "sha256:9461802f2e965de5cff80c5a13bc945abea7edaa1d29360b485c3d2b56cdb075",
-                "sha256:9b66fcd38659cab5d29e8de5409cdf91e9986817703e1078b2fdaad731ea66f5",
-                "sha256:a6bec1c010a6d65b3ed88c863d56b9ea5eeefdf62b5e39cafd08c65f5ce5198b",
-                "sha256:a921002be69ac3ab2cf0c3017c4e6a3377f800f1fca7f254c13b5f1a2f10022c",
-                "sha256:aca7b6d99a4541b2ebab4494f6c8c2f947e0df4ac859ced575238e1d6ca5716b",
-                "sha256:ad7acbe95bac70e4e687a4dc9ae3f7a2f467aa6597049eeb6d4a662ecd990bb6",
-                "sha256:af8ce2d31679006e7b747d30a89cd3ac1ec304c3d4c20973f0f4ad58e2d1c4c9",
-                "sha256:b4a2cf92995635b64876dc141af0ef089c6eea7e05898d8d8865e71a326c0385",
-                "sha256:bbda76961eb8f27e6ad3c84d1dc56d5bc61ba8f02bd20fcf3450bd421c2fcc9c",
-                "sha256:bd7e4baf9161d076b9a7e432fce06217b9bd90cfb8f1d543d6e8c4595627edb9",
-                "sha256:bea30da1e76cb1acc5b72e204a920a3a7678d9d52f688f087dc08e54e2754c67",
-                "sha256:c61e2e41656a673b777e2f0cbbe545323dbe0d32312f590b1bc09da1de6c2a02",
-                "sha256:c6c4da4843e0dabde41b8f2e8147438330924114f541949e6318358a56d1875a",
-                "sha256:d3499008ddec83127ab286c6f6ec82a34f39c9817f020f75eca96155f9765097",
-                "sha256:dbb990612c36163c6072723523d2be7c3eb1517bbdd63fe50449f56afafd1133",
-                "sha256:dd53b6c4e6d960600fd6532b79ee28e2da489322fcf6648738134587faf767b6",
-                "sha256:df40c16a7e8be7413b885c9bf900d402918cc848be08a59b022478804ea076b8",
-                "sha256:e0a5354cb4de9b64bccb6ea33162cb83e03dbefa0d892db88a672f5aad638a75",
-                "sha256:e0b148ab0438f72ad21cb004ce3bdaafd28465c4276af66df3b9ecd2037bf252",
-                "sha256:e23b88c69497a6322b5796c0781400692eca1ae5532821b39ce81a48c395aae9",
-                "sha256:fc4974d3684f28b61b9a90fcb4c41fb340fd4b6a50c04365704a4da5a9603b05",
-                "sha256:feea693c452d85ea0015ebe3bb9cd15b6f49acc1a31c28b3c50f4db0f8fb1e71",
-                "sha256:fffcc8edc508801ed2e6a4e7b0d150a62196fd28b4e16ab9f65192e8186102b6"
+                "sha256:03e08af7a5f9386a43919eda9de33ffda16b44eb11f3b313e6822243770e9763",
+                "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436",
+                "sha256:07b441f7d03b9a66299ce7ccf3ef2900abc81c0db434f42a5694a37bd73870f2",
+                "sha256:1bc330d9d29c7f06f003ab10e1eaced295e87940405afe1b110f2eb93a233588",
+                "sha256:1e0d612a17581b6616ff03c8e3d5eff7452f34655c901f75d62bd86449d9750e",
+                "sha256:23623166bfefe1487d81b698c423f8678e80df8b54614c2bf4b4cfcd7c711959",
+                "sha256:2519f3a5d0517fc159afab1015e54bb81b4406c278749779be57a569d8d1bb0d",
+                "sha256:28120ef39c92c2dd60f2721af9328479516844c6b550b077ca450c7d7dc68575",
+                "sha256:37350015056a553e442ff672c2d20e6f4b6d0b2495691fa239d8aa18bb3bc908",
+                "sha256:39769a115f730d683b0eb7b694db9789267bcd027326cccc3125e862eb03bfd8",
+                "sha256:3c01117dd36800f2ecaa238c65365b7b16497adc1522bf84906e5710ee9ba0e8",
+                "sha256:3d6718667da04294d7df1670d70eeddd414f313738d20a6f1d1f379e3139a545",
+                "sha256:3dbb986bad3ed5ceaf090200eba750b5245150bd97d3e67343a3cfed06feecf7",
+                "sha256:4557e1f11c5f653ebfdd924f3f9d5ebfc718283b0b9beebaa5dd6b77ec290971",
+                "sha256:46331b00096a6db1fdc052d55b101dbbfc99155a548e20a0e4a8e5e4d1362855",
+                "sha256:4a121d62ebe7d26fec9155f83f8be5189ef1405f5973ea4874a26fab9f1e262c",
+                "sha256:4f5e9cd989b45b73bd359f693b935364f7e1f79486e29015813c338450aa5a71",
+                "sha256:50aae840ebbd6cdd41af1c14590e5741665e5272d2fee999306673a1bb1fdb4d",
+                "sha256:59b1ee96617135f6e1d6f275bbe988f419c5178016f3d41d3c0abb0c819f75bb",
+                "sha256:59b8f3adb3971929a3e660337f5dacc5942c2cdb760afcabb2614ffbda9f9f72",
+                "sha256:66bffbad8d6271bb1cc2f9a4ea4f86f80fe5e2e3e501a5ae2a3dc6a76e604e6f",
+                "sha256:69f93723edbca7342624d09f6704e7126b152eaed3cdbb634cb657a54332a3c5",
+                "sha256:6a440293d802d3011028e14e4226da1434b373cbaf4a4bbb63f845761a708346",
+                "sha256:72c28b84b174ce8af8504ca28ae9347d317f9dba3999e5981a3cd441f3712e24",
+                "sha256:79d2e78abc26d871875b419e1fd3c0bca31a1cb0043277d0d850014599626c2e",
+                "sha256:7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5",
+                "sha256:8318f4776c85abc3f40ab185e388bee7a6ea99e7fa3a30686580b209eaa35c08",
+                "sha256:8958b10490125124463095bbdadda5aa22ec799f91958e410438ad6c97a7b793",
+                "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88",
+                "sha256:90812a8933df713fdf748b355527e3af257a11e415b613dd794512461eb8a686",
+                "sha256:9bc633f4ee4b4c46e7adcb3a9b5ec083bf1d9a97c1d3854b92749d935de40b9b",
+                "sha256:9e46ed38affdfc95d2c958de328d037d87801cfcbea6d421000859e9789e61c2",
+                "sha256:9fe53b404f24789b5ea9003fc25b9a3988feddebd7e7b369c8fac27ad6f52f28",
+                "sha256:a4e46a888b54be23d03a89be510f24a7652fe6ff660787b96cd0e57a4ebcb46d",
+                "sha256:a86bfab2ef46d63300c0f06936bd6e6c0105faa11d509083ba8f2f9d237fb5b5",
+                "sha256:ac9dfa18ff2a67b09b372d5db8743c27966abf0e5344c555d86cc7199f7ad83a",
+                "sha256:af148a33ff0349f53512a049c6406923e4e02bf2f26c5fb285f143faf4f0e46a",
+                "sha256:b11d0cfdd2b095e7b0686cf5fabeb9c67fae5b06d265d8180715b8cfa86522e3",
+                "sha256:b2985c0b06e989c043f1dc09d4fe89e1616aadd35392aea2844f0458a989eacf",
+                "sha256:b544ad1935a8541d177cb402948b94e871067656b3a0b9e91dbec136b06a2ff5",
+                "sha256:b5cc79df7f4bc3d11e4b542596c03826063092611e481fcf1c9dfee3c94355ef",
+                "sha256:b817d41d692bf286abc181f8af476c4fbef3fd05e798777492618378448ee689",
+                "sha256:b81ee3d84803fd42d0b154cb6892ae57ea6b7c55d8359a02379965706c7efe6c",
+                "sha256:be9812b766cad94a25bc63bec11f88c4ad3629a0cec1cd5d4ba48dc23860486b",
+                "sha256:c245b1fbade9c35e5bd3b64270ab49ce990369018289ecfde3f9c318411aaa07",
+                "sha256:c3f3631693003d8e585d4200730616b78fafd5a01ef8b698f6967da5c605b3fa",
+                "sha256:c4ae3005ed83f5967f961fd091f2f8c5329161f69ce8480aa8168b2d7fe37f06",
+                "sha256:c54a1e53a0c308a8e8a7dffb59097bff7facda27c70c286f005327f21b2bd6b1",
+                "sha256:d0ddd9db6e59c44875211bc4c7953a9f6638b937b0a88ae6d09eb46cced54eff",
+                "sha256:dc022184d3e5cacc9579e41805a681187650e170eb2fd70e28b86192a479dcaa",
+                "sha256:e32092c47011d113dc01ab3e1d3ce9f006a47223b18422c5c0d150af13a00687",
+                "sha256:f7b64e6ec3f02c35647be6b4851008b26cff592a95ecb13b6788a54ef80bbdd4",
+                "sha256:f942a799516184c855e1a32fbc7b29d7e571b52612647866d4ec1c3242578fcb",
+                "sha256:f9511d8dd4a6e9271d07d150fb2f81874a3c8c95e11ff9af3a2dfc35fe42ee44",
+                "sha256:fd3a55deef00f689ce931d4d1b23fa9f04c880a48ee97af488fd215cf24e2a6c",
+                "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e",
+                "sha256:fdf3386a801ea5aba17c6410dd1dc8d39cf454ca2565541b5ac42a84e1e28f53"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.28"
+            "version": "==2.0.36"
         },
         "sympy": {
             "hashes": [
-                "sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5",
-                "sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8"
+                "sha256:54612cf55a62755ee71824ce692986f23c88ffa77207b30c1368eda4a7060f73",
+                "sha256:b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.12"
+            "version": "==1.13.3"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
-                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.10.0"
+            "version": "==4.12.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
-                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
+                "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e",
+                "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.26.18"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.20"
         },
         "webpack-manifest": {
             "hashes": [
@@ -886,138 +912,124 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc",
-                "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"
+                "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
+                "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.1"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.3"
         },
         "wrapt": {
             "hashes": [
-                "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc",
-                "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81",
-                "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09",
-                "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e",
-                "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca",
-                "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0",
-                "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb",
-                "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487",
-                "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40",
-                "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c",
-                "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060",
-                "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202",
-                "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41",
-                "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9",
-                "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b",
-                "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664",
-                "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d",
-                "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362",
-                "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00",
-                "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc",
-                "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1",
-                "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267",
-                "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956",
-                "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966",
-                "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1",
-                "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228",
-                "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72",
-                "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d",
-                "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292",
-                "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0",
-                "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0",
-                "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36",
-                "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c",
-                "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5",
-                "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f",
-                "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73",
-                "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b",
-                "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2",
-                "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593",
-                "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39",
-                "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389",
-                "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf",
-                "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf",
-                "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89",
-                "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c",
-                "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c",
-                "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f",
-                "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440",
-                "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465",
-                "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136",
-                "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b",
-                "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8",
-                "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3",
-                "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8",
-                "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6",
-                "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e",
-                "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f",
-                "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c",
-                "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e",
-                "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8",
-                "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2",
-                "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020",
-                "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35",
-                "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d",
-                "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3",
-                "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537",
-                "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809",
-                "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d",
-                "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a",
-                "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
+                "sha256:0229b247b0fc7dee0d36176cbb79dbaf2a9eb7ecc50ec3121f40ef443155fb1d",
+                "sha256:0698d3a86f68abc894d537887b9bbf84d29bcfbc759e23f4644be27acf6da301",
+                "sha256:0a0a1a1ec28b641f2a3a2c35cbe86c00051c04fffcfcc577ffcdd707df3f8635",
+                "sha256:0b48554952f0f387984da81ccfa73b62e52817a4386d070c75e4db7d43a28c4a",
+                "sha256:0f2a28eb35cf99d5f5bd12f5dd44a0f41d206db226535b37b0c60e9da162c3ed",
+                "sha256:140ea00c87fafc42739bd74a94a5a9003f8e72c27c47cd4f61d8e05e6dec8721",
+                "sha256:16187aa2317c731170a88ef35e8937ae0f533c402872c1ee5e6d079fcf320801",
+                "sha256:17fcf043d0b4724858f25b8826c36e08f9fb2e475410bece0ec44a22d533da9b",
+                "sha256:18b956061b8db634120b58f668592a772e87e2e78bc1f6a906cfcaa0cc7991c1",
+                "sha256:2399408ac33ffd5b200480ee858baa58d77dd30e0dd0cab6a8a9547135f30a88",
+                "sha256:2a0c23b8319848426f305f9cb0c98a6e32ee68a36264f45948ccf8e7d2b941f8",
+                "sha256:2dfb7cff84e72e7bf975b06b4989477873dcf160b2fd89959c629535df53d4e0",
+                "sha256:2f495b6754358979379f84534f8dd7a43ff8cff2558dcdea4a148a6e713a758f",
+                "sha256:33539c6f5b96cf0b1105a0ff4cf5db9332e773bb521cc804a90e58dc49b10578",
+                "sha256:3c34f6896a01b84bab196f7119770fd8466c8ae3dfa73c59c0bb281e7b588ce7",
+                "sha256:498fec8da10e3e62edd1e7368f4b24aa362ac0ad931e678332d1b209aec93045",
+                "sha256:4d63f4d446e10ad19ed01188d6c1e1bb134cde8c18b0aa2acfd973d41fcc5ada",
+                "sha256:4e4b4385363de9052dac1a67bfb535c376f3d19c238b5f36bddc95efae15e12d",
+                "sha256:4e547b447073fc0dbfcbff15154c1be8823d10dab4ad401bdb1575e3fdedff1b",
+                "sha256:4f643df3d4419ea3f856c5c3f40fec1d65ea2e89ec812c83f7767c8730f9827a",
+                "sha256:4f763a29ee6a20c529496a20a7bcb16a73de27f5da6a843249c7047daf135977",
+                "sha256:5ae271862b2142f4bc687bdbfcc942e2473a89999a54231aa1c2c676e28f29ea",
+                "sha256:5d8fd17635b262448ab8f99230fe4dac991af1dabdbb92f7a70a6afac8a7e346",
+                "sha256:69c40d4655e078ede067a7095544bcec5a963566e17503e75a3a3e0fe2803b13",
+                "sha256:69d093792dc34a9c4c8a70e4973a3361c7a7578e9cd86961b2bbf38ca71e4e22",
+                "sha256:6a9653131bda68a1f029c52157fd81e11f07d485df55410401f745007bd6d339",
+                "sha256:6ff02a91c4fc9b6a94e1c9c20f62ea06a7e375f42fe57587f004d1078ac86ca9",
+                "sha256:714c12485aa52efbc0fc0ade1e9ab3a70343db82627f90f2ecbc898fdf0bb181",
+                "sha256:7264cbb4a18dc4acfd73b63e4bcfec9c9802614572025bdd44d0721983fc1d9c",
+                "sha256:73a96fd11d2b2e77d623a7f26e004cc31f131a365add1ce1ce9a19e55a1eef90",
+                "sha256:74bf625b1b4caaa7bad51d9003f8b07a468a704e0644a700e936c357c17dd45a",
+                "sha256:81b1289e99cf4bad07c23393ab447e5e96db0ab50974a280f7954b071d41b489",
+                "sha256:8425cfce27b8b20c9b89d77fb50e368d8306a90bf2b6eef2cdf5cd5083adf83f",
+                "sha256:875d240fdbdbe9e11f9831901fb8719da0bd4e6131f83aa9f69b96d18fae7504",
+                "sha256:879591c2b5ab0a7184258274c42a126b74a2c3d5a329df16d69f9cee07bba6ea",
+                "sha256:89fc28495896097622c3fc238915c79365dd0ede02f9a82ce436b13bd0ab7569",
+                "sha256:8a5e7cc39a45fc430af1aefc4d77ee6bad72c5bcdb1322cfde852c15192b8bd4",
+                "sha256:8f8909cdb9f1b237786c09a810e24ee5e15ef17019f7cecb207ce205b9b5fcce",
+                "sha256:914f66f3b6fc7b915d46c1cc424bc2441841083de01b90f9e81109c9759e43ab",
+                "sha256:92a3d214d5e53cb1db8b015f30d544bc9d3f7179a05feb8f16df713cecc2620a",
+                "sha256:948a9bd0fb2c5120457b07e59c8d7210cbc8703243225dbd78f4dfc13c8d2d1f",
+                "sha256:9c900108df470060174108012de06d45f514aa4ec21a191e7ab42988ff42a86c",
+                "sha256:9f2939cd4a2a52ca32bc0b359015718472d7f6de870760342e7ba295be9ebaf9",
+                "sha256:a4192b45dff127c7d69b3bdfb4d3e47b64179a0b9900b6351859f3001397dabf",
+                "sha256:a8fc931382e56627ec4acb01e09ce66e5c03c384ca52606111cee50d931a342d",
+                "sha256:ad47b095f0bdc5585bced35bd088cbfe4177236c7df9984b3cc46b391cc60627",
+                "sha256:b1ca5f060e205f72bec57faae5bd817a1560fcfc4af03f414b08fa29106b7e2d",
+                "sha256:ba1739fb38441a27a676f4de4123d3e858e494fac05868b7a281c0a383c098f4",
+                "sha256:baa7ef4e0886a6f482e00d1d5bcd37c201b383f1d314643dfb0367169f94f04c",
+                "sha256:bb90765dd91aed05b53cd7a87bd7f5c188fcd95960914bae0d32c5e7f899719d",
+                "sha256:bc7f729a72b16ee21795a943f85c6244971724819819a41ddbaeb691b2dd85ad",
+                "sha256:bdf62d25234290db1837875d4dceb2151e4ea7f9fff2ed41c0fde23ed542eb5b",
+                "sha256:c30970bdee1cad6a8da2044febd824ef6dc4cc0b19e39af3085c763fdec7de33",
+                "sha256:d2c63b93548eda58abf5188e505ffed0229bf675f7c3090f8e36ad55b8cbc371",
+                "sha256:d751300b94e35b6016d4b1e7d0e7bbc3b5e1751e2405ef908316c2a9024008a1",
+                "sha256:da427d311782324a376cacb47c1a4adc43f99fd9d996ffc1b3e8529c4074d393",
+                "sha256:daba396199399ccabafbfc509037ac635a6bc18510ad1add8fd16d4739cdd106",
+                "sha256:e185ec6060e301a7e5f8461c86fb3640a7beb1a0f0208ffde7a65ec4074931df",
+                "sha256:e4a557d97f12813dc5e18dad9fa765ae44ddd56a672bb5de4825527c847d6379",
+                "sha256:e5ed16d95fd142e9c72b6c10b06514ad30e846a0d0917ab406186541fe68b451",
+                "sha256:e711fc1acc7468463bc084d1b68561e40d1eaa135d8c509a65dd534403d83d7b",
+                "sha256:f28b29dc158ca5d6ac396c8e0a2ef45c4e97bb7e65522bfc04c989e6fe814575",
+                "sha256:f335579a1b485c834849e9075191c9898e0731af45705c2ebf70e0cd5d58beed",
+                "sha256:fce6fee67c318fdfb7f285c29a82d84782ae2579c0e1b385b7f36c6e8074fffb",
+                "sha256:fd136bb85f4568fffca995bd3c8d52080b1e5b225dbf1c2b17b66b4c5fa02838"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.16.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.17.0"
         },
         "wtforms": {
             "hashes": [
-                "sha256:bf831c042829c8cdbad74c27575098d541d039b1faa74c771545ecac916f2c07",
-                "sha256:f8d76180d7239c94c6322f7990ae1216dae3659b7aa1cee94b6318bdffb474b9"
+                "sha256:583bad77ba1dd7286463f21e11aa3043ca4869d03575921d1a1698d0715e0fd4",
+                "sha256:df3e6b70f3192e92623128123ec8dca3067df9cfadd43d59681e210cfb8d4682"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.1.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.2.1"
         },
         "zipp": {
             "hashes": [
-                "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31",
-                "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
+                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
+                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.17.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.21.0"
         }
     },
     "develop": {
         "blinker": {
             "hashes": [
-                "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9",
-                "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182"
+                "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf",
+                "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.7.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
         },
         "click": {
             "hashes": [
-                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
-                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
+                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.7"
-        },
-        "flake8": {
-            "hashes": [
-                "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132",
-                "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"
-            ],
-            "index": "pypi",
-            "markers": "python_full_version >= '3.8.1'",
-            "version": "==7.0.0"
+            "version": "==8.1.8"
         },
         "flask": {
             "hashes": [
-                "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e",
-                "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d"
+                "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac",
+                "sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.2"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.0"
         },
         "iniconfig": {
             "hashes": [
@@ -1029,134 +1041,164 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
-                "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"
+                "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef",
+                "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.2.0"
         },
         "jinja2": {
             "hashes": [
-                "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
-                "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
+                "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb",
+                "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.3"
+            "version": "==3.1.5"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf",
-                "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff",
-                "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f",
-                "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3",
-                "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532",
-                "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f",
-                "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617",
-                "sha256:2d2d793e36e230fd32babe143b04cec8a8b3eb8a3122d2aceb4a371e6b09b8df",
-                "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4",
-                "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906",
-                "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f",
-                "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4",
-                "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8",
-                "sha256:4096e9de5c6fdf43fb4f04c26fb114f61ef0bf2e5604b6ee3019d51b69e8c371",
-                "sha256:4275d846e41ecefa46e2015117a9f491e57a71ddd59bbead77e904dc02b1bed2",
-                "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465",
-                "sha256:4f11aa001c540f62c6166c7726f71f7573b52c68c31f014c25cc7901deea0b52",
-                "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6",
-                "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169",
-                "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad",
-                "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2",
-                "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0",
-                "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029",
-                "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f",
-                "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a",
-                "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced",
-                "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5",
-                "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c",
-                "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf",
-                "sha256:7b2e5a267c855eea6b4283940daa6e88a285f5f2a67f2220203786dfa59b37e9",
-                "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb",
-                "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad",
-                "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3",
-                "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1",
-                "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46",
-                "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc",
-                "sha256:a549b9c31bec33820e885335b451286e2969a2d9e24879f83fe904a5ce59d70a",
-                "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee",
-                "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900",
-                "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5",
-                "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea",
-                "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f",
-                "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5",
-                "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e",
-                "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a",
-                "sha256:c8b29db45f8fe46ad280a7294f5c3ec36dbac9491f2d1c17345be8e69cc5928f",
-                "sha256:ce409136744f6521e39fd8e2a24c53fa18ad67aa5bc7c2cf83645cce5b5c4e50",
-                "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a",
-                "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b",
-                "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4",
-                "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff",
-                "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2",
-                "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46",
-                "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b",
-                "sha256:ec6a563cff360b50eed26f13adc43e61bc0c04d94b8be985e6fb24b81f6dcfdf",
-                "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5",
-                "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5",
-                "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab",
-                "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd",
-                "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
+                "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4",
+                "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30",
+                "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0",
+                "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9",
+                "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396",
+                "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13",
+                "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028",
+                "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca",
+                "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557",
+                "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832",
+                "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0",
+                "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b",
+                "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579",
+                "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a",
+                "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c",
+                "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff",
+                "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c",
+                "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22",
+                "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094",
+                "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb",
+                "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e",
+                "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5",
+                "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a",
+                "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d",
+                "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a",
+                "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b",
+                "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8",
+                "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225",
+                "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c",
+                "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144",
+                "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f",
+                "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87",
+                "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d",
+                "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93",
+                "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf",
+                "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158",
+                "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84",
+                "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb",
+                "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48",
+                "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171",
+                "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c",
+                "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6",
+                "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd",
+                "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d",
+                "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1",
+                "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d",
+                "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca",
+                "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a",
+                "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29",
+                "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe",
+                "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798",
+                "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c",
+                "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8",
+                "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f",
+                "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f",
+                "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a",
+                "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178",
+                "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0",
+                "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79",
+                "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430",
+                "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.5"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.0.2"
         },
-        "mccabe": {
+        "mypy": {
             "hashes": [
-                "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325",
-                "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.7.0"
-        },
-        "packaging": {
-            "hashes": [
-                "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
-                "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==24.0"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981",
-                "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.4.0"
-        },
-        "pycodestyle": {
-            "hashes": [
-                "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f",
-                "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.11.1"
-        },
-        "pyflakes": {
-            "hashes": [
-                "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f",
-                "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.2.0"
-        },
-        "pytest": {
-            "hashes": [
-                "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7",
-                "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"
+                "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c",
+                "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd",
+                "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f",
+                "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0",
+                "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9",
+                "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b",
+                "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14",
+                "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35",
+                "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319",
+                "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc",
+                "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb",
+                "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb",
+                "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e",
+                "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60",
+                "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31",
+                "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f",
+                "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6",
+                "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107",
+                "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11",
+                "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a",
+                "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837",
+                "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6",
+                "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b",
+                "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d",
+                "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255",
+                "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae",
+                "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1",
+                "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8",
+                "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b",
+                "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac",
+                "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9",
+                "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9",
+                "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1",
+                "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34",
+                "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427",
+                "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1",
+                "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c",
+                "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.1.1"
+            "version": "==1.14.1"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+                "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6",
+                "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.4"
         },
         "pytest-flask": {
             "hashes": [
@@ -1167,13 +1209,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.3.0"
         },
-        "werkzeug": {
+        "typing-extensions": {
             "hashes": [
-                "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc",
-                "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.1"
+            "version": "==4.12.2"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
+                "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.3"
         }
     }
 }

--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -17,7 +17,7 @@ from app.scope import ScopeManager
 from app.url_converters import register_converters
 
 
-class AnonUser(AnonymousUserMixin):
+class AnonUser(AnonymousUserMixin):  # type: ignore[misc]
     results_per_page = 50
     preview_length = 50
 
@@ -31,11 +31,11 @@ mail = Mail()
 db = SQLAlchemy()
 migrate = Migrate()
 csrf = CSRFProtect()
-ScopeManager = ScopeManager()
+ScopeManager = ScopeManager()  # type: ignore[assignment, misc]
 
 
 @login.unauthorized_handler
-def unauthorized():
+def unauthorized():  # type: ignore[no-untyped-def]
     if current_user.is_anonymous:
         flash("You must login to continue.", "warning")
         return redirect(url_for("auth.login"))
@@ -46,7 +46,7 @@ def unauthorized():
     return redirect(url_for("auth.login"))
 
 
-def create_app(config_class=config.Config, migrating=False):
+def create_app(config_class=config.Config, migrating=False):  # type: ignore[no-untyped-def]
     app = Flask(__name__)
     initialize_opentelemetry(config_class, app)
 
@@ -67,7 +67,7 @@ def create_app(config_class=config.Config, migrating=False):
         )
 
     app.jinja_env.add_extension("jinja2.ext.do")
-    app.elastic = ElasticInterface(
+    app.elastic = ElasticInterface(  # type: ignore[attr-defined]
         app.config["ELASTICSEARCH_URL"],
         app.config["ELASTIC_AUTH_ENABLE"],
         app.config["ELASTIC_USER"],
@@ -77,7 +77,7 @@ def create_app(config_class=config.Config, migrating=False):
     login.init_app(app)
     mail.init_app(app)
     csrf.init_app(app)
-    ScopeManager.init_app(app)
+    ScopeManager.init_app(app)  # type: ignore[arg-type, call-arg]
     app.config["webpack"] = webpack_manifest.load(
         # An absolute path to a manifest file
         path=os.path.join(
@@ -89,7 +89,7 @@ def create_app(config_class=config.Config, migrating=False):
 
     with app.app_context():
         load_config_from_db(app, db)
-        ScopeManager.load_all_groups()
+        ScopeManager.load_all_groups()  # type: ignore[call-arg]
 
     register_converters(app)
 

--- a/natlas-server/app/admin/forms.py
+++ b/natlas-server/app/admin/forms.py
@@ -16,7 +16,7 @@ from wtforms.validators import DataRequired, Email, ValidationError
 from app.models import AgentScript, ScopeItem, User
 
 
-class ConfigForm(FlaskForm):
+class ConfigForm(FlaskForm):  # type: ignore[misc]
     login_required = BooleanField("Login Required")
     register_allowed = BooleanField("Registration Allowed")
     agent_authentication = BooleanField("Agent Authentication Required")
@@ -24,11 +24,11 @@ class ConfigForm(FlaskForm):
     submit = SubmitField("Save Changes")
 
 
-class InviteUserForm(FlaskForm):
+class InviteUserForm(FlaskForm):  # type: ignore[misc]
     email = StringField("Email", validators=[DataRequired(), Email()])
     submit = SubmitField("Invite User")
 
-    def validate_email(self, email):
+    def validate_email(self, email):  # type: ignore[no-untyped-def]
         if not User.validate_email(email.data):
             flash(
                 f"{email.data} does not appear to be a valid, deliverable email address.",
@@ -41,20 +41,20 @@ class InviteUserForm(FlaskForm):
             raise ValidationError
 
 
-class UserDeleteForm(FlaskForm):
+class UserDeleteForm(FlaskForm):  # type: ignore[misc]
     deleteUser = SubmitField("Delete User")
 
 
-class UserEditForm(FlaskForm):
+class UserEditForm(FlaskForm):  # type: ignore[misc]
     editUser = SubmitField("Toggle Admin")
 
 
-class NewScopeForm(FlaskForm):
+class NewScopeForm(FlaskForm):  # type: ignore[misc]
     target = StringField("Target", validators=[DataRequired()])
     blacklist = BooleanField("Blacklist")
     submit = SubmitField("Add Target")
 
-    def validate_target(self, target):
+    def validate_target(self, target):  # type: ignore[no-untyped-def]
         try:
             isValid = ipaddress.ip_network(target.data, False)
             item = ScopeItem.query.filter_by(target=isValid.with_prefixlen).first()
@@ -64,45 +64,45 @@ class NewScopeForm(FlaskForm):
             raise ValidationError(e) from e
 
 
-class ImportScopeForm(FlaskForm):
+class ImportScopeForm(FlaskForm):  # type: ignore[misc]
     scope = TextAreaField("Scope Import", validators=[DataRequired()])
     submit = SubmitField("Import Scope")
 
 
-class ImportBlacklistForm(FlaskForm):
+class ImportBlacklistForm(FlaskForm):  # type: ignore[misc]
     scope = TextAreaField("Blacklist Import", validators=[DataRequired()])
     submit = SubmitField("Import Blacklist")
 
 
-class ScopeDeleteForm(FlaskForm):
+class ScopeDeleteForm(FlaskForm):  # type: ignore[misc]
     deleteScopeItem = SubmitField("Delete Target")
 
 
-class ScopeToggleForm(FlaskForm):
+class ScopeToggleForm(FlaskForm):  # type: ignore[misc]
     toggleScopeItem = SubmitField("Toggle Blacklist")
 
 
-class ServicesUploadForm(FlaskForm):
+class ServicesUploadForm(FlaskForm):  # type: ignore[misc]
     serviceFile = FileField("Select a file to upload", validators=[DataRequired()])
     uploadFile = SubmitField("Upload Services File")
 
 
-class AddServiceForm(FlaskForm):
+class AddServiceForm(FlaskForm):  # type: ignore[misc]
     serviceName = StringField("Service Name", validators=[DataRequired()])
     servicePort = IntegerField("Service Port", validators=[DataRequired()])
     serviceProtocol = SelectField("Protocol", validators=[DataRequired()])
     addService = SubmitField("Add Service")
 
-    def validate_serviceName(self, serviceName):
+    def validate_serviceName(self, serviceName):  # type: ignore[no-untyped-def]
         if " " in serviceName.data:
             raise ValidationError("Service names cannot contain spaces! Use - instead.")
 
-    def validate_servicePort(self, servicePort):
+    def validate_servicePort(self, servicePort):  # type: ignore[no-untyped-def]
         if servicePort.data > 65535 or servicePort.data < 0:
             raise ValidationError("Port has to be withing range of 0-65535")
 
 
-class AgentConfigForm(FlaskForm):
+class AgentConfigForm(FlaskForm):  # type: ignore[misc]
     versionDetection = BooleanField("Version Detection (-sV)")
     osDetection = BooleanField("OS Detection (-O)")
     enableScripts = BooleanField("Scripting Engine (--script)")
@@ -121,25 +121,25 @@ class AgentConfigForm(FlaskForm):
     updateAgents = SubmitField("Update Agent Config")
 
 
-class AddScriptForm(FlaskForm):
+class AddScriptForm(FlaskForm):  # type: ignore[misc]
     scriptName = StringField("Script Name", validators=[DataRequired()])
     addScript = SubmitField("Add Script")
 
-    def validate_scriptname(self, scriptName):
+    def validate_scriptname(self, scriptName):  # type: ignore[no-untyped-def]
         script = AgentScript.query.filter_by(name=scriptName).first()
         if script is not None:
             raise ValidationError(f"{script.name} already exists!")
 
 
-class DeleteForm(FlaskForm):
+class DeleteForm(FlaskForm):  # type: ignore[misc]
     delete = SubmitField("Delete")
 
 
-class AddTagForm(FlaskForm):
+class AddTagForm(FlaskForm):  # type: ignore[misc]
     tagname = StringField("Tag Name", validators=[DataRequired()])
     addTag = SubmitField("Add Tag")
 
 
-class TagScopeForm(FlaskForm):
+class TagScopeForm(FlaskForm):  # type: ignore[misc]
     tagname = SelectField("Tag Name", validators=[DataRequired()])
     addTagToScope = SubmitField("Add Tag to Scope")

--- a/natlas-server/app/admin/redirects.py
+++ b/natlas-server/app/admin/redirects.py
@@ -1,7 +1,7 @@
 from flask import redirect, url_for
 
 
-def get_scope_redirect(type):
+def get_scope_redirect(type):  # type: ignore[no-untyped-def]
     redirects = {
         "scope": url_for("admin.scope"),
         "blacklist": url_for("admin.blacklist"),

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -30,7 +30,7 @@ from app.models import (
 @bp.route("/", methods=["GET", "POST"])
 @login_required
 @is_admin
-def admin():
+def admin():  # type: ignore[no-untyped-def]
     configForm = forms.ConfigForm()
     configItems = current_app.config
     if configForm.validate_on_submit():
@@ -51,7 +51,7 @@ def admin():
 @bp.route("/users", methods=["GET", "POST"])
 @login_required
 @is_admin
-def users():
+def users():  # type: ignore[no-untyped-def]
     users = User.query.all()
     inviteForm = forms.InviteUserForm()
     if inviteForm.validate_on_submit():
@@ -72,7 +72,7 @@ def users():
 @bp.route("/users/<int:id>/delete", methods=["POST"])
 @login_required
 @is_admin
-def delete_user(id):
+def delete_user(id):  # type: ignore[no-untyped-def]
     delForm = forms.UserDeleteForm()
     if delForm.validate_on_submit():
         if current_user.id == id:
@@ -91,7 +91,7 @@ def delete_user(id):
 @bp.route("/users/<int:id>/toggle", methods=["POST"])
 @login_required
 @is_admin
-def toggle_user(id):
+def toggle_user(id):  # type: ignore[no-untyped-def]
     editForm = forms.UserEditForm()
     if editForm.validate_on_submit():
         user = User.query.filter_by(id=id).first()
@@ -110,11 +110,11 @@ def toggle_user(id):
 @bp.route("/scope", methods=["GET", "POST"])
 @login_required
 @is_admin
-def scope():
+def scope():  # type: ignore[no-untyped-def]
     render = {
         "scope": ScopeItem.getScope(),
-        "scopeSize": current_app.ScopeManager.get_scope_size(),
-        "effectiveScopeSize": current_app.ScopeManager.get_effective_scope_size(),
+        "scopeSize": current_app.ScopeManager.get_scope_size(),  # type: ignore[attr-defined]
+        "effectiveScopeSize": current_app.ScopeManager.get_effective_scope_size(),  # type: ignore[attr-defined]
         "newForm": forms.NewScopeForm(),
         "delForm": forms.ScopeDeleteForm(),
         "editForm": forms.ScopeToggleForm(),
@@ -130,7 +130,7 @@ def scope():
         newTarget = ScopeItem(target=target.with_prefixlen, blacklist=False)
         db.session.add(newTarget)
         db.session.commit()
-        current_app.ScopeManager.update()
+        current_app.ScopeManager.update()  # type: ignore[attr-defined]
         flash(f"{newTarget.target} added.", "success")
         return redirect(url_for("admin.scope"))
     return render_template("admin/scope.html", **render)
@@ -139,11 +139,11 @@ def scope():
 @bp.route("/blacklist", methods=["GET", "POST"])
 @login_required
 @is_admin
-def blacklist():
+def blacklist():  # type: ignore[no-untyped-def]
     render = {
         "scope": ScopeItem.getBlacklist(),
-        "blacklistSize": current_app.ScopeManager.get_blacklist_size(),
-        "effectiveScopeSize": current_app.ScopeManager.get_effective_scope_size(),
+        "blacklistSize": current_app.ScopeManager.get_blacklist_size(),  # type: ignore[attr-defined]
+        "effectiveScopeSize": current_app.ScopeManager.get_effective_scope_size(),  # type: ignore[attr-defined]
         "newForm": forms.NewScopeForm(),
         "delForm": forms.ScopeDeleteForm(),
         "editForm": forms.ScopeToggleForm(),
@@ -158,7 +158,7 @@ def blacklist():
         newTarget = ScopeItem(target=target.with_prefixlen, blacklist=True)
         db.session.add(newTarget)
         db.session.commit()
-        current_app.ScopeManager.update()
+        current_app.ScopeManager.update()  # type: ignore[attr-defined]
         flash(f"{newTarget.target} blacklisted.", "success")
         return redirect(url_for("admin.blacklist"))
     return render_template("admin/blacklist.html", **render)
@@ -167,7 +167,7 @@ def blacklist():
 @bp.route("/import/<string:scopetype>", methods=["POST"])
 @login_required
 @is_admin
-def import_scope(scopetype=""):
+def import_scope(scopetype=""):  # type: ignore[no-untyped-def]
     if scopetype == "blacklist":
         importBlacklist = True
         importForm = forms.ImportBlacklistForm()
@@ -180,7 +180,7 @@ def import_scope(scopetype=""):
         newScopeItems = importForm.scope.data.split("\n")
         result = ScopeItem.import_scope_list(newScopeItems, importBlacklist)
         db.session.commit()
-        current_app.ScopeManager.update()
+        current_app.ScopeManager.update()  # type: ignore[attr-defined]
         if result["success"]:
             flash(f"{result['success']} targets added to {scopetype}.", "success")
         if result["exist"]:
@@ -199,7 +199,7 @@ def import_scope(scopetype=""):
 @bp.route("/export/<string:scopetype>", methods=["GET"])
 @login_required
 @is_admin
-def export_scope(scopetype=""):
+def export_scope(scopetype=""):  # type: ignore[no-untyped-def]
     if scopetype == "blacklist":
         exportBlacklist = True
     elif scopetype == "scope":
@@ -215,7 +215,7 @@ def export_scope(scopetype=""):
 @bp.route("/<string:scopetype>/<int:id>/delete", methods=["POST"])
 @login_required
 @is_admin
-def delete_scope(scopetype, id):
+def delete_scope(scopetype, id):  # type: ignore[no-untyped-def]
     if scopetype not in ["scope", "blacklist"]:
         return abort(404)
     delForm = forms.ScopeDeleteForm()
@@ -225,7 +225,7 @@ def delete_scope(scopetype, id):
             item.tags.remove(tag)
         ScopeItem.query.filter_by(id=id).delete()
         db.session.commit()
-        current_app.ScopeManager.update()
+        current_app.ScopeManager.update()  # type: ignore[attr-defined]
         flash(f"{item.target} deleted.", "success")
     else:
         flash("Form couldn't validate!", "danger")
@@ -235,7 +235,7 @@ def delete_scope(scopetype, id):
 @bp.route("/<string:scopetype>/<int:id>/toggle", methods=["POST"])
 @login_required
 @is_admin
-def toggle_scope(scopetype, id):
+def toggle_scope(scopetype, id):  # type: ignore[no-untyped-def]
     if scopetype not in ["scope", "blacklist"]:
         return abort(404)
     toggleForm = forms.ScopeToggleForm()
@@ -244,7 +244,7 @@ def toggle_scope(scopetype, id):
         item.blacklist = not item.blacklist
         flash(f"Toggled scope status for {item.target}.", "success")
         db.session.commit()
-        current_app.ScopeManager.update()
+        current_app.ScopeManager.update()  # type: ignore[attr-defined]
     else:
         flash("Form couldn't validate!", "danger")
     return redirects.get_scope_redirect(scopetype)
@@ -253,7 +253,7 @@ def toggle_scope(scopetype, id):
 @bp.route("/<string:scopetype>/<int:id>/tag", methods=["POST"])
 @login_required
 @is_admin
-def tag_scope(scopetype, id):
+def tag_scope(scopetype, id):  # type: ignore[no-untyped-def]
     if scopetype not in ["scope", "blacklist"]:
         return abort(404)
     addTagForm = forms.TagScopeForm()
@@ -272,7 +272,7 @@ def tag_scope(scopetype, id):
 @bp.route("/<string:scopetype>/<int:id>/untag", methods=["POST"])
 @login_required
 @is_admin
-def untag_scope(scopetype, id):
+def untag_scope(scopetype, id):  # type: ignore[no-untyped-def]
     if scopetype not in ["scope", "blacklist"]:
         return abort(404)
     delTagForm = forms.TagScopeForm()
@@ -291,7 +291,7 @@ def untag_scope(scopetype, id):
 @bp.route("/services", methods=["GET", "POST"])
 @login_required
 @is_admin
-def services():
+def services():  # type: ignore[no-untyped-def]
     uploadForm = forms.ServicesUploadForm(prefix="upload-services")
     addServiceForm = forms.AddServiceForm(prefix="add-service")
     addServiceForm.serviceProtocol.choices = [("tcp", "TCP"), ("udp", "UDP")]
@@ -300,12 +300,12 @@ def services():
             uploadForm.serviceFile.data.read().decode("utf-8").rstrip("\r\n")
         )
         new_services = NatlasServices(services=newServicesContent)
-        if not new_services.hash_equals(current_app.current_services["sha256"]):
+        if not new_services.hash_equals(current_app.current_services["sha256"]):  # type: ignore[attr-defined]
             db.session.add(new_services)
             db.session.commit()
-            current_app.current_services = new_services.as_dict()
+            current_app.current_services = new_services.as_dict()  # type: ignore[attr-defined]
             flash(
-                f'New services file with hash {current_app.current_services["sha256"]} has been uploaded.',
+                f'New services file with hash {current_app.current_services["sha256"]} has been uploaded.',  # type: ignore[attr-defined]
                 "success",
             )
         else:
@@ -321,11 +321,11 @@ def services():
             + "/"
             + addServiceForm.serviceProtocol.data
         )
-        if "\t" + newServicePort in str(current_app.current_services["services"]):
+        if "\t" + newServicePort in str(current_app.current_services["services"]):  # type: ignore[attr-defined]
             flash(f"A service with port {newServicePort} already exists!", "danger")
         else:
             newServices = (
-                current_app.current_services["services"]
+                current_app.current_services["services"]  # type: ignore[attr-defined]
                 + "\n"
                 + newServiceName
                 + "\t"
@@ -334,7 +334,7 @@ def services():
             ns = NatlasServices(services=newServices)
             db.session.add(ns)
             db.session.commit()
-            current_app.current_services = NatlasServices.get_latest_services()
+            current_app.current_services = NatlasServices.get_latest_services()  # type: ignore[attr-defined]
             flash(
                 f"New service {newServiceName} on port {newServicePort} has been added.",
                 "success",
@@ -354,7 +354,7 @@ def services():
 @bp.route("/services/export", methods=["GET"])
 @login_required
 @is_admin
-def export_services():
+def export_services():  # type: ignore[no-untyped-def]
     current_services = NatlasServices.get_latest_services()
     return Response(str(current_services["services"]), mimetype="text/plain")
 
@@ -362,7 +362,7 @@ def export_services():
 @bp.route("/agents", methods=["GET", "POST"])
 @login_required
 @is_admin
-def agent_config():
+def agent_config():  # type: ignore[no-untyped-def]
     agentConfig = AgentConfig.query.get(1)
     agent_scripts = AgentScript.query.all()
     # pass the model to the form to populate
@@ -374,7 +374,7 @@ def agent_config():
         # populate the object from the form data
         agentForm.populate_obj(agentConfig)
         db.session.commit()
-        current_app.agentConfig = agentConfig.as_dict()
+        current_app.agentConfig = agentConfig.as_dict()  # type: ignore[attr-defined]
         flash("Successfully updated agent configuration.", "success")
 
     return render_template(
@@ -389,14 +389,14 @@ def agent_config():
 @bp.route("/agents/script/add", methods=["POST"])
 @login_required
 @is_admin
-def add_script():
+def add_script():  # type: ignore[no-untyped-def]
     addScriptForm = forms.AddScriptForm(prefix="add-script")
 
     if addScriptForm.validate_on_submit():
         newscript = AgentScript(name=addScriptForm.scriptName.data)
         db.session.add(newscript)
         db.session.commit()
-        current_app.agent_scripts = AgentScript.get_scripts_string()
+        current_app.agent_scripts = AgentScript.get_scripts_string()  # type: ignore[attr-defined]
         flash(f"{newscript.name} successfully added to scripts.", "success")
     else:
         flash(
@@ -409,7 +409,7 @@ def add_script():
 @bp.route("/agents/script/<string:name>/delete", methods=["POST"])
 @login_required
 @is_admin
-def delete_script(name):
+def delete_script(name):  # type: ignore[no-untyped-def]
     deleteForm = forms.DeleteForm()
 
     if deleteForm.validate_on_submit():
@@ -417,7 +417,7 @@ def delete_script(name):
         if delScript:
             db.session.delete(delScript)
             db.session.commit()
-            current_app.agent_scripts = AgentScript.get_scripts_string()
+            current_app.agent_scripts = AgentScript.get_scripts_string()  # type: ignore[attr-defined]
             flash(f"{name} successfully deleted.", "success")
         else:
             flash(f"{name} doesn't exist!", "danger")
@@ -428,12 +428,12 @@ def delete_script(name):
 @bp.route("/scans/delete/<scan_id>", methods=["POST"])
 @login_required
 @is_admin
-def delete_scan(scan_id):
+def delete_scan(scan_id):  # type: ignore[no-untyped-def]
     delForm = forms.DeleteForm()
     redirectLoc = url_for("main.browse")
 
     if delForm.validate_on_submit():
-        deleted = current_app.elastic.delete_scan(scan_id)
+        deleted = current_app.elastic.delete_scan(scan_id)  # type: ignore[attr-defined]
         if deleted not in [1, 2]:
             flash(f"Couldn't delete scan {scan_id}!", "danger")
         else:
@@ -447,12 +447,12 @@ def delete_scan(scan_id):
 @bp.route("/hosts/delete/<ip>", methods=["POST"])
 @login_required
 @is_admin
-def delete_host(ip):
+def delete_host(ip):  # type: ignore[no-untyped-def]
     delForm = forms.DeleteForm()
     redirectLoc = url_for("main.browse")
 
     if delForm.validate_on_submit():
-        deleted = current_app.elastic.delete_host(ip)
+        deleted = current_app.elastic.delete_host(ip)  # type: ignore[attr-defined]
         if deleted > 0:
             flash(
                 f"Successfully deleted {deleted - 1 if deleted > 1 else deleted} scans for {ip}.",
@@ -468,7 +468,7 @@ def delete_host(ip):
 @bp.route("/tags", methods=["GET", "POST"])
 @login_required
 @is_admin
-def tags():
+def tags():  # type: ignore[no-untyped-def]
     tags = Tag.query.all()
 
     addForm = forms.AddTagForm()
@@ -485,6 +485,6 @@ def tags():
 @bp.route("/logs", methods=["GET"])
 @login_required
 @is_admin
-def logs():
+def logs():  # type: ignore[no-untyped-def]
     scope_logs = ScopeLog.query.order_by(ScopeLog.created_at.desc()).all()
     return render_template("admin/logs.html", scope_logs=scope_logs)

--- a/natlas-server/app/api/prepare_work.py
+++ b/natlas-server/app/api/prepare_work.py
@@ -5,7 +5,7 @@ from flask import current_app
 from app.models import ScopeItem
 
 
-def get_target_tags(target: str) -> list:
+def get_target_tags(target: str) -> list:  # type: ignore[type-arg]
     overlap = ScopeItem.get_overlapping_ranges(target)
     tags = []
     for scope in overlap:
@@ -15,22 +15,22 @@ def get_target_tags(target: str) -> list:
     )  # make it a set for only uniques, then make it a list to serialize to JSON
 
 
-def get_unique_scan_id():
+def get_unique_scan_id():  # type: ignore[no-untyped-def]
     scan_id = ""
     while scan_id == "":
         rand = secrets.token_hex(16)
-        count, context = current_app.elastic.get_host_by_scan_id(rand)
+        count, context = current_app.elastic.get_host_by_scan_id(rand)  # type: ignore[attr-defined]
         if count == 0:
             scan_id = rand
     return scan_id
 
 
-def prepare_work(work):
+def prepare_work(work):  # type: ignore[no-untyped-def]
     work["tags"] = get_target_tags(work["target"])
     work["type"] = "nmap"
-    work["agent_config"] = current_app.agentConfig
-    work["agent_config"]["scripts"] = current_app.agent_scripts
-    work["services_hash"] = current_app.current_services["sha256"]
+    work["agent_config"] = current_app.agentConfig  # type: ignore[attr-defined]
+    work["agent_config"]["scripts"] = current_app.agent_scripts  # type: ignore[attr-defined]
+    work["services_hash"] = current_app.current_services["sha256"]  # type: ignore[attr-defined]
     work["scan_id"] = get_unique_scan_id()
     work["status"] = 200
     work["message"] = "Target: " + str(work["target"])

--- a/natlas-server/app/api/processing/screenshot.py
+++ b/natlas-server/app/api/processing/screenshot.py
@@ -32,7 +32,7 @@ def get_file_path(img_hash: str, subdir: str, ext: str) -> str:
     return os.path.join(hash_dir, img_hash + ext)
 
 
-def create_thumbnail(fname, file_ext):
+def create_thumbnail(fname, file_ext):  # type: ignore[no-untyped-def]
     thumb_size = (255, 160)
     thumb = Image.open(fname)
     thumb.thumbnail(thumb_size)
@@ -43,12 +43,12 @@ def create_thumbnail(fname, file_ext):
     return thumb_hash
 
 
-def process_screenshot(screenshot: dict):
+def process_screenshot(screenshot: dict):  # type: ignore[no-untyped-def, type-arg]
     file_ext = get_file_ext(screenshot["service"])
     image = base64.b64decode(screenshot["data"])
     del screenshot["data"]
 
-    if not is_valid_image(BytesIO(image)):
+    if not is_valid_image(BytesIO(image)):  # type: ignore[arg-type]
         return {}
 
     image_hash = hashlib.sha256(image).hexdigest()
@@ -63,7 +63,7 @@ def process_screenshot(screenshot: dict):
     return screenshot
 
 
-def process_screenshots(screenshots: list) -> tuple:
+def process_screenshots(screenshots: list) -> tuple:  # type: ignore[type-arg]
     processed_screenshots = []
     for item in screenshots:
         screenshot = process_screenshot(item)

--- a/natlas-server/app/api/processing/ssl.py
+++ b/natlas-server/app/api/processing/ssl.py
@@ -1,4 +1,4 @@
-def parse_alt_names(cert_data):
+def parse_alt_names(cert_data):  # type: ignore[no-untyped-def]
     altnames = []
     # Parse out Subject Alternative Names because libnmap doesn't give them to us
     for line in cert_data.split("\n"):
@@ -10,7 +10,7 @@ def parse_alt_names(cert_data):
     return altnames
 
 
-def parse_subject(subject, altnames):
+def parse_subject(subject, altnames):  # type: ignore[no-untyped-def]
     subDict = {}
     if subject.get("commonName"):
         subDict["commonName"] = subject.get("commonName")
@@ -19,7 +19,7 @@ def parse_subject(subject, altnames):
     return subDict
 
 
-def parse_pubkey(pubkey):
+def parse_pubkey(pubkey):  # type: ignore[no-untyped-def]
     pubkeyDict = {}
     if pubkey.get("type"):
         pubkeyDict["type"] = pubkey.get("type")
@@ -28,7 +28,7 @@ def parse_pubkey(pubkey):
     return pubkeyDict
 
 
-def parse_ssl_data(sslcert):
+def parse_ssl_data(sslcert):  # type: ignore[no-untyped-def]
     altnames = parse_alt_names(sslcert["output"])
     elements = sslcert["elements"]
     subject = elements.get("subject")

--- a/natlas-server/app/api/rescan_handler.py
+++ b/natlas-server/app/api/rescan_handler.py
@@ -3,21 +3,21 @@ from flask import current_app
 from app import db
 
 
-def mark_scan_dispatched(rescan):
+def mark_scan_dispatched(rescan):  # type: ignore[no-untyped-def]
     rescan.dispatchTask()
     db.session.add(rescan)
     db.session.commit()
-    current_app.ScopeManager.update_pending_rescans()
-    current_app.ScopeManager.update_dispatched_rescans()
+    current_app.ScopeManager.update_pending_rescans()  # type: ignore[attr-defined]
+    current_app.ScopeManager.update_dispatched_rescans()  # type: ignore[attr-defined]
 
 
-def mark_scan_completed(ip, scan_id):
-    dispatched = current_app.ScopeManager.get_dispatched_rescans()
+def mark_scan_completed(ip, scan_id):  # type: ignore[no-untyped-def]
+    dispatched = current_app.ScopeManager.get_dispatched_rescans()  # type: ignore[attr-defined]
     for scan in dispatched:
         if scan.target == ip:
             scan.completeTask(scan_id)
             db.session.add(scan)
             db.session.commit()
-            current_app.ScopeManager.update_dispatched_rescans()
+            current_app.ScopeManager.update_dispatched_rescans()  # type: ignore[attr-defined]
             return True
     return False

--- a/natlas-server/app/auth/email.py
+++ b/natlas-server/app/auth/email.py
@@ -16,7 +16,7 @@ token_types = {
 }
 
 
-def validate_email(addr):
+def validate_email(addr):  # type: ignore[no-untyped-def]
     from app.models import User
 
     validemail = User.validate_email(addr)
@@ -29,7 +29,7 @@ def validate_email(addr):
     return validemail
 
 
-def build_email_url(token, token_type):
+def build_email_url(token, token_type):  # type: ignore[no-untyped-def]
     return url_for(
         token_types[token_type]["route"],
         token=token,
@@ -39,10 +39,10 @@ def build_email_url(token, token_type):
 
 
 def email_configured() -> bool:
-    return current_app.config["MAIL_FROM"] and current_app.config["MAIL_SERVER"]
+    return current_app.config["MAIL_FROM"] and current_app.config["MAIL_SERVER"]  # type: ignore[no-any-return]
 
 
-def send_auth_email(email, token, token_type):
+def send_auth_email(email, token, token_type):  # type: ignore[no-untyped-def]
     send_email(
         token_types[token_type]["subject"],
         sender=current_app.config["MAIL_FROM"],
@@ -53,7 +53,7 @@ def send_auth_email(email, token, token_type):
     )
 
 
-def deliver_auth_link(email: str, token: str, token_type: str):
+def deliver_auth_link(email: str, token: str, token_type: str):  # type: ignore[no-untyped-def]
     if email_configured() and email:
         send_auth_email(email, token, token_type)
         msg = f"Email sent to {email} via {current_app.config['MAIL_SERVER']}!"

--- a/natlas-server/app/auth/forms.py
+++ b/natlas-server/app/auth/forms.py
@@ -5,14 +5,14 @@ from wtforms.validators import DataRequired, Email, EqualTo, Length, ValidationE
 from app.models import User
 
 
-class LoginForm(FlaskForm):
+class LoginForm(FlaskForm):  # type: ignore[misc]
     email = StringField("Email", validators=[DataRequired(), Email()])
     password = PasswordField("Password", validators=[DataRequired()])
     remember_me = BooleanField("Remember Me")
     submit = SubmitField("Sign In")
 
 
-class RegistrationForm(FlaskForm):
+class RegistrationForm(FlaskForm):  # type: ignore[misc]
     email = StringField("Email", validators=[DataRequired(), Email()])
     password = PasswordField("Password", validators=[DataRequired(), Length(min=8)])
     password2 = PasswordField(
@@ -20,18 +20,18 @@ class RegistrationForm(FlaskForm):
     )
     submit = SubmitField("Register")
 
-    def validate_email(self, email):
+    def validate_email(self, email):  # type: ignore[no-untyped-def]
         user = User.query.filter_by(email=email.data.lower()).first()
         if user is not None:
             raise ValidationError("Email already exists!")
 
 
-class ResetPasswordRequestForm(FlaskForm):
+class ResetPasswordRequestForm(FlaskForm):  # type: ignore[misc]
     email = StringField("Email", validators=[DataRequired(), Email()])
     submit = SubmitField("Request Password Reset")
 
 
-class ResetPasswordForm(FlaskForm):
+class ResetPasswordForm(FlaskForm):  # type: ignore[misc]
     password = PasswordField("Password", validators=[DataRequired(), Length(min=8)])
     password2 = PasswordField(
         "Repeat Password", validators=[DataRequired(), EqualTo("password")]
@@ -39,7 +39,7 @@ class ResetPasswordForm(FlaskForm):
     submit = SubmitField("Reset Password")
 
 
-class AcceptInviteForm(FlaskForm):
+class AcceptInviteForm(FlaskForm):  # type: ignore[misc]
     password = PasswordField("Password", validators=[DataRequired(), Length(min=8)])
     password2 = PasswordField(
         "Repeat Password", validators=[DataRequired(), EqualTo("password")]

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -19,7 +19,7 @@ from app.models import User, UserInvitation
 
 @bp.route("/login", methods=["GET", "POST"])
 @is_not_authenticated
-def login():
+def login():  # type: ignore[no-untyped-def]
     form = LoginForm(prefix="login")
     if form.validate_on_submit():
         user = User.query.filter_by(email=User.validate_email(form.email.data)).first()
@@ -36,14 +36,14 @@ def login():
 
 @bp.route("/logout")
 @is_authenticated
-def logout():
+def logout():  # type: ignore[no-untyped-def]
     logout_user()
     return redirect(url_for("auth.login"))
 
 
 @bp.route("/register", methods=["GET", "POST"])
 @is_not_authenticated
-def register():
+def register():  # type: ignore[no-untyped-def]
     if not current_app.config["REGISTER_ALLOWED"]:
         flash(
             "Sorry, we're not currently accepting new users. If you feel you've received this message in error, please contact an administrator.",
@@ -67,7 +67,7 @@ def register():
 
 @bp.route("/reset_password_request", methods=["GET", "POST"])
 @is_not_authenticated
-def reset_password_request():
+def reset_password_request():  # type: ignore[no-untyped-def]
     if not email_configured():
         flash(
             "Sorry, self-service password resets are not currently available. Please contact an administrator for assistance.",
@@ -95,7 +95,7 @@ def reset_password_request():
 
 @bp.route("/reset_password", methods=["GET", "POST"])
 @is_not_authenticated
-def reset_password():
+def reset_password():  # type: ignore[no-untyped-def]
     url_token = request.args.get("token", None)
     if not url_token:
         flash("No reset token found")
@@ -119,7 +119,7 @@ def reset_password():
 
 @bp.route("/invite", methods=["GET", "POST"])
 @is_not_authenticated
-def invite_user():
+def invite_user():  # type: ignore[no-untyped-def]
     url_token = request.args.get("token", None)
     invite = UserInvitation.get_invite(url_token)
     if not invite:
@@ -132,7 +132,7 @@ def invite_user():
     }
 
     form_type = "invite" if invite.email else "register"
-    form = supported_forms[form_type]["form"]()
+    form = supported_forms[form_type]["form"]()  # type: ignore[operator]
     if form.validate_on_submit():
         email = invite.email if invite.email else form.email.data
         new_user = User.new_user_from_invite(invite, form.password.data, email=email)
@@ -141,5 +141,7 @@ def invite_user():
         flash("Your password has been set.", "success")
         return redirect(url_for("main.browse"))
     return render_template(
-        supported_forms[form_type]["template"], title="Accept Invitation", form=form
+        supported_forms[form_type]["template"],
+        title="Accept Invitation",
+        form=form,  # type: ignore[arg-type]
     )

--- a/natlas-server/app/auth/wrappers.py
+++ b/natlas-server/app/auth/wrappers.py
@@ -9,9 +9,9 @@ from app.models import Agent
 
 
 # This can be used in lieu of @login_required for pages that don't require a user account
-def is_authenticated(f):
+def is_authenticated(f):  # type: ignore[no-untyped-def]
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
         if current_app.config["LOGIN_REQUIRED"] and not current_user.is_authenticated:
             return lm.unauthorized()
         return f(*args, **kwargs)
@@ -20,9 +20,9 @@ def is_authenticated(f):
 
 
 # An explicit wrapper to make a route only available if a request is not authenticated
-def is_not_authenticated(f):
+def is_not_authenticated(f):  # type: ignore[no-untyped-def]
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
         if current_user.is_authenticated:
             flash("You're already logged in!", "warning")
             return redirect(url_for("main.browse"))
@@ -32,9 +32,9 @@ def is_not_authenticated(f):
 
 
 # Ensure current user is an admin
-def is_admin(f):
+def is_admin(f):  # type: ignore[no-untyped-def]
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
         if current_user.is_anonymous or not current_user.is_admin:
             return lm.unauthorized()
         return f(*args, **kwargs)
@@ -43,9 +43,9 @@ def is_admin(f):
 
 
 # Validate agent authentication if required
-def is_agent_authenticated(f):
+def is_agent_authenticated(f):  # type: ignore[no-untyped-def]
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
         # if we don't require agent authentication then don't bother
         if not current_app.config["AGENT_AUTHENTICATION"]:
             return f(*args, **kwargs)

--- a/natlas-server/app/cli/scope.py
+++ b/natlas-server/app/cli/scope.py
@@ -14,8 +14,8 @@ import_helptext = "Import scope/blacklist from a file containing line-separated 
 Optionally, each line can contain a comma separated list of tags to apply to that target. e.g. 127.0.0.1,local,private,test"
 
 
-def import_scope(scope_file: typing.TextIO, blacklist: bool):
-    if not scope_file:
+def import_scope(scope_file: typing.TextIO, blacklist: bool):  # type: ignore[no-untyped-def]
+    if not scope_file:  # type: ignore[truthy-bool]
         return {"failed": 0, "existed": 0, "successful": 0}
     addresses = scope_file.readlines()
     result = ScopeItem.import_scope_list(addresses, blacklist)
@@ -32,17 +32,17 @@ def import_scope(scope_file: typing.TextIO, blacklist: bool):
     default=False,
     help="Should this file be considered in scope or blacklisted?",
 )
-def import_items(file: str, import_as_blacklist: bool):
+def import_items(file: str, import_as_blacklist: bool):  # type: ignore[no-untyped-def]
     import_name = "blacklist" if import_as_blacklist else "scope"
     results = {
         "timestamp": datetime.utcnow().isoformat(),
-        import_name: import_scope(file, import_as_blacklist),
+        import_name: import_scope(file, import_as_blacklist),  # type: ignore[arg-type]
     }
     print(json.dumps(results, indent=2))
 
 
 @cli_group.command("export")
-def export_items():
+def export_items():  # type: ignore[no-untyped-def]
     result = {
         "timestamp": datetime.utcnow().isoformat(),
         "scope": [

--- a/natlas-server/app/cli/user.py
+++ b/natlas-server/app/cli/user.py
@@ -16,14 +16,14 @@ err_msgs = {
 }
 
 
-def get_user(email):
+def get_user(email):  # type: ignore[no-untyped-def]
     user = User.query.filter_by(email=email).first()
     if not user:
         raise click.BadParameter(err_msgs["no_such_user"].format(email))
     return user
 
 
-def validate_email(ctx, param, value):
+def validate_email(ctx, param, value):  # type: ignore[no-untyped-def]
     if not value:
         return None
     valid_email = User.validate_email(value)
@@ -32,7 +32,7 @@ def validate_email(ctx, param, value):
     return valid_email
 
 
-def ensure_server_name():
+def ensure_server_name():  # type: ignore[no-untyped-def]
     if not current_app.config["SERVER_NAME"]:
         raise click.UsageError(err_msgs["server_name"])
 
@@ -40,7 +40,7 @@ def ensure_server_name():
 @cli_group.command("new")
 @click.option("--email", callback=validate_email, default=None)
 @click.option("--admin", is_flag=True, default=False)
-def new_user(email, admin):
+def new_user(email, admin):  # type: ignore[no-untyped-def]
     ensure_server_name()
 
     if email and User.exists(email):
@@ -55,7 +55,7 @@ def new_user(email, admin):
 @cli_group.command("role")
 @click.argument("email", callback=validate_email)
 @click.option("--promote/--demote", default=False)
-def promote_user(email, promote):
+def promote_user(email, promote):  # type: ignore[no-untyped-def]
     user = get_user(email)
     if user.is_admin == promote:
         print(f"{email} is already{' not ' if not promote else ' '}an admin")
@@ -67,7 +67,7 @@ def promote_user(email, promote):
 
 @cli_group.command("reset-password")
 @click.argument("email", callback=validate_email)
-def reset_password(email):
+def reset_password(email):  # type: ignore[no-untyped-def]
     ensure_server_name()
     user = User.get_reset_token(email)
     if not user:

--- a/natlas-server/app/config_loader.py
+++ b/natlas-server/app/config_loader.py
@@ -2,7 +2,7 @@ import config
 import sqlalchemy
 
 
-def load_natlas_config(app, db):
+def load_natlas_config(app, db):  # type: ignore[no-untyped-def]
     insp = sqlalchemy.inspect(db.engine)
     if not insp.has_table("config_item"):
         return
@@ -13,7 +13,7 @@ def load_natlas_config(app, db):
         app.config[item.name] = config.casted_value(item.type, item.value)
 
 
-def load_natlas_services(app, db):
+def load_natlas_services(app, db):  # type: ignore[no-untyped-def]
     insp = sqlalchemy.inspect(db.engine)
     if not insp.has_table("natlas_services"):
         return
@@ -22,7 +22,7 @@ def load_natlas_services(app, db):
     app.current_services = NatlasServices.get_latest_services()
 
 
-def load_agent_config(app, db):
+def load_agent_config(app, db):  # type: ignore[no-untyped-def]
     insp = sqlalchemy.inspect(db.engine)
     if not insp.has_table("agent_config"):
         return
@@ -33,7 +33,7 @@ def load_agent_config(app, db):
     app.agentConfig = db.session.get(AgentConfig, 1).as_dict()
 
 
-def load_agent_scripts(app, db):
+def load_agent_scripts(app, db):  # type: ignore[no-untyped-def]
     insp = sqlalchemy.inspect(db.engine)
     if not insp.has_table("agent_script"):
         return
@@ -43,7 +43,7 @@ def load_agent_scripts(app, db):
     app.agent_scripts = AgentScript.get_scripts_string()
 
 
-def load_config_from_db(app, db):
+def load_config_from_db(app, db):  # type: ignore[no-untyped-def]
     load_natlas_config(app, db)
     load_natlas_services(app, db)
     load_agent_config(app, db)

--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -8,8 +8,8 @@ from opentelemetry import trace
 
 
 class ElasticClient:
-    es = None
-    lastReconnectAttempt = None
+    es = None  # type: ignore[var-annotated]
+    lastReconnectAttempt = None  # type: ignore[var-annotated]
     status = False
     # Quiets the elasticsearch logger because otherwise connection errors print tracebacks to the WARNING level, even when the exception is handled.
     logger = logging.getLogger("elasticsearch")
@@ -43,26 +43,26 @@ class ElasticClient:
             # Set the lastReconnectAttempt to the timestamp after initialization
             self.lastReconnectAttempt = datetime.utcnow()
 
-    def _ping(self):
+    def _ping(self):  # type: ignore[no-untyped-def]
         """
         Returns True if the cluster is up, False otherwise
         """
         with self._new_trace_span(operation="ping"):
-            return self.es.ping()
+            return self.es.ping()  # type: ignore[union-attr]
 
-    def _attempt_reconnect(self):
+    def _attempt_reconnect(self):  # type: ignore[no-untyped-def]
         """
         Attempt to reconnect if we haven't tried to reconnect too recently
         """
         now = datetime.utcnow()
-        delta = now - self.lastReconnectAttempt
+        delta = now - self.lastReconnectAttempt  # type: ignore[operator]
         if delta.seconds >= 30:
             self.status = self._ping()
             self.lastReconnectAttempt = now
 
         return self.status
 
-    def _check_status(self):
+    def _check_status(self):  # type: ignore[no-untyped-def]
         """
         If we're in a known bad state, try to reconnect
         """
@@ -70,40 +70,40 @@ class ElasticClient:
             raise elasticsearch.ConnectionError("Could not connect to Elasticsearch")
         return self.status
 
-    def set_auth(self, elasticUser: str, elasticPassword: str):
-        self.es.options(basic_auth=(elasticUser, elasticPassword))
+    def set_auth(self, elasticUser: str, elasticPassword: str):  # type: ignore[no-untyped-def]
+        self.es.options(basic_auth=(elasticUser, elasticPassword))  # type: ignore[union-attr]
 
-    def initialize_index(self, index: str, mapping: dict):
+    def initialize_index(self, index: str, mapping: dict):  # type: ignore[no-untyped-def, type-arg]
         """
         Check each required index and make sure it exists, if it doesn't then create it
         """
         with self._new_trace_span(operation="initialize_index"):
-            if not self.es.indices.exists(index=index):
-                self.es.indices.create(index=index)
+            if not self.es.indices.exists(index=index):  # type: ignore[union-attr]
+                self.es.indices.create(index=index)  # type: ignore[union-attr]
 
             time.sleep(1)
 
             if self.esversion.match("<7.0.0"):
-                self.es.indices.put_mapping(
+                self.es.indices.put_mapping(  # type: ignore[union-attr]
                     index=index, doc_type="_doc", body=mapping, include_type_name=True
                 )
             else:
-                self.es.indices.put_mapping(index=index, body=mapping)
+                self.es.indices.put_mapping(index=index, body=mapping)  # type: ignore[union-attr]
 
-    def delete_index(self, index: str):
+    def delete_index(self, index: str):  # type: ignore[no-untyped-def]
         """
         Delete an existing index
         """
-        if self.es.indices.exists(index=index):
-            self.es.indices.delete(index=index)
+        if self.es.indices.exists(index=index):  # type: ignore[union-attr]
+            self.es.indices.delete(index=index)  # type: ignore[union-attr]
 
-    def index_exists(self, index: str):
+    def index_exists(self, index: str):  # type: ignore[no-untyped-def]
         """
         Check if index exists
         """
-        return self.es.indices.exists(index=index)
+        return self.es.indices.exists(index=index)  # type: ignore[union-attr]
 
-    def get_collection(self, **kwargs):
+    def get_collection(self, **kwargs):  # type: ignore[no-untyped-def]
         """
         Execute a search and return a collection of results
         """
@@ -113,7 +113,7 @@ class ElasticClient:
         docsources = self.collate_source(results["hits"]["hits"])
         return results["hits"]["total"], docsources
 
-    def get_single_host(self, **kwargs):
+    def get_single_host(self, **kwargs):  # type: ignore[no-untyped-def]
         """
         Execute a search and return a single result
         """
@@ -122,62 +122,64 @@ class ElasticClient:
             return 0, None
         return results["hits"]["total"], results["hits"]["hits"][0]["_source"]
 
-    def collate_source(self, documents):
+    def collate_source(self, documents):  # type: ignore[no-untyped-def]
         return [doc["_source"] for doc in documents]
 
     # Mid-level query executor abstraction.
-    def execute_search(self, **kwargs):
+    def execute_search(self, **kwargs):  # type: ignore[no-untyped-def]
         """
         Execute an arbitrary search.
         """
         with self._new_trace_span(operation="search", **kwargs) as span:
             results = self._execute_raw_query(
-                self.es.search, rest_total_hits_as_int=True, **kwargs
+                self.es.search,
+                rest_total_hits_as_int=True,
+                **kwargs,  # type: ignore[union-attr]
             )
             span.set_attribute("es.hits.total", results["hits"]["total"])
             self._attach_shard_span_attrs(span, results)
             return results
 
-    def execute_count(self, **kwargs):
+    def execute_count(self, **kwargs):  # type: ignore[no-untyped-def]
         """
         Executes an arbitrary count.
         """
         results = None
         with self._new_trace_span(operation="count", **kwargs) as span:
-            results = self._execute_raw_query(self.es.count, **kwargs)
+            results = self._execute_raw_query(self.es.count, **kwargs)  # type: ignore[union-attr]
             self._attach_shard_span_attrs(span, results)
         if not results:
             return 0
         return results
 
-    def execute_delete_by_query(self, **kwargs):
+    def execute_delete_by_query(self, **kwargs):  # type: ignore[no-untyped-def]
         """
         Executes an arbitrary delete_by_query.
         """
         with self._new_trace_span(operation="delete_by", **kwargs):
-            return self._execute_raw_query(self.es.delete_by_query, **kwargs)
+            return self._execute_raw_query(self.es.delete_by_query, **kwargs)  # type: ignore[union-attr]
 
-    def execute_index(self, **kwargs):
+    def execute_index(self, **kwargs):  # type: ignore[no-untyped-def]
         """
         Executes an arbitrary index.
         """
         with self._new_trace_span(operation="index", **kwargs):
-            return self._execute_raw_query(self.es.index, **kwargs)
+            return self._execute_raw_query(self.es.index, **kwargs)  # type: ignore[union-attr]
 
     # Inner-most query executor. All queries route through here.
-    def _execute_raw_query(self, func: callable, **kwargs):
+    def _execute_raw_query(self, func: callable, **kwargs):  # type: ignore[no-untyped-def, valid-type]
         """
         Wraps the es client to make sure that ConnectionErrors are handled uniformly
         """
         self._check_status()
         try:
-            return func(**kwargs)
+            return func(**kwargs)  # type: ignore[misc]
         except elasticsearch.ConnectionError:
             self.status = False
             raise
 
     # Tracing methods
-    def _new_trace_span(self, operation: str, **kwargs):
+    def _new_trace_span(self, operation: str, **kwargs):  # type: ignore[no-untyped-def]
         tracer = trace.get_tracer(__name__)
         span_name = "elasticsearch"
         if "index" in kwargs:
@@ -189,6 +191,6 @@ class ElasticClient:
             span.set_attribute("es.query", f'{kwargs["body"]}')
         return span
 
-    def _attach_shard_span_attrs(self, span, results: dict):
+    def _attach_shard_span_attrs(self, span, results: dict):  # type: ignore[no-untyped-def, type-arg]
         span.set_attribute("es.shards.total", results["_shards"]["total"])
         span.set_attribute("es.shards.successful", results["_shards"]["successful"])

--- a/natlas-server/app/elastic/indices.py
+++ b/natlas-server/app/elastic/indices.py
@@ -7,8 +7,8 @@ from app.elastic.client import ElasticClient
 
 
 class ElasticIndices:
-    basename = None
-    indices = None
+    basename = None  # type: ignore[var-annotated]
+    indices = None  # type: ignore[var-annotated]
     logger = logging.getLogger("elasticsearch")
     logger.setLevel("ERROR")
 
@@ -18,7 +18,7 @@ class ElasticIndices:
         self.indices = {"latest": basename, "history": f"{basename}_history"}
         self._initialize_indices()
 
-    def _initialize_indices(self):
+    def _initialize_indices(self):  # type: ignore[no-untyped-def]
         """
         Ensure each index in this context is initalized
         """
@@ -28,7 +28,7 @@ class ElasticIndices:
             self.client.initialize_index(index, mapping)
         self.logger.info(f"Initialized Elasticsearch {self.basename} indices")
 
-    def _delete_indices(self):
+    def _delete_indices(self):  # type: ignore[no-untyped-def]
         """
         Delete all indices in this context
         """
@@ -36,19 +36,19 @@ class ElasticIndices:
             self.client.delete_index(index=index)
         self.logger.info(f"Deleted Elasticsearch {self.basename} indices")
 
-    def name(self, alias: str):
+    def name(self, alias: str):  # type: ignore[no-untyped-def]
         """
         Get the name of an index based on the current context
         """
-        return self.indices[alias]
+        return self.indices[alias]  # type: ignore[index]
 
-    def all_indices(self):
+    def all_indices(self):  # type: ignore[no-untyped-def]
         """
         Return a list of indices in the current context
         """
-        return [v for _, v in self.indices.items()]
+        return [v for _, v in self.indices.items()]  # type: ignore[union-attr]
 
-    def str_indices(self):
+    def str_indices(self):  # type: ignore[no-untyped-def]
         """
         Return a comma-separated string of indices in the current context
         """

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -7,8 +7,8 @@ from app.elastic.indices import ElasticIndices
 
 
 class ElasticInterface:
-    client = None
-    indices = None
+    client = None  # type: ignore[var-annotated]
+    indices = None  # type: ignore[var-annotated]
 
     def __init__(
         self,
@@ -26,13 +26,13 @@ class ElasticInterface:
         )
         self.indices = ElasticIndices(self.client, basename)
 
-    def search(
+    def search(  # type: ignore[no-untyped-def]
         self, limit: int, offset: int, query: str = "nmap", searchIndex: str = "latest"
     ):
         """
         Execute a user supplied search and return the results
         """
-        query = {
+        query = {  # type: ignore[assignment]
             "bool": {
                 "must": [
                     {
@@ -49,33 +49,35 @@ class ElasticInterface:
         }
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_collection(
-            index=self.indices.name(searchIndex),
+        return self.client.get_collection(  # type: ignore[union-attr]
+            index=self.indices.name(searchIndex),  # type: ignore[union-attr]
             query=query,
             sort=sort,
             from_=offset,
         )
 
-    def total_hosts(self):
+    def total_hosts(self):  # type: ignore[no-untyped-def]
         """
         Count the number of documents in nmap and return the count
         """
-        result = self.client.execute_count(index=self.indices.name("latest"))
+        result = self.client.execute_count(index=self.indices.name("latest"))  # type: ignore[union-attr]
         return result["count"]
 
-    def new_result(self, host: dict):
+    def new_result(self, host: dict):  # type: ignore[no-untyped-def, type-arg]
         """
         Create new elastic documents in both indices for a new scan result
         """
         ip = str(host["ip"])
 
-        self.client.execute_index(index=self.indices.name("history"), document=host)
-        self.client.execute_index(
-            index=self.indices.name("latest"), id=ip, document=host
+        self.client.execute_index(index=self.indices.name("history"), document=host)  # type: ignore[union-attr]
+        self.client.execute_index(  # type: ignore[union-attr]
+            index=self.indices.name("latest"),
+            id=ip,
+            document=host,  # type: ignore[union-attr]
         )
         return True
 
-    def get_host(self, ip: str):
+    def get_host(self, ip: str):  # type: ignore[no-untyped-def]
         """
         Gets the most recent result for a host, but by querying the nmap_history it also gives us the total number of historical results
         """
@@ -84,26 +86,29 @@ class ElasticInterface:
         query = {"term": {"ip": ip}}
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_single_host(
-            index=self.indices.name("history"), size=size, query=query, sort=sort
+        return self.client.get_single_host(  # type: ignore[union-attr]
+            index=self.indices.name("history"),
+            size=size,
+            query=query,
+            sort=sort,  # type: ignore[union-attr]
         )
 
-    def get_host_history(self, ip: str, limit: int, offset: int):
+    def get_host_history(self, ip: str, limit: int, offset: int):  # type: ignore[no-untyped-def]
         """
         Gets a collection of historical results for a specific ip address
         """
         query = {"term": {"ip": ip}}
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_collection(
-            index=self.indices.name("history"),
+        return self.client.get_collection(  # type: ignore[union-attr]
+            index=self.indices.name("history"),  # type: ignore[union-attr]
             size=limit,
             from_=offset,
             query=query,
             sort=sort,
         )
 
-    def count_host_screenshots(self, ip: str):
+    def count_host_screenshots(self, ip: str):  # type: ignore[no-untyped-def]
         """
         Search history for an ip address and returns the number of historical screenshots
         """
@@ -114,7 +119,7 @@ class ElasticInterface:
         result = self.count_scans_matching(query=query, aggs=aggs)
         return int(result["aggregations"]["screenshot_count"]["value"])
 
-    def get_host_screenshots(self, ip: str, limit: int, offset: int):
+    def get_host_screenshots(self, ip: str, limit: int, offset: int):  # type: ignore[no-untyped-def]
         """
         Gets screenshots and minimal context for a given host
         """
@@ -128,8 +133,8 @@ class ElasticInterface:
         }
         sort = {"ctime": {"order": "desc"}}
         source_fields = ["screenshots", "ctime", "scan_id"]
-        return self.client.get_collection(
-            index=self.indices.name("history"),
+        return self.client.get_collection(  # type: ignore[union-attr]
+            index=self.indices.name("history"),  # type: ignore[union-attr]
             query=query,
             size=limit,
             from_=offset,
@@ -138,7 +143,7 @@ class ElasticInterface:
             track_scores=False,
         )
 
-    def get_host_by_scan_id(self, scan_id: str):
+    def get_host_by_scan_id(self, scan_id: str):  # type: ignore[no-untyped-def]
         """
         Get a specific historical result based on scan_id, which should be unique
         """
@@ -153,11 +158,14 @@ class ElasticInterface:
         }
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_single_host(
-            index=self.indices.name("history"), size=size, query=query, sort=sort
+        return self.client.get_single_host(  # type: ignore[union-attr]
+            index=self.indices.name("history"),
+            size=size,
+            query=query,
+            sort=sort,  # type: ignore[union-attr]
         )
 
-    def delete_scan(self, scan_id: str):
+    def delete_scan(self, scan_id: str):  # type: ignore[no-untyped-def]
         """
         Delete a specific scan, if it's the most recent then try to migrate the next oldest back into the latest index
         """
@@ -165,8 +173,11 @@ class ElasticInterface:
         size = 1
         query = {"query_string": {"query": scan_id, "fields": ["scan_id"]}}
         sort = {"ctime": {"order": "desc"}}
-        count, host = self.client.get_single_host(
-            index=self.indices.name("latest"), size=size, query=query, sort=sort
+        count, host = self.client.get_single_host(  # type: ignore[union-attr]
+            index=self.indices.name("latest"),
+            size=size,
+            query=query,
+            sort=sort,  # type: ignore[union-attr]
         )
         if count != 0:
             # we're deleting the most recent scan result and need to pull the next most recent into the nmap index
@@ -176,8 +187,11 @@ class ElasticInterface:
             query = {"query_string": {"query": ipaddr, "fields": ["ip"]}}
             sort = {"ctime": {"order": "desc"}}
 
-            count, twoscans = self.client.get_collection(
-                index=self.indices.name("history"), size=size, query=query, sort=sort
+            count, twoscans = self.client.get_collection(  # type: ignore[union-attr]
+                index=self.indices.name("history"),
+                size=size,
+                query=query,
+                sort=sort,  # type: ignore[union-attr]
             )
             # If count is one then there's only one result in history so we can just delete it.
             # If count is > 1 then we need to migrate the next oldest scan data
@@ -192,16 +206,19 @@ class ElasticInterface:
                 }
             }
         }
-        result = self.client.execute_delete_by_query(
-            index=self.indices.str_indices(), body=deleteBody
+        result = self.client.execute_delete_by_query(  # type: ignore[union-attr]
+            index=self.indices.str_indices(),
+            body=deleteBody,  # type: ignore[union-attr]
         )
         if migrate:
-            self.client.execute_index(
-                index=self.indices.name("latest"), id=ipaddr, document=twoscans[1]
+            self.client.execute_index(  # type: ignore[union-attr]
+                index=self.indices.name("latest"),
+                id=ipaddr,
+                document=twoscans[1],  # type: ignore[possibly-undefined, union-attr]
             )
         return result["deleted"]
 
-    def delete_host(self, ip: str):
+    def delete_host(self, ip: str):  # type: ignore[no-untyped-def]
         """
         Delete all occurrences of a given ip address
         """
@@ -215,12 +232,13 @@ class ElasticInterface:
             }
         }
 
-        deleted = self.client.execute_delete_by_query(
-            index=self.indices.str_indices(), body=deleteBody
+        deleted = self.client.execute_delete_by_query(  # type: ignore[union-attr]
+            index=self.indices.str_indices(),
+            body=deleteBody,  # type: ignore[union-attr]
         )
         return deleted["deleted"]
 
-    def random_host(self):
+    def random_host(self):  # type: ignore[no-untyped-def]
         """
         Get a random single host and return it
         """
@@ -241,12 +259,15 @@ class ElasticInterface:
             }
         }
 
-        count, host = self.client.get_single_host(
-            index=self.indices.name("latest"), size=size, from_=offset, query=query
+        count, host = self.client.get_single_host(  # type: ignore[union-attr]
+            index=self.indices.name("latest"),
+            size=size,
+            from_=offset,
+            query=query,  # type: ignore[union-attr]
         )
         return host
 
-    def get_current_screenshots(self, limit: int, offset: int):
+    def get_current_screenshots(self, limit: int, offset: int):  # type: ignore[no-untyped-def]
         """
         Get all current screenshots
         """
@@ -255,8 +276,8 @@ class ElasticInterface:
         sort = {"ctime": {"order": "desc"}}
         source_fields = ["screenshots", "ctime", "scan_id", "ip"]
         # We need to execute_search instead of get_collection here because we also need the aggregation information
-        result = self.client.execute_search(
-            index=self.indices.name("latest"),
+        result = self.client.execute_search(  # type: ignore[union-attr]
+            index=self.indices.name("latest"),  # type: ignore[union-attr]
             query=query,
             size=limit,
             from_=offset,
@@ -266,21 +287,24 @@ class ElasticInterface:
             track_scores=False,
         )
         num_screenshots = int(result["aggregations"]["screenshot_count"]["value"])
-        results = self.client.collate_source(result["hits"]["hits"])
+        results = self.client.collate_source(result["hits"]["hits"])  # type: ignore[union-attr]
 
         return result["hits"]["total"], num_screenshots, results
 
-    def count_scans_since(self, timestamp: datetime):
+    def count_scans_since(self, timestamp: datetime):  # type: ignore[no-untyped-def]
         """
         Count the number of scans that started after a given timestamp
         """
         query = {"range": {"scan_start": {"gte": timestamp}}}
         return self.count_scans_matching(query=query)["hits"]["total"]
 
-    def count_scans_matching(self, index: str = "history", **kwargs):
+    def count_scans_matching(self, index: str = "history", **kwargs):  # type: ignore[no-untyped-def]
         """
         Count the number of scans that match an arbitrary search body
         """
-        return self.client.execute_search(
-            index=self.indices.name(index), size=0, track_scores=False, **kwargs
+        return self.client.execute_search(  # type: ignore[union-attr]
+            index=self.indices.name(index),
+            size=0,
+            track_scores=False,
+            **kwargs,  # type: ignore[union-attr]
         )

--- a/natlas-server/app/email.py
+++ b/natlas-server/app/email.py
@@ -6,14 +6,15 @@ from flask_mail import Message
 from app import mail
 
 
-def send_async_email(app, msg):
+def send_async_email(app, msg):  # type: ignore[no-untyped-def]
     with app.app_context():
         mail.send(msg)
 
 
-def send_email(subject, sender, recipients, text_body):
+def send_email(subject, sender, recipients, text_body):  # type: ignore[no-untyped-def]
     msg = Message(subject, sender=sender, recipients=recipients)
     msg.body = text_body
     Thread(
-        target=send_async_email, args=(current_app._get_current_object(), msg)
+        target=send_async_email,
+        args=(current_app._get_current_object(), msg),  # type: ignore[attr-defined]
     ).start()

--- a/natlas-server/app/errors/errors.py
+++ b/natlas-server/app/errors/errors.py
@@ -7,18 +7,18 @@ class NatlasServiceError(Exception):
         self.message = message
         self.template = template if template else f"errors/{self.status_code}.html"
 
-    def __str__(self):
+    def __str__(self):  # type: ignore[no-untyped-def]
         return f"{self.status_code}: {self.message}"
 
-    def get_dict(self):
+    def get_dict(self):  # type: ignore[no-untyped-def]
         return {"status": self.status_code, "message": self.message}
 
-    def get_json(self):
+    def get_json(self):  # type: ignore[no-untyped-def]
         return json.dumps(self.get_dict(), sort_keys=True, indent=4)
 
 
 class NatlasSearchError(NatlasServiceError):
-    def __init__(self, e):
+    def __init__(self, e):  # type: ignore[no-untyped-def]
         self.status_code = 400
         self.message = e.info["error"]["root_cause"][0]["reason"]
         self.template = "errors/search.html"

--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -7,7 +7,7 @@ from app.errors import NatlasSearchError, NatlasServiceError, bp
 from app.errors.responses import get_response, get_supported_formats
 
 
-def build_response(err: NatlasServiceError):
+def build_response(err: NatlasServiceError):  # type: ignore[no-untyped-def]
     selected_format = request.accept_mimetypes.best_match(
         get_supported_formats(), default="application/json"
     )
@@ -15,28 +15,28 @@ def build_response(err: NatlasServiceError):
 
 
 @bp.app_errorhandler(400)
-def bad_request(e):
+def bad_request(e):  # type: ignore[no-untyped-def]
     errmsg = "The server was unable to process your request"
     err = NatlasServiceError(400, errmsg)
     return build_response(err)
 
 
 @bp.app_errorhandler(404)
-def page_not_found(e):
+def page_not_found(e):  # type: ignore[no-untyped-def]
     errmsg = f"{request.path} Not found"
     err = NatlasServiceError(404, errmsg)
     return build_response(err)
 
 
 @bp.app_errorhandler(405)
-def method_not_allowed(e):
+def method_not_allowed(e):  # type: ignore[no-untyped-def]
     errmsg = f"Method {request.method} Not Allowed on {request.path}"
     err = NatlasServiceError(405, errmsg)
     return build_response(err)
 
 
 @bp.app_errorhandler(500)
-def internal_server_error(e):
+def internal_server_error(e):  # type: ignore[no-untyped-def]
     errmsg = "Internal Server Error"
     err = NatlasServiceError(500, errmsg)
     db.session.rollback()
@@ -44,7 +44,7 @@ def internal_server_error(e):
 
 
 @bp.app_errorhandler(elasticsearch.ConnectionError)
-def elastic_unavailable(e):
+def elastic_unavailable(e):  # type: ignore[no-untyped-def]
     """
     This capture_exception happens here but not in others because
     the others use Flask's exception handling already. Since we are handling
@@ -57,6 +57,6 @@ def elastic_unavailable(e):
 
 
 @bp.app_errorhandler(NatlasSearchError)
-def invalid_elastic_query(e):
+def invalid_elastic_query(e):  # type: ignore[no-untyped-def]
     sentry_sdk.capture_exception(e)
     return build_response(e)

--- a/natlas-server/app/errors/responses.py
+++ b/natlas-server/app/errors/responses.py
@@ -18,8 +18,8 @@ supported_formats = {"text/html": html_response, "application/json": json_respon
 
 
 def get_response(requested_format: str, err: NatlasServiceError) -> Response:
-    return supported_formats.get(requested_format)(err)
+    return supported_formats.get(requested_format)(err)  # type: ignore[misc]
 
 
-def get_supported_formats() -> list:
-    return supported_formats.keys()
+def get_supported_formats() -> list:  # type: ignore[type-arg]
+    return supported_formats.keys()  # type: ignore[return-value]

--- a/natlas-server/app/filters.py
+++ b/natlas-server/app/filters.py
@@ -5,14 +5,14 @@ bp = Blueprint("filters", __name__)
 
 
 @bp.app_template_filter("ctime")
-def ctime(s, human=False):
+def ctime(s, human=False):  # type: ignore[no-untyped-def]
     if human:
         return parser.parse(s).strftime("%Y-%m-%d %H:%M:%S %Z")
     return parser.parse(s).strftime("%Y-%m-%d %H:%M")
 
 
 @bp.app_template_filter("get_screenshot_path")
-def get_screenshot_path(inhash: str, service: str = "HTTP"):
+def get_screenshot_path(inhash: str, service: str = "HTTP"):  # type: ignore[no-untyped-def]
     ext_map = {"HTTP": ".png", "HTTPS": ".png", "VNC": ".jpg"}
 
     return f"{inhash[0:2]}/{inhash[2:4]}/{inhash}{ext_map[service]}"

--- a/natlas-server/app/host/forms.py
+++ b/natlas-server/app/host/forms.py
@@ -2,5 +2,5 @@ from flask_wtf import FlaskForm
 from wtforms import SubmitField
 
 
-class RescanForm(FlaskForm):
+class RescanForm(FlaskForm):  # type: ignore[misc]
     requestRescan = SubmitField("Request Rescan")

--- a/natlas-server/app/host/migrators.py
+++ b/natlas-server/app/host/migrators.py
@@ -1,7 +1,7 @@
 import semver
 
 
-def determine_data_version(hostdata):
+def determine_data_version(hostdata):  # type: ignore[no-untyped-def]
     if "agent_version" in hostdata:
         ver = semver.VersionInfo.parse(hostdata["agent_version"])
 
@@ -11,6 +11,6 @@ def determine_data_version(hostdata):
         # If agent_version is present and older than 0.6.3, "fall up" to 0.6.3 templates
         version = str(fallupVer) if ver < fallupVer else hostdata["agent_version"]
     else:
-        version = str(fallupVer)
+        version = str(fallupVer)  # type: ignore[used-before-def]
 
     return version

--- a/natlas-server/app/host/summarizers.py
+++ b/natlas-server/app/host/summarizers.py
@@ -1,13 +1,13 @@
 from flask import abort, current_app
 
 
-def hostinfo(ip):
+def hostinfo(ip):  # type: ignore[no-untyped-def]
     hostinfo = {}
-    count, context = current_app.elastic.get_host(ip)
+    count, context = current_app.elastic.get_host(ip)  # type: ignore[attr-defined]
     if count == 0:
         return abort(404)
     hostinfo["history"] = count
-    screenshot_count = current_app.elastic.count_host_screenshots(ip)
+    screenshot_count = current_app.elastic.count_host_screenshots(ip)  # type: ignore[attr-defined]
     hostinfo["screenshot_count"] = screenshot_count
     screenshots = 0
     screenshotTypes = [

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -16,19 +16,19 @@ SERVICE_NAME = "natlas-server"
 template_span = threading.local()
 
 
-def render_template_end(*kargs, **kwargs):  # sender, template, context):
+def render_template_end(*kargs, **kwargs):  # type: ignore[no-untyped-def]
     span = template_span.x
     template_span.x = None
     span.end()
 
 
-def render_template_start(app, template, context):
+def render_template_start(app, template, context):  # type: ignore[no-untyped-def]
     tracer = trace.get_tracer(__name__)
     template_span.x = tracer.start_span(name="render_template")
     template_span.x.set_attribute("flask.template", template.name)
 
 
-def initialize_opentelemetry(config, flask_app):
+def initialize_opentelemetry(config, flask_app):  # type: ignore[no-untyped-def]
     if config.otel_enable:
         collector = config.otel_collector
         print(f"OpenTelemetry enabled and reporting to {collector} using gRPC")
@@ -45,7 +45,7 @@ def initialize_opentelemetry(config, flask_app):
         flask.template_rendered.connect(render_template_end, flask_app)
 
 
-def initialize_sentryio(config):
+def initialize_sentryio(config):  # type: ignore[no-untyped-def]
     if config.sentry_dsn:
         url = urlparse(config.sentry_dsn)
         print(

--- a/natlas-server/app/instrumentation/sentryio_middleware.py
+++ b/natlas-server/app/instrumentation/sentryio_middleware.py
@@ -3,10 +3,10 @@ from sentry_sdk import configure_scope
 
 
 class SentryIoContextMiddleware:
-    def __init__(self, app):
+    def __init__(self, app):  # type: ignore[no-untyped-def]
         self.app = app
 
-    def __call__(self, environ, start_response):
+    def __call__(self, environ, start_response):  # type: ignore[no-untyped-def]
         span = trace.get_current_span()
         with configure_scope() as scope:
             scope.set_extra("trace_id", span.get_span_context().trace_id)

--- a/natlas-server/app/main/pagination.py
+++ b/natlas-server/app/main/pagination.py
@@ -2,7 +2,7 @@ from flask import url_for
 from flask_login import current_user
 
 
-def build_pagination_urls(route, page, count, **kargs):
+def build_pagination_urls(route, page, count, **kargs):  # type: ignore[no-untyped-def]
     next_url = (
         url_for(route, page=page + 1, **kargs)
         if count > page * current_user.results_per_page
@@ -12,7 +12,7 @@ def build_pagination_urls(route, page, count, **kargs):
     return next_url, prev_url
 
 
-def results_offset(page):
+def results_offset(page):  # type: ignore[no-untyped-def]
     results_per_page = current_user.results_per_page
     search_offset = results_per_page * (page - 1)
     return results_per_page, search_offset

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -19,7 +19,7 @@ from app.main.pagination import build_pagination_urls, results_offset
 
 
 @bp.route("/")
-def index():
+def index():  # type: ignore[no-untyped-def]
     login_form = None
     reg_form = None
     if current_user.is_anonymous:
@@ -33,7 +33,7 @@ def index():
 # Serve media files in case the front-end proxy doesn't do it
 @bp.route("/media/<path:filename>")
 @is_authenticated
-def send_media(filename):
+def send_media(filename):  # type: ignore[no-untyped-def]
     # If you're looking at this function, wondering why your files aren't sending...
     # It's probably because current_app.config['MEDIA_DIRECTORY'] isn't pointing to an absolute file path
     return send_from_directory(current_app.config["MEDIA_DIRECTORY"], filename)
@@ -41,7 +41,7 @@ def send_media(filename):
 
 @bp.route("/browse")
 @is_authenticated
-def browse():
+def browse():  # type: ignore[no-untyped-def]
     """
     A simple browser that doesn't deal with queries at all
     """
@@ -52,10 +52,10 @@ def browse():
 
     searchIndex = "history" if includeHistory else "latest"
 
-    count, hostdata = current_app.elastic.search(
+    count, hostdata = current_app.elastic.search(  # type: ignore[attr-defined]
         results_per_page, search_offset, searchIndex=searchIndex
     )
-    totalHosts = current_app.elastic.total_hosts()
+    totalHosts = current_app.elastic.total_hosts()  # type: ignore[attr-defined]
 
     if includeHistory:
         next_url, prev_url = build_pagination_urls(
@@ -78,7 +78,7 @@ def browse():
 
 @bp.route("/search")
 @is_authenticated
-def search():
+def search():  # type: ignore[no-untyped-def]
     """
     Return search results for a given query
     """
@@ -95,13 +95,13 @@ def search():
     searchIndex = "history" if includeHistory else "latest"
 
     try:
-        count, context = current_app.elastic.search(
+        count, context = current_app.elastic.search(  # type: ignore[attr-defined]
             results_per_page, search_offset, query=query, searchIndex=searchIndex
         )
     except elasticsearch.RequestError as e:
         raise NatlasSearchError(e) from e
 
-    totalHosts = current_app.elastic.total_hosts()
+    totalHosts = current_app.elastic.total_hosts()  # type: ignore[attr-defined]
 
     if includeHistory:
         next_url, prev_url = build_pagination_urls(
@@ -137,18 +137,18 @@ def search():
 
 @bp.route("/searchmodal")
 @is_authenticated
-def search_modal():
+def search_modal():  # type: ignore[no-untyped-def]
     return render_template("includes/search_modal_content.html")
 
 
 @bp.route("/screenshots")
 @is_authenticated
-def screenshots():
+def screenshots():  # type: ignore[no-untyped-def]
     page = int(request.args.get("page", 1))
 
     results_per_page, search_offset = results_offset(page)
 
-    total_hosts, total_screenshots, hosts = current_app.elastic.get_current_screenshots(
+    total_hosts, total_screenshots, hosts = current_app.elastic.get_current_screenshots(  # type: ignore[attr-defined]
         results_per_page, search_offset
     )
 
@@ -166,7 +166,7 @@ def screenshots():
 
 @bp.route("/status")
 @is_authenticated
-def status():
+def status():  # type: ignore[no-untyped-def]
     """
     Simple html representation of the status api
     """

--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -10,7 +10,7 @@ from app.util import generate_hex_16
 # Agent registration
 # Users can have many agents, each agent has an ID and a secret (token)
 # Friendly name is purely for identification of agents in the management page
-class Agent(db.Model, DictSerializable):
+class Agent(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     # agent identification string for storing in reports
@@ -21,11 +21,11 @@ class Agent(db.Model, DictSerializable):
     # optional friendly name for viewing on user page
     friendly_name = db.Column(db.String(128), default="")
 
-    def verify_secret(self, secret):
+    def verify_secret(self, secret):  # type: ignore[no-untyped-def]
         return secrets.compare_digest(secret, self.token)
 
     @staticmethod
-    def verify_agent(auth_header):
+    def verify_agent(auth_header):  # type: ignore[no-untyped-def]
         auth_list = auth_header.split()
         if auth_list[0].lower() != "bearer":
             return False
@@ -34,14 +34,14 @@ class Agent(db.Model, DictSerializable):
         return bool(agent and agent.verify_secret(agent_token))
 
     @staticmethod
-    def load_agent(agentid):
+    def load_agent(agentid):  # type: ignore[no-untyped-def]
         return Agent.query.filter_by(agentid=agentid).first()
 
     @staticmethod
-    def generate_token():
+    def generate_token():  # type: ignore[no-untyped-def]
         tokencharset = string.ascii_uppercase + string.ascii_lowercase + string.digits
         return "".join(secrets.choice(tokencharset) for _ in range(32))
 
     @staticmethod
-    def generate_agentid():
+    def generate_agentid():  # type: ignore[no-untyped-def]
         return generate_hex_16()

--- a/natlas-server/app/models/agent_config.py
+++ b/natlas-server/app/models/agent_config.py
@@ -2,7 +2,7 @@ from app import db
 from app.models.dict_serializable import DictSerializable
 
 
-class AgentConfig(db.Model, DictSerializable):
+class AgentConfig(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     versionDetection = db.Column(
         db.Boolean, default=True

--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -7,10 +7,10 @@ from app.models.dict_serializable import DictSerializable
 # groups of scripts are also accepted, such as "safe" and "default"
 # auth, broadcast, default, discovery, dos, exploit, external, fuzzer, intrusive, malware, safe, version, vuln
 # https://nmap.org/book/nse-usage.html#nse-categories
-class AgentScript(db.Model, DictSerializable):
+class AgentScript(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128), index=True, unique=True)
 
     @staticmethod
-    def get_scripts_string():
+    def get_scripts_string():  # type: ignore[no-untyped-def]
         return ",".join(s.name for s in AgentScript.query.all())

--- a/natlas-server/app/models/config_item.py
+++ b/natlas-server/app/models/config_item.py
@@ -5,7 +5,7 @@ from app.models.dict_serializable import DictSerializable
 # Server configuration options
 # This uses a generic key,value style schema so that we can avoid changing the model for every new feature
 # Default config options are defined in natlas-server/config.py
-class ConfigItem(db.Model, DictSerializable):
+class ConfigItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(256), unique=True)
     type = db.Column(db.String(256))

--- a/natlas-server/app/models/dict_serializable.py
+++ b/natlas-server/app/models/dict_serializable.py
@@ -1,3 +1,3 @@
 class DictSerializable:
-    def as_dict(self):
-        return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+    def as_dict(self):  # type: ignore[no-untyped-def]
+        return {c.name: getattr(self, c.name) for c in self.__table__.columns}  # type: ignore[attr-defined]

--- a/natlas-server/app/models/natlas_services.py
+++ b/natlas-server/app/models/natlas_services.py
@@ -5,23 +5,23 @@ from app import db
 
 # While generally I prefer to use a singular model name, each record here is going to be storing a set of services
 # Each record in this table is a complete nmap-services db
-class NatlasServices(db.Model):
+class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     sha256 = db.Column(db.String(64))
     services = db.Column(db.Text)
 
-    def __init__(self, services):
+    def __init__(self, services):  # type: ignore[no-untyped-def]
         self.services = services
         self.sha256 = hashlib.sha256(self.services.encode()).hexdigest()
 
     @staticmethod
-    def get_latest_services():
+    def get_latest_services():  # type: ignore[no-untyped-def]
         return NatlasServices.query.order_by(NatlasServices.id.desc()).first().as_dict()
 
-    def hash_equals(self, hash):
+    def hash_equals(self, hash):  # type: ignore[no-untyped-def]
         return self.sha256 == hash
 
-    def services_as_list(self):
+    def services_as_list(self):  # type: ignore[no-untyped-def]
         servlist = []
         idx = 1
         for line in self.services.splitlines():
@@ -36,7 +36,7 @@ class NatlasServices(db.Model):
             idx += 1
         return servlist
 
-    def as_dict(self):
+    def as_dict(self):  # type: ignore[no-untyped-def]
         servdict = {c.name: getattr(self, c.name) for c in self.__table__.columns}
         servdict["as_list"] = self.services_as_list()
         return servdict

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -7,7 +7,7 @@ from app.models.dict_serializable import DictSerializable
 # Rescan Queue
 # Each record represents a user-requested rescan of a given target.
 # Tracks when it was dispatched, when it was completed, and the scan id of the complete scan.
-class RescanTask(db.Model, DictSerializable):
+class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     date_added = db.Column(
         db.DateTime, index=True, default=datetime.utcnow, nullable=False
@@ -20,34 +20,34 @@ class RescanTask(db.Model, DictSerializable):
     date_completed = db.Column(db.DateTime, index=True)
     scan_id = db.Column(db.String(256), index=True, unique=True)
 
-    def dispatchTask(self):
+    def dispatchTask(self):  # type: ignore[no-untyped-def]
         self.dispatched = True
         self.date_dispatched = datetime.utcnow()
 
-    def completeTask(self, scan_id):
+    def completeTask(self, scan_id):  # type: ignore[no-untyped-def]
         self.scan_id = scan_id
         self.complete = True
         self.date_completed = datetime.utcnow()
 
     @staticmethod
-    def getPendingTasks():
+    def getPendingTasks():  # type: ignore[no-untyped-def]
         # Tasks that haven't been completed and haven't been dispatched
         return (
             RescanTask.query.filter_by(complete=False).filter_by(dispatched=False).all()
         )
 
     @staticmethod
-    def getDispatchedTasks():
+    def getDispatchedTasks():  # type: ignore[no-untyped-def]
         # Tasks that have been dispatched but haven't been completed
         return (
             RescanTask.query.filter_by(dispatched=True).filter_by(complete=False).all()
         )
 
     @staticmethod
-    def getIncompleteTasks():
+    def getIncompleteTasks():  # type: ignore[no-untyped-def]
         # All tasks that haven't been marked as complete
         return RescanTask.query.filter_by(complete=False).all()
 
     @staticmethod
-    def getIncompleteTaskForTarget(ip):
+    def getIncompleteTaskForTarget(ip):  # type: ignore[no-untyped-def]
         return RescanTask.query.filter_by(target=ip).filter_by(complete=False).all()

--- a/natlas-server/app/models/scope_log.py
+++ b/natlas-server/app/models/scope_log.py
@@ -5,14 +5,14 @@ from app.models.dict_serializable import DictSerializable
 
 
 # Basic Logging for Scope related events
-class ScopeLog(db.Model, DictSerializable):
+class ScopeLog(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     msg = db.Column(db.String(256))
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
-    def __init__(self, msg=None):
+    def __init__(self, msg=None):  # type: ignore[no-untyped-def]
         self.msg = msg
 
-    def __repr__(self):
+    def __repr__(self):  # type: ignore[no-untyped-def]
         timerepr = self.created_at.strftime("%Y-%m-%d-%H:%M:%S")
         return f"<Log: {timerepr} - {self.msg[:50]}>"

--- a/natlas-server/app/models/tag.py
+++ b/natlas-server/app/models/tag.py
@@ -3,12 +3,12 @@ from app.models.dict_serializable import DictSerializable
 
 
 # Simple tags that can be added to scope items for automatic tagging
-class Tag(db.Model, DictSerializable):
+class Tag(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128), index=True, unique=True, nullable=False)
 
     @staticmethod
-    def create_if_none(tag):
+    def create_if_none(tag):  # type: ignore[no-untyped-def]
         """If tag exists, return it. If not, create it and return it."""
         tag = tag.strip()
         existingTag = Tag.query.filter_by(name=tag).first()

--- a/natlas-server/app/models/token_validation.py
+++ b/natlas-server/app/models/token_validation.py
@@ -1,12 +1,12 @@
 import secrets
 
 
-def default_validator():
+def default_validator():  # type: ignore[no-untyped-def]
     # if no custom validator is supplied then just pass
     return True
 
 
-def validate_token(record, provided_token, stored_token, validator=default_validator):
+def validate_token(record, provided_token, stored_token, validator=default_validator):  # type: ignore[no-untyped-def]
     if record and secrets.compare_digest(provided_token, stored_token) and validator():
         return record
     # still do a digest compare of equal sizes to resist timing attacks

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -10,7 +10,7 @@ from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
 
 
-class User(UserMixin, db.Model, DictSerializable):
+class User(UserMixin, db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(254), index=True, unique=True)
     password_hash = db.Column(db.String(128))
@@ -29,49 +29,49 @@ class User(UserMixin, db.Model, DictSerializable):
     expiration_duration = 60 * 60 * 24 * 2
     token_length = 32
 
-    def __repr__(self):
+    def __repr__(self):  # type: ignore[no-untyped-def]
         return f"<User {self.email}>"
 
     @staticmethod
-    def exists(email):
+    def exists(email):  # type: ignore[no-untyped-def]
         return User.query.filter_by(email=email).first() is not None
 
     # https://github.com/JoshData/python-email-validator
     @staticmethod
-    def validate_email(email):
+    def validate_email(email):  # type: ignore[no-untyped-def]
         try:
             valid = validate_email(email)
             return valid["email"]
         except EmailNotValidError:
             return False
 
-    def set_password(self, password):
+    def set_password(self, password):  # type: ignore[no-untyped-def]
         self.password_hash = generate_password_hash(password)
 
-    def check_password(self, password):
+    def check_password(self, password):  # type: ignore[no-untyped-def]
         return check_password_hash(self.password_hash, password)
 
     @login.user_loader
-    def load_user(id):
+    def load_user(id):  # type: ignore[no-untyped-def]
         return User.query.get(id)
 
-    def new_reset_token(self):
+    def new_reset_token(self):  # type: ignore[no-untyped-def]
         self.password_reset_token = secrets.token_urlsafe(User.token_length)
         self.password_reset_expiration = datetime.utcnow() + timedelta(
             seconds=User.expiration_duration
         )
 
-    def expire_reset_token(self):
+    def expire_reset_token(self):  # type: ignore[no-untyped-def]
         self.password_reset_token = None
         self.password_reset_expiration = None
 
-    def validate_reset_token(self):
+    def validate_reset_token(self):  # type: ignore[no-untyped-def]
         if not (self.password_reset_token and self.password_reset_expiration):
             return False
         return self.password_reset_expiration > datetime.utcnow()
 
     @staticmethod
-    def get_reset_token(email):
+    def get_reset_token(email):  # type: ignore[no-untyped-def]
         user = User.query.filter_by(email=email).first()
         if not user:
             return None
@@ -80,7 +80,7 @@ class User(UserMixin, db.Model, DictSerializable):
         return user
 
     @staticmethod
-    def get_user_by_token(url_token):
+    def get_user_by_token(url_token):  # type: ignore[no-untyped-def]
         record = User.query.filter_by(password_reset_token=url_token).first()
         if not record:
             return False
@@ -89,7 +89,7 @@ class User(UserMixin, db.Model, DictSerializable):
         )
 
     @staticmethod
-    def new_user_from_invite(invite, password, email=None):
+    def new_user_from_invite(invite, password, email=None):  # type: ignore[no-untyped-def]
         user_email = email if email else invite.email
         new_user = User(email=user_email, is_admin=invite.is_admin, is_active=True)
         new_user.set_password(password)

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -7,7 +7,7 @@ from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
 
 
-class UserInvitation(db.Model, DictSerializable):
+class UserInvitation(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(254), unique=True)
     token = db.Column(db.String(256), unique=True, nullable=False)
@@ -24,7 +24,7 @@ class UserInvitation(db.Model, DictSerializable):
 
     # Build a new invitation
     @staticmethod
-    def new_invite(email=None, is_admin=False):
+    def new_invite(email=None, is_admin=False):  # type: ignore[no-untyped-def]
         if email and User.query.filter_by(email=email).first():
             return False
         now = datetime.utcnow()
@@ -45,31 +45,31 @@ class UserInvitation(db.Model, DictSerializable):
         return invite
 
     @staticmethod
-    def deliver_invite(invite):
+    def deliver_invite(invite):  # type: ignore[no-untyped-def]
         from app.auth.email import deliver_auth_link
 
         return deliver_auth_link(invite.email, invite.token, "invite")
 
     @staticmethod
-    def get_invite(url_token):
+    def get_invite(url_token):  # type: ignore[no-untyped-def]
         record = UserInvitation.query.filter_by(token=url_token).first()
         if not record:
             return False
         return validate_token(record, url_token, record.token, record.validate_invite)
 
-    def accept_invite(self):
+    def accept_invite(self):  # type: ignore[no-untyped-def]
         now = datetime.utcnow()
         self.accepted_date = now
         self.expire_invite(now)
 
     # If a token is expired, mark it as such
-    def expire_invite(self, timestamp):
+    def expire_invite(self, timestamp):  # type: ignore[no-untyped-def]
         self.expiration_date = min(timestamp, self.expiration_date)
 
         # Leave original expiration date intact since it's already past
         self.is_expired = True
 
     # verify that the token is not expired
-    def validate_invite(self):
+    def validate_invite(self):  # type: ignore[no-untyped-def]
         now = datetime.utcnow()
         return self.expiration_date > now and not self.is_expired

--- a/natlas-server/app/scope/scan_group.py
+++ b/natlas-server/app/scope/scan_group.py
@@ -28,7 +28,7 @@ class ScanGroup:
         return self.blacklist.size
 
     def get_effective_size(self) -> int:
-        return self.effective_size
+        return self.effective_size  # type: ignore[no-any-return]
 
     def get_scan_manager(self) -> None | IPScanManager:
         return self.scan_manager
@@ -36,28 +36,28 @@ class ScanGroup:
     def get_last_cycle_start(self) -> None | datetime:
         if self.scan_manager is None:
             return None
-        return self.scan_manager.rng.cycle_start_time
+        return self.scan_manager.rng.cycle_start_time  # type: ignore[unreachable]
 
     def get_completed_cycle_count(self) -> int:
         if self.scan_manager is None:
             return 0
-        return self.scan_manager.rng.completed_cycle_count
+        return self.scan_manager.rng.completed_cycle_count  # type: ignore[unreachable]
 
-    def update(self):
+    def update(self):  # type: ignore[no-untyped-def]
         self.scope.update()
         self.blacklist.update()
         self.update_scan_manager()
         self.effective_size = (self.scope.set - self.blacklist.set).size
 
-    def update_scan_manager(self):
+    def update_scan_manager(self):  # type: ignore[no-untyped-def]
         try:
-            self.scan_manager = IPScanManager(
+            self.scan_manager = IPScanManager(  # type: ignore[assignment]
                 self.scope.set,
                 self.blacklist.set,
                 current_app.config["CONSISTENT_SCAN_CYCLE"],
             )
         except Exception as e:
-            if self.scan_manager is None or self.scan_manager.get_total() == 0:
+            if self.scan_manager is None or self.scan_manager.get_total() == 0:  # type: ignore[unreachable]
                 errmsg = "Scan manager could not be instantiated because there was no scope configured."
                 current_app.logger.warning(f"{datetime.utcnow()!s} - {errmsg}\n")
             else:

--- a/natlas-server/app/scope/scan_manager.py
+++ b/natlas-server/app/scope/scan_manager.py
@@ -3,10 +3,10 @@ from netaddr import IPSet
 
 
 class IPScanManager:
-    networks = None
+    networks = None  # type: ignore[var-annotated]
     total = 0
-    rng = None
-    consistent = None
+    rng = None  # type: ignore[var-annotated]
+    consistent = None  # type: ignore[var-annotated]
 
     def __init__(self, whitelist: IPSet, blacklist: IPSet, consistent: bool):
         self.networks = []
@@ -17,7 +17,7 @@ class IPScanManager:
         self.blacklist = blacklist
         self.initialize_manager()
 
-    def log_to_db(self, message: str):
+    def log_to_db(self, message: str):  # type: ignore[no-untyped-def]
         from app import db
         from app.models import ScopeLog
 
@@ -30,7 +30,7 @@ class IPScanManager:
         db.session.add(db_log)
         db.session.commit()
 
-    def initialize_manager(self):
+    def initialize_manager(self):  # type: ignore[no-untyped-def]
         self.networks = []
         self.ipset = self.whitelist - self.blacklist
 
@@ -49,7 +49,7 @@ class IPScanManager:
             self.total, consistent=self.consistent, event_handler=self.log_to_db
         )
 
-        def blockcomp(b):
+        def blockcomp(b):  # type: ignore[no-untyped-def]
             return b["start"]
 
         self.networks.sort(key=blockcomp)
@@ -61,20 +61,20 @@ class IPScanManager:
 
         self.initialized = True
 
-    def get_total(self):
+    def get_total(self):  # type: ignore[no-untyped-def]
         return self.total
 
-    def get_ready(self):
+    def get_ready(self):  # type: ignore[no-untyped-def]
         return self.rng and self.total > 0 and self.initialized
 
-    def get_next_ip(self):
+    def get_next_ip(self):  # type: ignore[no-untyped-def]
         if self.rng:
             index = self.rng.get_random()
             return self.get_ip(index)
         return None
 
-    def get_ip(self, index):
-        def binarysearch(networks, i):
+    def get_ip(self, index):  # type: ignore[no-untyped-def]
+        def binarysearch(networks, i):  # type: ignore[no-untyped-def]
             middle = int(len(networks) / 2)
             network = networks[middle]
             if i < network["index"]:

--- a/natlas-server/app/scope/scope_collection.py
+++ b/natlas-server/app/scope/scope_collection.py
@@ -4,16 +4,16 @@ from netaddr import IPNetwork, IPSet
 class ScopeCollection:
     size = 0
 
-    def __init__(self, scope_source: callable):
+    def __init__(self, scope_source: callable):  # type: ignore[valid-type]
         """
         name: A name for this collection of scopes
         scope_source: A callable that returns a collection of ScopeItem
         """
         self.scope_source = scope_source
-        self.list = []
+        self.list = []  # type: ignore[var-annotated]
         self.set = IPSet()
 
-    def update(self):
-        self.list = [IPNetwork(item.target, False) for item in self.scope_source()]
+    def update(self):  # type: ignore[no-untyped-def]
+        self.list = [IPNetwork(item.target, False) for item in self.scope_source()]  # type: ignore[misc]
         self.set = IPSet(self.list)
         self.size = self.set.size

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -9,17 +9,17 @@ from app.scope.scan_manager import IPScanManager
 
 
 class ScopeManager:
-    scanmanager = None
-    init_time = None
-    scopes = None
+    scanmanager = None  # type: ignore[var-annotated]
+    init_time = None  # type: ignore[var-annotated]
+    scopes = None  # type: ignore[var-annotated]
     effective_size = 0
     default_group = "all"
 
-    def __init__(self):
+    def __init__(self):  # type: ignore[no-untyped-def]
         self.pendingRescans = []
         self.dispatchedRescans = []
 
-    def init_app(self, app):
+    def init_app(self, app):  # type: ignore[no-untyped-def]
         app.ScopeManager = self
 
         with app.app_context():
@@ -31,39 +31,39 @@ class ScopeManager:
             }
         self.init_time = datetime.utcnow()
 
-    def load_all_groups(self):
+    def load_all_groups(self):  # type: ignore[no-untyped-def]
         """
         Used at initialization to update all scan groups with their database values
         """
-        for _, group in self.scopes.items():
+        for _, group in self.scopes.items():  # type: ignore[union-attr]
             group.update()
 
     def get_scope_size(self, group: str = default_group) -> int:
-        return self.scopes[group].get_scope_size()
+        return self.scopes[group].get_scope_size()  # type: ignore[index, no-any-return]
 
     def get_blacklist_size(self, group: str = default_group) -> int:
-        return self.scopes[group].get_blacklist_size()
+        return self.scopes[group].get_blacklist_size()  # type: ignore[index, no-any-return]
 
     def get_effective_scope_size(self, group: str = default_group) -> int:
-        return self.scopes[group].get_effective_size()
+        return self.scopes[group].get_effective_size()  # type: ignore[index, no-any-return]
 
-    def get_scope(self, group: str = default_group) -> list:
-        return self.scopes[group].scope.list
+    def get_scope(self, group: str = default_group) -> list:  # type: ignore[type-arg]
+        return self.scopes[group].scope.list  # type: ignore[index, no-any-return]
 
-    def get_blacklist(self, group: str = default_group) -> list:
-        return self.scopes[group].blacklist.list
+    def get_blacklist(self, group: str = default_group) -> list:  # type: ignore[type-arg]
+        return self.scopes[group].blacklist.list  # type: ignore[index, no-any-return]
 
     def get_scan_manager(self, group: str = default_group) -> IPScanManager:
-        return self.scopes.get(group).get_scan_manager()
+        return self.scopes.get(group).get_scan_manager()  # type: ignore[no-any-return, union-attr]
 
     def get_last_cycle_start(self, group: str = default_group) -> datetime:
-        return self.scopes[group].get_last_cycle_start()
+        return self.scopes[group].get_last_cycle_start()  # type: ignore[index, no-any-return]
 
     def get_completed_cycle_count(self, group: str = default_group) -> int:
-        return self.scopes[group].get_completed_cycle_count()
+        return self.scopes[group].get_completed_cycle_count()  # type: ignore[index, no-any-return]
 
-    def update(self, group: str = default_group):
-        self.scopes.get(group).update()
+    def update(self, group: str = default_group):  # type: ignore[no-untyped-def]
+        self.scopes.get(group).update()  # type: ignore[union-attr]
         current_app.logger.info(f"{datetime.utcnow()!s} - ScopeManager Updated\n")
 
     def is_acceptable_target(self, target: str, group: str = default_group) -> bool:
@@ -77,17 +77,17 @@ class ScopeManager:
             self.update()
 
         return (
-            target not in self.scopes[group].blacklist.set
-            and target in self.scopes[group].scope.set
+            target not in self.scopes[group].blacklist.set  # type: ignore[index]
+            and target in self.scopes[group].scope.set  # type: ignore[index]
         )
 
-    def get_pending_rescans(self) -> list:
+    def get_pending_rescans(self) -> list:  # type: ignore[type-arg]
         return self.pendingRescans
 
-    def get_dispatched_rescans(self) -> list:
+    def get_dispatched_rescans(self) -> list:  # type: ignore[type-arg]
         return self.dispatchedRescans
 
-    def get_incomplete_scans(self) -> list:
+    def get_incomplete_scans(self) -> list:  # type: ignore[type-arg]
         if self.pendingRescans == [] or self.dispatchedRescans == []:
             from app.models import RescanTask
 
@@ -95,12 +95,12 @@ class ScopeManager:
             self.dispatchedRescans = RescanTask.getDispatchedTasks()
         return self.pendingRescans + self.dispatchedRescans
 
-    def update_dispatched_rescans(self):
+    def update_dispatched_rescans(self):  # type: ignore[no-untyped-def]
         from app.models import RescanTask
 
         self.dispatchedRescans = RescanTask.getDispatchedTasks()
 
-    def update_pending_rescans(self):
+    def update_pending_rescans(self):  # type: ignore[no-untyped-def]
         from app.models import RescanTask
 
         self.pendingRescans = RescanTask.getPendingTasks()

--- a/natlas-server/app/url_converters.py
+++ b/natlas-server/app/url_converters.py
@@ -11,13 +11,13 @@ class NatlasConverter(BaseConverter):
 class IPConverter(NatlasConverter):
     name = "ip"
 
-    def to_python(self, value):
+    def to_python(self, value):  # type: ignore[no-untyped-def]
         try:
             return str(IPAddress(value))
         except AddrFormatError as e:
             raise ValidationError from e
 
 
-def register_converters(app: Flask) -> dict:
+def register_converters(app: Flask) -> dict:  # type: ignore[return, type-arg]
     for converter in NatlasConverter.__subclasses__():
-        app.url_map.converters[converter.name] = converter
+        app.url_map.converters[converter.name] = converter  # type: ignore[attr-defined]

--- a/natlas-server/app/user/forms.py
+++ b/natlas-server/app/user/forms.py
@@ -6,7 +6,7 @@ from wtforms.validators import DataRequired, EqualTo, Length, ValidationError
 from app.models import User
 
 
-class ChangePasswordForm(FlaskForm):
+class ChangePasswordForm(FlaskForm):  # type: ignore[misc]
     old_password = PasswordField("Old Password", validators=[DataRequired()])
     password = PasswordField("Password", validators=[DataRequired(), Length(min=8)])
     password2 = PasswordField(
@@ -14,7 +14,7 @@ class ChangePasswordForm(FlaskForm):
     )
     changePassword = SubmitField("Change Password")
 
-    def validate_old_password(self, old_password):
+    def validate_old_password(self, old_password):  # type: ignore[no-untyped-def]
         user = User.query.get(current_user.id)
         if user is None:
             raise ValidationError("You're not logged in!")
@@ -24,21 +24,21 @@ class ChangePasswordForm(FlaskForm):
             )
 
 
-class DisplaySettingsForm(FlaskForm):
+class DisplaySettingsForm(FlaskForm):  # type: ignore[misc]
     results_per_page = SelectField("Results Per Page", coerce=int)
     preview_length = SelectField("Preview Length", coerce=int)
     result_format = SelectField("Result Format", coerce=int)
     updateDisplaySettings = SubmitField("Submit Changes")
 
 
-class GenerateTokenForm(FlaskForm):
+class GenerateTokenForm(FlaskForm):  # type: ignore[misc]
     generateToken = SubmitField("Generate Token")
 
 
-class AgentNameForm(FlaskForm):
+class AgentNameForm(FlaskForm):  # type: ignore[misc]
     agent_name = StringField("New Agent Name", validators=[DataRequired()])
     change_name = SubmitField("Change Name")
 
-    def validate_agent_name(self, agent_name):
+    def validate_agent_name(self, agent_name):  # type: ignore[no-untyped-def]
         if len(agent_name.data) > 32:
             raise ValidationError("Name must be less than 32 characters")

--- a/natlas-server/app/user/routes.py
+++ b/natlas-server/app/user/routes.py
@@ -14,7 +14,7 @@ from app.user.forms import (
 
 @bp.route("/", methods=["GET", "POST"])
 @login_required
-def profile():
+def profile():  # type: ignore[no-untyped-def]
     myagents = current_user.agents
     changePasswordForm = ChangePasswordForm(prefix="change-password")
     displaySettingsForm = DisplaySettingsForm(
@@ -71,7 +71,7 @@ def profile():
 
 @bp.route("/agent/<string:agent_id>/newToken", methods=["POST"])
 @login_required
-def generate_new_token(agent_id):
+def generate_new_token(agent_id):  # type: ignore[no-untyped-def]
     generateTokenForm = GenerateTokenForm()
 
     if generateTokenForm.validate_on_submit():
@@ -86,7 +86,7 @@ def generate_new_token(agent_id):
 
 @bp.route("/agent/<string:agent_id>/newName", methods=["POST"])
 @login_required
-def change_agent_name(agent_id):
+def change_agent_name(agent_id):  # type: ignore[no-untyped-def]
     agentNameForm = AgentNameForm()
 
     if agentNameForm.validate_on_submit():
@@ -104,7 +104,7 @@ def change_agent_name(agent_id):
 
 @bp.route("/agent/newAgent", methods=["POST"])
 @login_required
-def new_agent():
+def new_agent():  # type: ignore[no-untyped-def]
     newAgentForm = AgentNameForm()
 
     if newAgentForm.validate_on_submit():

--- a/natlas-server/app/util.py
+++ b/natlas-server/app/util.py
@@ -2,21 +2,21 @@ import secrets
 from datetime import UTC, datetime
 
 
-def utcnow_tz():
+def utcnow_tz():  # type: ignore[no-untyped-def]
     return datetime.now(UTC)
 
 
-def generate_hex_16():
+def generate_hex_16():  # type: ignore[no-untyped-def]
     # 8 bytes converted to two hex digits each
     return secrets.token_hex(8)
 
 
-def generate_hex_32():
+def generate_hex_32():  # type: ignore[no-untyped-def]
     # 16 bytes converted to two hex digits each
     return secrets.token_hex(16)
 
 
-def pretty_time_delta(delta):
+def pretty_time_delta(delta):  # type: ignore[no-untyped-def]
     hours, seconds = divmod(delta.seconds, 3600)
     minutes, seconds = divmod(seconds, 60)
     daystr = (str(delta.days) + "d, ") if delta.days else ""

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -8,20 +8,20 @@ with open("defaults/db_configs.json") as f:
     defaultConfig = json.load(f)
 
 
-def get_defaults():
+def get_defaults():  # type: ignore[no-untyped-def]
     return defaultConfig.items()
 
 
 # This mechanism for casting a bool is needed because bool("False") == True
-def casted_bool(value):
+def casted_bool(value):  # type: ignore[no-untyped-def]
     if isinstance(value, bool):
         return value
     return value.lower() == "true"
 
 
-def casted_value(expected_type, value):
+def casted_value(expected_type, value):  # type: ignore[no-untyped-def]
     cast_map = {"bool": casted_bool, "string": str, "int": int}
-    return cast_map[expected_type](value)
+    return cast_map[expected_type](value)  # type: ignore[operator]
 
 
 # Things in the Class object are config options we will likely never want to change from the database.

--- a/natlas-server/migrations/env.py
+++ b/natlas-server/migrations/env.py
@@ -10,7 +10,7 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+fileConfig(config.config_file_name)  # type: ignore[arg-type]
 logger = logging.getLogger("alembic.env")
 
 # add your model's MetaData object here
@@ -20,7 +20,8 @@ logger = logging.getLogger("alembic.env")
 from flask import current_app
 
 config.set_main_option(
-    "sqlalchemy.url", current_app.config.get("SQLALCHEMY_DATABASE_URI")
+    "sqlalchemy.url",
+    current_app.config.get("SQLALCHEMY_DATABASE_URI"),  # type: ignore[arg-type]
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 
@@ -30,7 +31,7 @@ target_metadata = current_app.extensions["migrate"].db.metadata
 # ... etc.
 
 
-def run_migrations_offline():
+def run_migrations_offline():  # type: ignore[no-untyped-def]
     """Run migrations in 'offline' mode.
 
     This configures the context with just a URL
@@ -49,7 +50,7 @@ def run_migrations_offline():
         context.run_migrations()
 
 
-def run_migrations_online():
+def run_migrations_online():  # type: ignore[no-untyped-def]
     """Run migrations in 'online' mode.
 
     In this scenario we need to create an Engine
@@ -60,7 +61,7 @@ def run_migrations_online():
     # this callback is used to prevent an auto-migration from being generated
     # when there are no changes to the schema
     # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
-    def process_revision_directives(context, revision, directives):
+    def process_revision_directives(context, revision, directives):  # type: ignore[no-untyped-def]
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
             if script.upgrade_ops.is_empty():
@@ -68,7 +69,7 @@ def run_migrations_online():
                 logger.info("No changes in schema detected.")
 
     engine = engine_from_config(
-        config.get_section(config.config_ini_section),
+        config.get_section(config.config_ini_section),  # type: ignore[arg-type]
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/natlas-server/migrations/migrator.py
+++ b/natlas-server/migrations/migrator.py
@@ -6,7 +6,7 @@ from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
 
 
-def migration_needed(sqlalchemy_uri):
+def migration_needed(sqlalchemy_uri):  # type: ignore[no-untyped-def]
     engine = sqlalchemy.create_engine(sqlalchemy_uri)
     conn = engine.connect()
 
@@ -14,11 +14,11 @@ def migration_needed(sqlalchemy_uri):
     cfg = alembic_cfg("migrations/alembic.ini")
     cfg.set_main_option("script_location", "migrations")
     scripts_dir = ScriptDirectory.from_config(cfg)
-    with context.EnvironmentContext(cfg, scripts_dir):
+    with context.EnvironmentContext(cfg, scripts_dir):  # type: ignore[attr-defined]
         return context.get_head_revision() != m_ctx.get_current_revision()
 
 
-def handle_db_upgrade(app):
+def handle_db_upgrade(app):  # type: ignore[no-untyped-def]
     if app.config["DB_AUTO_UPGRADE"]:
         with app.app_context():
             print("upgrading")
@@ -28,13 +28,13 @@ def handle_db_upgrade(app):
         return False
 
 
-def handle_db_downgrade(app):
+def handle_db_downgrade(app):  # type: ignore[no-untyped-def]
     with app.app_context():
         print("downgrading")
         flask_migrate.downgrade()
 
 
-def handle_db_migrate(app, message=""):
+def handle_db_migrate(app, message=""):  # type: ignore[no-untyped-def]
     with app.app_context():
         print("migrating")
         flask_migrate.migrate(message=message)

--- a/natlas-server/natlas-db.py
+++ b/natlas-server/natlas-db.py
@@ -19,7 +19,7 @@ It is best practice to take a backup of your database before you upgrade or down
 """
 
 
-def main():
+def main():  # type: ignore[no-untyped-def]
     parser = argparse.ArgumentParser(description=parser_desc)
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(

--- a/natlas-server/natlas-migrate.py
+++ b/natlas-server/natlas-migrate.py
@@ -12,7 +12,7 @@ going through the full app init process\
 """
 
 
-def main():
+def main():  # type: ignore[no-untyped-def]
     parser = argparse.ArgumentParser(description=parser_desc)
     parser.add_argument(
         "--message",

--- a/natlas-server/natlas-server.py
+++ b/natlas-server/natlas-server.py
@@ -26,7 +26,7 @@ except Exception as e:
 
 
 @app.shell_context_processor
-def make_shell_context():
+def make_shell_context():  # type: ignore[no-untyped-def]
     return {
         "db": db,
         "User": User,

--- a/natlas-server/tests/cli/conftest.py
+++ b/natlas-server/tests/cli/conftest.py
@@ -2,5 +2,5 @@ import pytest
 
 
 @pytest.fixture
-def runner(app):
+def runner(app):  # type: ignore[no-untyped-def]
     return app.test_cli_runner()

--- a/natlas-server/tests/cli/test_scope_cli.py
+++ b/natlas-server/tests/cli/test_scope_cli.py
@@ -6,13 +6,13 @@ from app.models import ScopeItem
 DEFAULT_SCOPE_ITEMS = ["10.0.0.0/8", "192.168.1.0/24", "192.168.5.0/28"]
 
 
-def mock_scope_file(scope_items: list = DEFAULT_SCOPE_ITEMS) -> str:
+def mock_scope_file(scope_items: list = DEFAULT_SCOPE_ITEMS) -> str:  # type: ignore[type-arg]
     with open("scope.txt", "w") as f:
         f.write("\n".join(scope_items))
     return "scope.txt"
 
 
-def test_import_items_no_flags(runner):
+def test_import_items_no_flags(runner):  # type: ignore[no-untyped-def]
     with runner.isolated_filesystem():
         scope_file = mock_scope_file()
         result = runner.invoke(import_items, [scope_file])
@@ -23,7 +23,7 @@ def test_import_items_no_flags(runner):
         assert len(result_dict["scope"]) == len(DEFAULT_SCOPE_ITEMS)
 
 
-def test_import_items_scope_flag(runner):
+def test_import_items_scope_flag(runner):  # type: ignore[no-untyped-def]
     with runner.isolated_filesystem():
         scope_file = mock_scope_file()
         result = runner.invoke(import_items, ["--scope", scope_file])
@@ -34,7 +34,7 @@ def test_import_items_scope_flag(runner):
         assert len(result_dict["scope"]) == len(DEFAULT_SCOPE_ITEMS)
 
 
-def test_import_items_blacklist_flag(runner):
+def test_import_items_blacklist_flag(runner):  # type: ignore[no-untyped-def]
     with runner.isolated_filesystem():
         scope_file = mock_scope_file()
         result = runner.invoke(import_items, ["--blacklist", scope_file])
@@ -45,7 +45,7 @@ def test_import_items_blacklist_flag(runner):
         assert len(result_dict["blacklist"]) == len(DEFAULT_SCOPE_ITEMS)
 
 
-def test_export_items_tagged(runner):
+def test_export_items_tagged(runner):  # type: ignore[no-untyped-def]
     scope_items = ["10.0.0.0/8,a", "192.168.5.0/28"]
     blacklist_items = ["192.168.1.0/24,b"]
     ScopeItem.import_scope_list(scope_items, False)

--- a/natlas-server/tests/conftest.py
+++ b/natlas-server/tests/conftest.py
@@ -8,7 +8,7 @@ from tests.config import TestConfig
 
 
 @pytest.fixture
-def app():
+def app():  # type: ignore[no-untyped-def]
     conf = TestConfig()
     db_fd, db_name = tempfile.mkstemp()
     conf.SQLALCHEMY_DATABASE_URI = "sqlite:///" + db_name
@@ -20,6 +20,6 @@ def app():
 
 
 @pytest.fixture
-def client(app):
+def client(app):  # type: ignore[no-untyped-def]
     with app.test_client() as client:
         yield client

--- a/natlas-server/tests/elastic/conftest.py
+++ b/natlas-server/tests/elastic/conftest.py
@@ -5,13 +5,13 @@ from tests.config import TestConfig
 conf = TestConfig()
 
 
-def reset_indices(indices):
+def reset_indices(indices):  # type: ignore[no-untyped-def]
     indices._delete_indices()
     indices._initialize_indices()
 
 
 @pytest.fixture(scope="module")
-def esinterface():
+def esinterface():  # type: ignore[no-untyped-def]
     esi = ElasticInterface(
         conf.ELASTICSEARCH_URL,
         True,
@@ -24,5 +24,5 @@ def esinterface():
 
 
 @pytest.fixture(scope="module")
-def esclient(esinterface):
+def esclient(esinterface):  # type: ignore[no-untyped-def]
     return esinterface.client

--- a/natlas-server/tests/elastic/test_client.py
+++ b/natlas-server/tests/elastic/test_client.py
@@ -1,2 +1,2 @@
-def test_ping(esclient):
+def test_ping(esclient):  # type: ignore[no-untyped-def]
     assert esclient._ping()

--- a/natlas-server/tests/elastic/test_indices.py
+++ b/natlas-server/tests/elastic/test_indices.py
@@ -1,7 +1,7 @@
 from app.elastic.indices import ElasticIndices
 
 
-def test_index_lifecycle(esclient):
+def test_index_lifecycle(esclient):  # type: ignore[no-untyped-def]
     base = "unittest"
     new_indices = ElasticIndices(esclient, base)
     assert new_indices.name("latest") == base

--- a/natlas-server/tests/elastic/test_interface.py
+++ b/natlas-server/tests/elastic/test_interface.py
@@ -1,7 +1,7 @@
 from time import sleep
 
 
-def test_delete_host(esinterface):
+def test_delete_host(esinterface):  # type: ignore[no-untyped-def]
     ip = "127.0.0.1"
     esinterface.new_result({"ip": ip})
     esinterface.new_result({"ip": ip})
@@ -9,7 +9,7 @@ def test_delete_host(esinterface):
     assert esinterface.delete_host(ip) == 3
 
 
-def test_delete_scan(esinterface):
+def test_delete_scan(esinterface):  # type: ignore[no-untyped-def]
     ip = "127.0.0.2"
     scan_id = "testscan"
     esinterface.new_result({"ip": ip, "scan_id": scan_id})
@@ -19,7 +19,7 @@ def test_delete_scan(esinterface):
     assert esinterface.delete_scan(scan_id * 2) == 2
 
 
-def test_get_host(esinterface):
+def test_get_host(esinterface):  # type: ignore[no-untyped-def]
     ip = "127.0.0.3"
     esinterface.new_result({"ip": ip})
     sleep(1)
@@ -29,7 +29,7 @@ def test_get_host(esinterface):
     assert esinterface.delete_host(ip) == 2
 
 
-def test_delete_scan_migrate(esinterface):
+def test_delete_scan_migrate(esinterface):  # type: ignore[no-untyped-def]
     ip = "127.0.0.4"
     scan_id = "testscan"
     scan_id2 = "nomatch"
@@ -43,7 +43,7 @@ def test_delete_scan_migrate(esinterface):
     assert host["ip"] == ip
 
 
-def test_get_scan(esinterface):
+def test_get_scan(esinterface):  # type: ignore[no-untyped-def]
     ip = "127.0.0.5"
     scan_id = "testscan1"
     esinterface.new_result({"ip": ip, "scan_id": scan_id})
@@ -54,7 +54,7 @@ def test_get_scan(esinterface):
     assert esinterface.delete_host(ip) == 2
 
 
-def test_random_host(esinterface):
+def test_random_host(esinterface):  # type: ignore[no-untyped-def]
     ips = ["127.0.0.6", "127.0.0.7", "127.0.0.8"]
     for ip in ips:
         esinterface.new_result({"ip": ip, "port_count": 2, "is_up": True})

--- a/natlas-server/tests/email/conftest.py
+++ b/natlas-server/tests/email/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def app_no_email(app):
+def app_no_email(app):  # type: ignore[no-untyped-def]
     app.config.update(
         {"MAIL_SERVER": None, "MAIL_FROM": None, "SERVER_NAME": "example.com"}
     )

--- a/natlas-server/tests/email/test_send_mail.py
+++ b/natlas-server/tests/email/test_send_mail.py
@@ -4,7 +4,7 @@ from app.email import send_email
 from flask import current_app
 
 
-def test_send_mail(app):
+def test_send_mail(app):  # type: ignore[no-untyped-def]
     with mail.record_messages() as outbox:
         send_email(
             "Natlas Test Mail",
@@ -17,7 +17,7 @@ def test_send_mail(app):
     assert outbox[0].sender == current_app.config["MAIL_FROM"]
 
 
-def test_send_invite(app):
+def test_send_invite(app):  # type: ignore[no-untyped-def]
     test_token = "testinvitepleaseignore"
     with mail.record_messages() as outbox:
         result = deliver_auth_link("user@example.com", test_token, "invite")
@@ -28,7 +28,7 @@ def test_send_invite(app):
     assert test_token not in result
 
 
-def test_send_password_reset(app):
+def test_send_password_reset(app):  # type: ignore[no-untyped-def]
     test_token = "testresetpleaseignore"
     with mail.record_messages() as outbox:
         result = deliver_auth_link("user@example.com", test_token, "reset")
@@ -39,7 +39,7 @@ def test_send_password_reset(app):
     assert test_token not in result
 
 
-def test_password_reset_no_email(app_no_email):
+def test_password_reset_no_email(app_no_email):  # type: ignore[no-untyped-def]
     test_token = "testresetpleaseignore"
     email = "user@example.com"
     result = deliver_auth_link(email, test_token, "reset")
@@ -47,7 +47,7 @@ def test_password_reset_no_email(app_no_email):
     assert email not in result
 
 
-def test_invite_no_email(app_no_email):
+def test_invite_no_email(app_no_email):  # type: ignore[no-untyped-def]
     test_token = "testinvitepleaseignore"
     email = "user@example.com"
     result = deliver_auth_link(email, test_token, "invite")

--- a/natlas-server/tests/models/conftest.py
+++ b/natlas-server/tests/models/conftest.py
@@ -3,5 +3,5 @@ from app import db
 
 
 @pytest.fixture(autouse=True)
-def session_rollback(app):
+def session_rollback(app):  # type: ignore[no-untyped-def]
     db.session.rollback()

--- a/natlas-server/tests/models/test_scope.py
+++ b/natlas-server/tests/models/test_scope.py
@@ -2,38 +2,38 @@ from app import db
 from app.models import ScopeItem
 
 
-def test_new_scope(app):
+def test_new_scope(app):  # type: ignore[no-untyped-def]
     test_scope = ScopeItem(target="10.0.0.0/8", blacklist=False)
     assert not test_scope.blacklist
     assert test_scope.target == "10.0.0.0/8"
 
 
-def test_ip6_scope(app):
+def test_ip6_scope(app):  # type: ignore[no-untyped-def]
     test_scope = ScopeItem(target="2001:db8::/32", blacklist=False)
     assert not test_scope.blacklist
     assert test_scope.target == "2001:db8::/32"
 
 
-def test_add_tags(app):
+def test_add_tags(app):  # type: ignore[no-untyped-def]
     tags = ["test", "tag", "three"]
     test_scope = ScopeItem(target="127.0.0.1/8", blacklist=False)
     db.session.add(test_scope)
     ScopeItem.addTags(test_scope, tags)
-    for tag in test_scope.tags:
+    for tag in test_scope.tags:  # type: ignore[attr-defined]
         assert test_scope.is_tagged(tag)
 
 
-def test_del_tags(app):
+def test_del_tags(app):  # type: ignore[no-untyped-def]
     tags = ["test", "tags", "three"]
     test_scope = ScopeItem(target="127.0.0.1/8", blacklist=False)
     db.session.add(test_scope)
     ScopeItem.addTags(test_scope, tags)
-    assert len([t.name for t in test_scope.tags]) == 3
-    test_scope.delTag(test_scope.tags[2])
-    assert len([t.name for t in test_scope.tags]) == 2
+    assert len([t.name for t in test_scope.tags]) == 3  # type: ignore[attr-defined]
+    test_scope.delTag(test_scope.tags[2])  # type: ignore[index]
+    assert len([t.name for t in test_scope.tags]) == 2  # type: ignore[attr-defined]
 
 
-def test_get_scope(app):
+def test_get_scope(app):  # type: ignore[no-untyped-def]
     test_scope1 = ScopeItem(target="127.0.0.1/8", blacklist=False)
     test_scope2 = ScopeItem(target="172.16.0.0/16", blacklist=True)
     db.session.add(test_scope1)
@@ -53,7 +53,7 @@ notevenanip
 """
 
 
-def test_import_scope(app):
+def test_import_scope(app):  # type: ignore[no-untyped-def]
     result = ScopeItem.import_scope_list(scopefile.split(), False)
     assert len(result["fail"]) == 1
     assert result["exist"] == 1

--- a/natlas-server/tests/models/test_user.py
+++ b/natlas-server/tests/models/test_user.py
@@ -6,7 +6,7 @@ from app.models import User
 test_password = secrets.token_urlsafe(16)
 
 
-def test_new_user(app):
+def test_new_user(app):  # type: ignore[no-untyped-def]
     test_user = User(email="newuser@example.com", is_active=True)
     test_user.set_password(test_password)
     db.session.add(test_user)
@@ -19,7 +19,7 @@ def test_new_user(app):
     db.session.rollback()
 
 
-def test_validate_email():
+def test_validate_email():  # type: ignore[no-untyped-def]
     assert User.validate_email("test@example.com")
     assert User.validate_email("test+extensions@example.com")
     assert User.validate_email("test.extensions@example.com")
@@ -28,7 +28,7 @@ def test_validate_email():
     assert not User.validate_email("test@example")
 
 
-def test_reset_token():
+def test_reset_token():  # type: ignore[no-untyped-def]
     email = "resettoken@example.com"
     user = User(email=email)
     db.session.add(user)
@@ -43,7 +43,7 @@ def test_reset_token():
     db.session.rollback()
 
 
-def test_double_reset_token():
+def test_double_reset_token():  # type: ignore[no-untyped-def]
     email = "double_validate@example.com"
     user = User(email=email)
     db.session.add(user)

--- a/natlas-server/tests/models/test_user_invitation.py
+++ b/natlas-server/tests/models/test_user_invitation.py
@@ -2,7 +2,7 @@ from app import db, mail
 from app.models import User, UserInvitation
 
 
-def test_new_anonymous_invite(app):
+def test_new_anonymous_invite(app):  # type: ignore[no-untyped-def]
     test_invite = UserInvitation.new_invite()
     assert test_invite.token in UserInvitation.deliver_invite(test_invite)
     assert not test_invite.is_expired
@@ -14,7 +14,7 @@ def test_new_anonymous_invite(app):
     db.session.rollback()
 
 
-def test_new_email_invite(app):
+def test_new_email_invite(app):  # type: ignore[no-untyped-def]
     email = "test_invite@example.com"
     test_invite = UserInvitation.new_invite(email)
     with mail.record_messages() as outbox:
@@ -28,14 +28,14 @@ def test_new_email_invite(app):
     db.session.rollback()
 
 
-def test_double_anonymous_deliver(app):
+def test_double_anonymous_deliver(app):  # type: ignore[no-untyped-def]
     test_invite = UserInvitation.new_invite()
     assert test_invite.token in UserInvitation.deliver_invite(test_invite)
     assert test_invite.token in UserInvitation.deliver_invite(test_invite)
     db.session.rollback()
 
 
-def test_double_email_deliver(app):
+def test_double_email_deliver(app):  # type: ignore[no-untyped-def]
     email = "test_invite@example.com"
     test_invite = UserInvitation.new_invite(email)
     with mail.record_messages() as outbox:
@@ -45,7 +45,7 @@ def test_double_email_deliver(app):
     db.session.rollback()
 
 
-def test_double_invite(app):
+def test_double_invite(app):  # type: ignore[no-untyped-def]
     email = "test_invite@example.com"
     invite_1 = UserInvitation.new_invite(email)
     old_token = invite_1.token
@@ -58,7 +58,7 @@ def test_double_invite(app):
     db.session.rollback()
 
 
-def test_inviting_existing_user(app):
+def test_inviting_existing_user(app):  # type: ignore[no-untyped-def]
     email = "test_invite@example.com"
     u = User(email=email)
     db.session.add(u)

--- a/natlas-server/tests/scope/conftest.py
+++ b/natlas-server/tests/scope/conftest.py
@@ -3,5 +3,5 @@ from app import db
 
 
 @pytest.fixture(autouse=True)
-def session_rollback(app):
+def session_rollback(app):  # type: ignore[no-untyped-def]
     db.session.rollback()

--- a/natlas-server/tests/scope/test_scan_manager.py
+++ b/natlas-server/tests/scope/test_scan_manager.py
@@ -2,7 +2,7 @@ from app.scope.scan_manager import IPScanManager
 from netaddr import IPSet
 
 
-def test_new_scan_manager(app):
+def test_new_scan_manager(app):  # type: ignore[no-untyped-def]
     scope = IPSet(["10.0.0.0/24"])
     blacklist = IPSet(["10.0.0.5/32"])
     mgr = IPScanManager(scope, blacklist, False)
@@ -10,7 +10,7 @@ def test_new_scan_manager(app):
     assert mgr.get_ready()
 
 
-def test_scan_cycle_complete_coverage(app):
+def test_scan_cycle_complete_coverage(app):  # type: ignore[no-untyped-def]
     scope = IPSet(["10.0.0.0/24"])
     blacklist = IPSet()
     mgr = IPScanManager(scope, blacklist, False)

--- a/natlas-server/tests/scope/test_scope_manager.py
+++ b/natlas-server/tests/scope/test_scope_manager.py
@@ -8,26 +8,26 @@ from flask import current_app
 network_lengths = {"/0": 4294967296, "/8": 16777216, "/16": 65536, "/24": 256, "/32": 1}
 
 
-def test_new_scopemanager(app):
+def test_new_scopemanager(app):  # type: ignore[no-untyped-def]
     sm = ScopeManager()
     sm.init_app(app)
     assert sm.get_scope() == []
     assert sm.get_blacklist() == []
     assert sm.scanmanager is None
-    assert datetime.utcnow() > sm.init_time
+    assert datetime.utcnow() > sm.init_time  # type: ignore[operator]
 
 
-def test_scope_update(app):
+def test_scope_update(app):  # type: ignore[no-untyped-def]
     scope_items = ["10.0.0.0/8"]
     for s in scope_items:
         item = ScopeItem(target=s, blacklist=False)
         db.session.add(item)
-    current_app.ScopeManager.update()
-    assert current_app.ScopeManager.get_scope_size() == network_lengths["/8"]
-    assert current_app.ScopeManager.is_acceptable_target("10.1.2.3")
+    current_app.ScopeManager.update()  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.get_scope_size() == network_lengths["/8"]  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.is_acceptable_target("10.1.2.3")  # type: ignore[attr-defined]
 
 
-def test_blacklist_update(app):
+def test_blacklist_update(app):  # type: ignore[no-untyped-def]
     scope_items = ["10.0.0.0/8"]
     blacklist_items = ["10.10.10.0/24"]
     for s in scope_items:
@@ -36,18 +36,18 @@ def test_blacklist_update(app):
     for s in blacklist_items:
         item = ScopeItem(target=s, blacklist=True)
         db.session.add(item)
-    current_app.ScopeManager.update()
-    assert current_app.ScopeManager.get_blacklist_size() == network_lengths["/24"]
-    assert current_app.ScopeManager.get_scope_size() == network_lengths["/8"]
+    current_app.ScopeManager.update()  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.get_blacklist_size() == network_lengths["/24"]  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.get_scope_size() == network_lengths["/8"]  # type: ignore[attr-defined]
     assert (
-        current_app.ScopeManager.get_effective_scope_size()
+        current_app.ScopeManager.get_effective_scope_size()  # type: ignore[attr-defined]
         == network_lengths["/8"] - network_lengths["/24"]
     )
-    assert current_app.ScopeManager.is_acceptable_target("10.10.11.1")
-    assert not current_app.ScopeManager.is_acceptable_target("10.10.10.10")
+    assert current_app.ScopeManager.is_acceptable_target("10.10.11.1")  # type: ignore[attr-defined]
+    assert not current_app.ScopeManager.is_acceptable_target("10.10.10.10")  # type: ignore[attr-defined]
 
 
-def test_acceptable_targets(app):
+def test_acceptable_targets(app):  # type: ignore[no-untyped-def]
     scope_items = ["192.168.0.0/16"]
     blacklist_items = ["192.168.1.0/24", "192.168.2.1/32"]
     for s in scope_items:
@@ -56,42 +56,42 @@ def test_acceptable_targets(app):
     for s in blacklist_items:
         item = ScopeItem(target=s, blacklist=True)
         db.session.add(item)
-    current_app.ScopeManager.update()
-    assert current_app.ScopeManager.is_acceptable_target("192.168.0.123")
-    assert current_app.ScopeManager.is_acceptable_target("192.168.2.2")
-    assert not current_app.ScopeManager.is_acceptable_target("192.168.1.234")
-    assert not current_app.ScopeManager.is_acceptable_target("192.168.2.1")
-    assert not current_app.ScopeManager.is_acceptable_target("192.0.2.34")
-    assert not current_app.ScopeManager.is_acceptable_target("example.com")
+    current_app.ScopeManager.update()  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.is_acceptable_target("192.168.0.123")  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.is_acceptable_target("192.168.2.2")  # type: ignore[attr-defined]
+    assert not current_app.ScopeManager.is_acceptable_target("192.168.1.234")  # type: ignore[attr-defined]
+    assert not current_app.ScopeManager.is_acceptable_target("192.168.2.1")  # type: ignore[attr-defined]
+    assert not current_app.ScopeManager.is_acceptable_target("192.0.2.34")  # type: ignore[attr-defined]
+    assert not current_app.ScopeManager.is_acceptable_target("example.com")  # type: ignore[attr-defined]
 
 
-def test_rescan_lifecycle(app):
+def test_rescan_lifecycle(app):  # type: ignore[no-untyped-def]
     scope_items = ["192.168.0.0/16"]
     user = User(email="test@example.com")
     db.session.add(user)
     for s in scope_items:
         item = ScopeItem(target=s, blacklist=False)
         db.session.add(item)
-    current_app.ScopeManager.update()
-    assert current_app.ScopeManager.get_pending_rescans() == []
-    assert current_app.ScopeManager.get_dispatched_rescans() == []
-    assert current_app.ScopeManager.get_incomplete_scans() == []
+    current_app.ScopeManager.update()  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.get_pending_rescans() == []  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.get_dispatched_rescans() == []  # type: ignore[attr-defined]
+    assert current_app.ScopeManager.get_incomplete_scans() == []  # type: ignore[attr-defined]
     r = RescanTask(target="192.168.123.45", user_id=user.id)
     db.session.add(r)
-    current_app.ScopeManager.update_pending_rescans()
-    assert len(current_app.ScopeManager.get_pending_rescans()) == 1
-    assert len(current_app.ScopeManager.get_incomplete_scans()) == 1
+    current_app.ScopeManager.update_pending_rescans()  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_pending_rescans()) == 1  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_incomplete_scans()) == 1  # type: ignore[attr-defined]
     r.dispatchTask()
     db.session.add(r)
-    current_app.ScopeManager.update_pending_rescans()
-    current_app.ScopeManager.update_dispatched_rescans()
-    assert len(current_app.ScopeManager.get_pending_rescans()) == 0
-    assert len(current_app.ScopeManager.get_dispatched_rescans()) == 1
-    assert len(current_app.ScopeManager.get_incomplete_scans()) == 1
+    current_app.ScopeManager.update_pending_rescans()  # type: ignore[attr-defined]
+    current_app.ScopeManager.update_dispatched_rescans()  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_pending_rescans()) == 0  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_dispatched_rescans()) == 1  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_incomplete_scans()) == 1  # type: ignore[attr-defined]
     r.completeTask("testscanid")
     db.session.add(r)
-    current_app.ScopeManager.update_pending_rescans()
-    current_app.ScopeManager.update_dispatched_rescans()
-    assert len(current_app.ScopeManager.get_pending_rescans()) == 0
-    assert len(current_app.ScopeManager.get_dispatched_rescans()) == 0
-    assert len(current_app.ScopeManager.get_incomplete_scans()) == 0
+    current_app.ScopeManager.update_pending_rescans()  # type: ignore[attr-defined]
+    current_app.ScopeManager.update_dispatched_rescans()  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_pending_rescans()) == 0  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_dispatched_rescans()) == 0  # type: ignore[attr-defined]
+    assert len(current_app.ScopeManager.get_incomplete_scans()) == 0  # type: ignore[attr-defined]

--- a/natlas-server/tests/test_errors.py
+++ b/natlas-server/tests/test_errors.py
@@ -7,19 +7,19 @@ weighted_headers = {"Accept": "text/html;q=0.8, application/json"}
 NONEXISTANT_URL = "/very_long_obviously_not_legitimate_url"
 
 
-def test_404_error(client):
+def test_404_error(client):  # type: ignore[no-untyped-def]
     expected_err_code = 404
     response = client.get(NONEXISTANT_URL)
     assert response.status_code == expected_err_code
 
 
-def test_405_error(client):
+def test_405_error(client):  # type: ignore[no-untyped-def]
     expected_err_code = 405
     response = client.delete("/")
     assert response.status_code == expected_err_code
 
 
-def test_json_error(client):
+def test_json_error(client):  # type: ignore[no-untyped-def]
     expected_err_code = 404
     expected_keys = ["status", "message"]
     response = client.get(NONEXISTANT_URL, headers=json_headers)
@@ -30,17 +30,17 @@ def test_json_error(client):
     assert response.get_json()["status"] == expected_err_code
 
 
-def test_html_error(client):
+def test_html_error(client):  # type: ignore[no-untyped-def]
     response = client.get(NONEXISTANT_URL, headers=html_headers)
     assert response.content_type == "text/html; charset=utf-8"
 
 
-def test_content_type_matching(client):
+def test_content_type_matching(client):  # type: ignore[no-untyped-def]
     response = client.get(NONEXISTANT_URL, headers=weighted_headers)
     assert response.content_type == "application/json; charset=utf-8"
 
 
-def test_invalid_search(client):
+def test_invalid_search(client):  # type: ignore[no-untyped-def]
     invalid_query = "tags:!invalid"
     current_app.config["LOGIN_REQUIRED"] = False
     response = client.get(

--- a/natlas-server/tests/test_url_converters.py
+++ b/natlas-server/tests/test_url_converters.py
@@ -6,12 +6,12 @@ TEST_IP_ADDRS = ["127.0.0.1", "::1"]
 
 
 @pytest.fixture
-def converter_client():
+def converter_client():  # type: ignore[no-untyped-def]
     app = Flask(__name__)
     register_converters(app)
 
     @app.route("/ip/<ip:ip>")
-    def ip_route(ip):
+    def ip_route(ip):  # type: ignore[no-untyped-def]
         if ip in TEST_IP_ADDRS:
             return ip
         # abort 400 to differentiate from an invalid ip 404 status code
@@ -21,7 +21,7 @@ def converter_client():
         yield client
 
 
-def test_ip_converter(converter_client):
+def test_ip_converter(converter_client):  # type: ignore[no-untyped-def]
     assert converter_client.get("/ip/127.0.0.1").status_code == 200
     assert converter_client.get("/ip/::1").status_code == 200
     assert converter_client.get("/ip/254.254.254.254").status_code == 400

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,35 @@
 name = "natlas"
 requires-python = "==3.11"
 
+[tool.mypy]
+disable_error_code = [
+  "import-untyped",
+  "no-untyped-call"
+]
+enable_error_code = [
+  "ignore-without-code",
+  "possibly-undefined",
+  "redundant-self",
+  "truthy-bool",
+  "truthy-iterable",
+  "unimported-reveal",
+  "unused-awaitable"
+]
+exclude = [
+  # This is weird because technically the exclude is for natlas-server/migrations, but mypy runs from within natlas-server using this config file
+  # so this is technically correct to ignore mypy for migrations.
+  'migrations/versions/.*\.py$'
+]
+files = "."
+local_partial_types = true
+mypy_path = "mypy_stubs"
+no_implicit_reexport = false
+pretty = false
+strict = true
+strict_optional = true
+warn_unreachable = true
+warn_unused_configs = true
+
 [tool.ruff]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Note: This is probably not the best way to do this.

I want to start enforcing mypy and type annotations for new code, as well as start working through all the old code that needs annotating. Mypy helps improve developer experience while also helping to find and fix bugs.

This adds mypy as dev dependencies for both natlas-agent as well as natlas-server. It does this rather than adding a new top level dependency manifest, because for mypy to work correctly, it needs to also have the relevant dependencies installed and available to analyze.

But in order to ensure consistency in the code base, the config file that defines the rules and behaviors of mypy is in the top level pyproject.toml. So when running mypy, we need to run it from within either component, and explicitly declare the config file like so: `mypy --config-file ../pyproject.toml`


This also used some [automation](https://gist.github.com/0xdade/0da0862cd110952c6fef855498dfc618) to add bulk type ignores wherever they currently needed to be. This means that mypy technically passes in this state, but only because most types are being ignored in most places.

The next step will be to require mypy to pass in CI for both the agent and the server. 