### PR TITLE
Fix docker syntax, circular import error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,10 @@ jobs:
       - name: Run pre-commit checks
         run: |
           pre-commit run --show-diff-on-failure --color=always --from-ref ${{ env.DEFAULT_BRANCH }} --to-ref HEAD
-
   required:
     runs-on: ubuntu-latest
-    needs: [pre-commit]
+    needs:
+      - pre-commit
     steps:
       - name: Ensure all jobs required for CI pass
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@
 #      DEVELOPMENT USE ONLY      #
 # DO NOT USE THIS IN PRODUCTION! #
 ##################################
-version: "3.7"
 services:
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18

--- a/natlas-agent/Dockerfile
+++ b/natlas-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11 as build
+FROM python:3.11 AS build
 
 RUN export DEBIAN_FRONTEND=noninteractive \
 	export BUILD_PKGS="unzip" \

--- a/natlas-server/Dockerfile
+++ b/natlas-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm as webpack
+FROM node:20-bookworm AS webpack
 ARG NATLAS_VERSION=unknown
 
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN yarn --no-progress --frozen-lockfile --non-interactive
 COPY . /app
 RUN yarn run webpack --mode production
 
-FROM python:3.12 as build
+FROM python:3.12 AS build
 
 COPY Pipfile .
 COPY Pipfile.lock .

--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -3,7 +3,8 @@ import sentry_sdk
 from flask import request
 
 from app import db
-from app.errors import NatlasSearchError, NatlasServiceError, bp
+from app.errors import bp
+from app.errors.errors import NatlasSearchError, NatlasServiceError
 from app.errors.responses import get_response, get_supported_formats
 
 

--- a/natlas-server/app/errors/responses.py
+++ b/natlas-server/app/errors/responses.py
@@ -1,6 +1,6 @@
 from flask import Response, render_template
 
-from app.errors import NatlasServiceError
+from app.errors.errors import NatlasServiceError
 
 
 def json_response(err: NatlasServiceError) -> Response:


### PR DESCRIPTION
Fixes a couple warnings when running/building things with docker compose. Also fixes a circular import error with the errors module.