### PR TITLE
Perform a bunch of simplification steps

### DIFF
--- a/natlas-agent/natlas/net.py
+++ b/natlas-agent/natlas/net.py
@@ -37,7 +37,7 @@ class NatlasNetworkServices:
     ):
         headers = {"user-agent": f"natlas-agent/{self.config.NATLAS_VERSION}"}  # type: ignore[union-attr]
         if self.config.agent_id and self.config.auth_token:  # type: ignore[union-attr]
-            authheader = f"{self.config.agent_id}:{self.config.auth_token}"
+            authheader = f"{self.config.agent_id}:{self.config.auth_token}"  # type: ignore[union-attr]
             headers["Authorization"] = f"Bearer {authheader}"
         args = {
             "timeout": self.config.request_timeout,  # type: ignore[union-attr]

--- a/natlas-agent/natlas/scanresult.py
+++ b/natlas-agent/natlas/scanresult.py
@@ -9,7 +9,7 @@ class ScanResult:
             "tags": target_data["tags"],
             "scan_id": target_data["scan_id"],
             "agent_version": config.NATLAS_VERSION,
-            "agent": config.agent_id if config.agent_id else "anonymous",
+            "agent": config.agent_id or "anonymous",
             "scan_start": datetime.now(UTC).isoformat(),
         }
 

--- a/natlas-agent/natlas/screenshots.py
+++ b/natlas-agent/natlas/screenshots.py
@@ -29,7 +29,7 @@ def is_valid_image(path: str) -> bool:
 
 def parse_url(url: str) -> tuple:  # type: ignore[type-arg]
     urlp = urlparse(url)
-    port = (80 if urlp.scheme == "http" else 443) if not urlp.port else urlp.port
+    port = urlp.port or (80 if urlp.scheme == "http" else 443)
 
     return urlp.scheme.upper(), port
 
@@ -55,9 +55,7 @@ def get_aquatone_session(base_dir: str) -> dict:  # type: ignore[type-arg]
     with open(session_path) as f:
         session = json.load(f)
 
-    if session["stats"]["screenshotSuccessful"] == 0:
-        return {}
-    return session  # type: ignore[no-any-return]
+    return {} if session["stats"]["screenshotSuccessful"] == 0 else session
 
 
 def parse_aquatone_session(base_dir: str) -> list:  # type: ignore[type-arg]
@@ -68,10 +66,8 @@ def parse_aquatone_session(base_dir: str) -> list:  # type: ignore[type-arg]
     output = []
     for _, page in session["pages"].items():
         fqScreenshotPath = os.path.join(base_dir, page["screenshotPath"])
-        parsed_page = parse_aquatone_page(page, fqScreenshotPath)
-        if not parsed_page:
-            continue
-        output.append(parsed_page)
+        if parsed_page := parse_aquatone_page(page, fqScreenshotPath):
+            output.append(parsed_page)
 
     return output
 

--- a/natlas-agent/natlas/threadscan.py
+++ b/natlas-agent/natlas/threadscan.py
@@ -73,7 +73,7 @@ def scan(target_data, config):  # type: ignore[no-untyped-def]
         path = os.path.join(scan_dir, f"nmap.{scan_id}.{ext}")
         try:
             with open(path) as f:
-                result.add_item(ext + "_data", f.read())
+                result.add_item(f"{ext}_data", f.read())
         except Exception:
             logger.warning(f"Couldn't read {path}")
             return False
@@ -106,12 +106,16 @@ def scan(target_data, config):  # type: ignore[no-untyped-def]
         )
         for item in screens:
             result.add_screenshot(item)
-    if agentConfig["vncScreenshots"] and "5900/tcp" in result.result["nmap_data"]:
-        vnc_screenshot = screenshots.get_vnc_screenshots(
-            target, scan_id, agentConfig["vncScreenshotTimeout"]
+    if (
+        agentConfig["vncScreenshots"]
+        and "5900/tcp" in result.result["nmap_data"]
+        and (
+            vnc_screenshot := screenshots.get_vnc_screenshots(
+                target, scan_id, agentConfig["vncScreenshotTimeout"]
+            )
         )
-        if vnc_screenshot:
-            result.add_screenshot(vnc_screenshot)
+    ):
+        result.add_screenshot(vnc_screenshot)
     # submit result
 
     return result

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -315,12 +315,10 @@ def services():  # type: ignore[no-untyped-def]
         return redirect(url_for("admin.services"))
 
     if addServiceForm.serviceName.data and addServiceForm.validate_on_submit():
-        newServiceName = addServiceForm.serviceName.data
         newServicePort = (
-            str(addServiceForm.servicePort.data)
-            + "/"
-            + addServiceForm.serviceProtocol.data
+            f"{addServiceForm.servicePort.data!s}/{addServiceForm.serviceProtocol.data}"
         )
+        newServiceName = addServiceForm.serviceName.data
         if "\t" + newServicePort in str(current_app.current_services["services"]):  # type: ignore[attr-defined]
             flash(f"A service with port {newServicePort} already exists!", "danger")
         else:
@@ -413,8 +411,7 @@ def delete_script(name):  # type: ignore[no-untyped-def]
     deleteForm = forms.DeleteForm()
 
     if deleteForm.validate_on_submit():
-        delScript = AgentScript.query.filter_by(name=name).first()
-        if delScript:
+        if delScript := AgentScript.query.filter_by(name=name).first():
             db.session.delete(delScript)
             db.session.commit()
             current_app.agent_scripts = AgentScript.get_scripts_string()  # type: ignore[attr-defined]

--- a/natlas-server/app/api/prepare_work.py
+++ b/natlas-server/app/api/prepare_work.py
@@ -17,7 +17,7 @@ def get_target_tags(target: str) -> list:  # type: ignore[type-arg]
 
 def get_unique_scan_id():  # type: ignore[no-untyped-def]
     scan_id = ""
-    while scan_id == "":
+    while not scan_id:
         rand = secrets.token_hex(16)
         count, context = current_app.elastic.get_host_by_scan_id(rand)  # type: ignore[attr-defined]
         if count == 0:

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -34,7 +34,7 @@ def getwork():  # type: ignore[no-untyped-def]
     work = {}
 
     if manual:
-        if current_app.ScopeManager.is_acceptable_target(manual):
+        if current_app.ScopeManager.is_acceptable_target(manual):  # type: ignore[attr-defined]
             work["scan_reason"] = "manual"
             work["target"] = manual
             work = prepare_work(work)

--- a/natlas-server/app/auth/email.py
+++ b/natlas-server/app/auth/email.py
@@ -54,9 +54,7 @@ def send_auth_email(email, token, token_type):  # type: ignore[no-untyped-def]
 
 
 def deliver_auth_link(email: str, token: str, token_type: str):  # type: ignore[no-untyped-def]
-    if email_configured() and email:
-        send_auth_email(email, token, token_type)
-        msg = f"Email sent to {email} via {current_app.config['MAIL_SERVER']}!"
-    else:
-        msg = f"Share this link: {build_email_url(token, token_type)}"
-    return msg
+    if not email_configured() or not email:
+        return f"Share this link: {build_email_url(token, token_type)}"
+    send_auth_email(email, token, token_type)
+    return f"Email sent to {email} via {current_app.config['MAIL_SERVER']}!"

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -79,8 +79,7 @@ def reset_password_request():  # type: ignore[no-untyped-def]
         validemail = validate_email(form.email.data)
         if not validemail:
             return redirect(url_for("auth.reset_password_request"))
-        user = User.get_reset_token(validemail)
-        if user:
+        if user := User.get_reset_token(validemail):
             deliver_auth_link(user.email, user.password_reset_token, "reset")
         db.session.commit()
         flash("Check your email for the instructions to reset your password", "info")
@@ -134,7 +133,7 @@ def invite_user():  # type: ignore[no-untyped-def]
     form_type = "invite" if invite.email else "register"
     form = supported_forms[form_type]["form"]()  # type: ignore[operator]
     if form.validate_on_submit():
-        email = invite.email if invite.email else form.email.data
+        email = invite.email or form.email.data
         new_user = User.new_user_from_invite(invite, form.password.data, email=email)
         db.session.commit()
         login_user(new_user)

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -140,7 +140,7 @@ def invite_user():  # type: ignore[no-untyped-def]
         flash("Your password has been set.", "success")
         return redirect(url_for("main.browse"))
     return render_template(
-        supported_forms[form_type]["template"],
+        supported_forms[form_type]["template"],  # type: ignore[arg-type]
         title="Accept Invitation",
-        form=form,  # type: ignore[arg-type]
+        form=form,
     )

--- a/natlas-server/app/cli/scope.py
+++ b/natlas-server/app/cli/scope.py
@@ -32,7 +32,7 @@ def import_scope(scope_file: typing.TextIO, blacklist: bool):  # type: ignore[no
     default=False,
     help="Should this file be considered in scope or blacklisted?",
 )
-def import_items(file: str, import_as_blacklist: bool):  # type: ignore[no-untyped-def]
+def import_items(file: typing.TextIO, import_as_blacklist: bool):  # type: ignore[no-untyped-def]
     import_name = "blacklist" if import_as_blacklist else "scope"
     results = {
         "timestamp": datetime.now(UTC).isoformat(),

--- a/natlas-server/app/cli/scope.py
+++ b/natlas-server/app/cli/scope.py
@@ -1,6 +1,6 @@
 import json
 import typing
-from datetime import datetime
+from datetime import UTC, datetime
 
 import click
 from flask.cli import AppGroup
@@ -35,8 +35,8 @@ def import_scope(scope_file: typing.TextIO, blacklist: bool):  # type: ignore[no
 def import_items(file: str, import_as_blacklist: bool):  # type: ignore[no-untyped-def]
     import_name = "blacklist" if import_as_blacklist else "scope"
     results = {
-        "timestamp": datetime.utcnow().isoformat(),
-        import_name: import_scope(file, import_as_blacklist),  # type: ignore[arg-type]
+        "timestamp": datetime.now(UTC).isoformat(),
+        import_name: import_scope(file, import_as_blacklist),
     }
     print(json.dumps(results, indent=2))
 
@@ -44,7 +44,7 @@ def import_items(file: str, import_as_blacklist: bool):  # type: ignore[no-untyp
 @cli_group.command("export")
 def export_items():  # type: ignore[no-untyped-def]
     result = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(UTC).isoformat(),
         "scope": [
             {
                 "target": item.target,

--- a/natlas-server/app/cli/user.py
+++ b/natlas-server/app/cli/user.py
@@ -17,19 +17,17 @@ err_msgs = {
 
 
 def get_user(email):  # type: ignore[no-untyped-def]
-    user = User.query.filter_by(email=email).first()
-    if not user:
-        raise click.BadParameter(err_msgs["no_such_user"].format(email))
-    return user
+    if user := User.query.filter_by(email=email).first():
+        return user
+    raise click.BadParameter(err_msgs["no_such_user"].format(email))
 
 
 def validate_email(ctx, param, value):  # type: ignore[no-untyped-def]
     if not value:
         return None
-    valid_email = User.validate_email(value)
-    if not valid_email:
-        raise click.BadParameter(err_msgs["invalid_email"].format(value))
-    return valid_email
+    if valid_email := User.validate_email(value):
+        return valid_email
+    raise click.BadParameter(err_msgs["invalid_email"].format(value))
 
 
 def ensure_server_name():  # type: ignore[no-untyped-def]
@@ -58,7 +56,7 @@ def new_user(email, admin):  # type: ignore[no-untyped-def]
 def promote_user(email, promote):  # type: ignore[no-untyped-def]
     user = get_user(email)
     if user.is_admin == promote:
-        print(f"{email} is already{' not ' if not promote else ' '}an admin")
+        print(f"{email} is already{' ' if promote else ' not '}an admin")
         return
     user.is_admin = promote
     db.session.commit()

--- a/natlas-server/app/elastic/client.py
+++ b/natlas-server/app/elastic/client.py
@@ -132,9 +132,9 @@ class ElasticClient:
         """
         with self._new_trace_span(operation="search", **kwargs) as span:
             results = self._execute_raw_query(
-                self.es.search,
+                self.es.search,  # type: ignore[union-attr]
                 rest_total_hits_as_int=True,
-                **kwargs,  # type: ignore[union-attr]
+                **kwargs,
             )
             span.set_attribute("es.hits.total", results["hits"]["total"])
             self._attach_shard_span_attrs(span, results)

--- a/natlas-server/app/elastic/indices.py
+++ b/natlas-server/app/elastic/indices.py
@@ -22,7 +22,7 @@ class ElasticIndices:
         """
         Ensure each index in this context is initalized
         """
-        with open(Config().BASEDIR + "/defaults/elastic/mapping.json") as mapfile:
+        with open(f"{Config().BASEDIR}/defaults/elastic/mapping.json") as mapfile:
             mapping = json.loads(mapfile.read())
         for index in self.all_indices():
             self.client.initialize_index(index, mapping)

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -71,9 +71,9 @@ class ElasticInterface:
 
         self.client.execute_index(index=self.indices.name("history"), document=host)  # type: ignore[union-attr]
         self.client.execute_index(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),
+            index=self.indices.name("latest"),  # type: ignore[union-attr]
             id=ip,
-            document=host,  # type: ignore[union-attr]
+            document=host,
         )
         return True
 
@@ -87,10 +87,10 @@ class ElasticInterface:
         sort = {"ctime": {"order": "desc"}}
 
         return self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("history"),
+            index=self.indices.name("history"),  # type: ignore[union-attr]
             size=size,
             query=query,
-            sort=sort,  # type: ignore[union-attr]
+            sort=sort,
         )
 
     def get_host_history(self, ip: str, limit: int, offset: int):  # type: ignore[no-untyped-def]
@@ -159,10 +159,10 @@ class ElasticInterface:
         sort = {"ctime": {"order": "desc"}}
 
         return self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("history"),
+            index=self.indices.name("history"),  # type: ignore[union-attr]
             size=size,
             query=query,
-            sort=sort,  # type: ignore[union-attr]
+            sort=sort,
         )
 
     def delete_scan(self, scan_id: str):  # type: ignore[no-untyped-def]
@@ -174,10 +174,10 @@ class ElasticInterface:
         query = {"query_string": {"query": scan_id, "fields": ["scan_id"]}}
         sort = {"ctime": {"order": "desc"}}
         count, host = self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),
+            index=self.indices.name("latest"),  # type: ignore[union-attr]
             size=size,
             query=query,
-            sort=sort,  # type: ignore[union-attr]
+            sort=sort,
         )
         if count != 0:
             # we're deleting the most recent scan result and need to pull the next most recent into the nmap index
@@ -188,10 +188,10 @@ class ElasticInterface:
             sort = {"ctime": {"order": "desc"}}
 
             count, twoscans = self.client.get_collection(  # type: ignore[union-attr]
-                index=self.indices.name("history"),
+                index=self.indices.name("history"),  # type: ignore[union-attr]
                 size=size,
                 query=query,
-                sort=sort,  # type: ignore[union-attr]
+                sort=sort,
             )
             # If count is one then there's only one result in history so we can just delete it.
             # If count is > 1 then we need to migrate the next oldest scan data
@@ -207,14 +207,14 @@ class ElasticInterface:
             }
         }
         result = self.client.execute_delete_by_query(  # type: ignore[union-attr]
-            index=self.indices.str_indices(),
-            body=deleteBody,  # type: ignore[union-attr]
+            index=self.indices.str_indices(),  # type: ignore[union-attr]
+            body=deleteBody,
         )
         if migrate:
             self.client.execute_index(  # type: ignore[union-attr]
-                index=self.indices.name("latest"),
-                id=ipaddr,
-                document=twoscans[1],  # type: ignore[possibly-undefined, union-attr]
+                index=self.indices.name("latest"),  # type: ignore[union-attr]
+                id=ipaddr,  # type: ignore[possibly-undefined]
+                document=twoscans[1],  # type: ignore[possibly-undefined]
             )
         return result["deleted"]
 
@@ -233,8 +233,8 @@ class ElasticInterface:
         }
 
         deleted = self.client.execute_delete_by_query(  # type: ignore[union-attr]
-            index=self.indices.str_indices(),
-            body=deleteBody,  # type: ignore[union-attr]
+            index=self.indices.str_indices(),  # type: ignore[union-attr]
+            body=deleteBody,
         )
         return deleted["deleted"]
 
@@ -260,10 +260,10 @@ class ElasticInterface:
         }
 
         count, host = self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),
+            index=self.indices.name("latest"),  # type: ignore[union-attr]
             size=size,
             from_=offset,
-            query=query,  # type: ignore[union-attr]
+            query=query,
         )
         return host
 
@@ -303,8 +303,8 @@ class ElasticInterface:
         Count the number of scans that match an arbitrary search body
         """
         return self.client.execute_search(  # type: ignore[union-attr]
-            index=self.indices.name(index),
+            index=self.indices.name(index),  # type: ignore[union-attr]
             size=0,
             track_scores=False,
-            **kwargs,  # type: ignore[union-attr]
+            **kwargs,
         )

--- a/natlas-server/app/errors/errors.py
+++ b/natlas-server/app/errors/errors.py
@@ -5,7 +5,7 @@ class NatlasServiceError(Exception):
     def __init__(self, status_code: int, message: str, template: str | None = None):
         self.status_code = status_code
         self.message = message
-        self.template = template if template else f"errors/{self.status_code}.html"
+        self.template = template or f"errors/{self.status_code}.html"
 
     def __str__(self):  # type: ignore[no-untyped-def]
         return f"{self.status_code}: {self.message}"

--- a/natlas-server/app/filters.py
+++ b/natlas-server/app/filters.py
@@ -15,4 +15,4 @@ def ctime(s, human=False):  # type: ignore[no-untyped-def]
 def get_screenshot_path(inhash: str, service: str = "HTTP"):  # type: ignore[no-untyped-def]
     ext_map = {"HTTP": ".png", "HTTPS": ".png", "VNC": ".jpg"}
 
-    return f"{inhash[0:2]}/{inhash[2:4]}/{inhash}{ext_map[service]}"
+    return f"{inhash[:2]}/{inhash[2:4]}/{inhash}{ext_map[service]}"

--- a/natlas-server/app/host/migrators.py
+++ b/natlas-server/app/host/migrators.py
@@ -2,15 +2,12 @@ import semver
 
 
 def determine_data_version(hostdata):  # type: ignore[no-untyped-def]
-    if "agent_version" in hostdata:
-        ver = semver.VersionInfo.parse(hostdata["agent_version"])
+    # 0.6.3 is our oldest host template set
+    fallupVer = semver.VersionInfo.parse("0.6.3")
+    if "agent_version" not in hostdata:
+        return str(fallupVer)
 
-        # 0.6.3 is our oldest host template set
-        fallupVer = semver.VersionInfo.parse("0.6.3")
+    ver = semver.VersionInfo.parse(hostdata["agent_version"])
 
-        # If agent_version is present and older than 0.6.3, "fall up" to 0.6.3 templates
-        version = str(fallupVer) if ver < fallupVer else hostdata["agent_version"]
-    else:
-        version = str(fallupVer)  # type: ignore[used-before-def]
-
-    return version
+    # If agent_version is present and older than 0.6.3, "fall up" to 0.6.3 templates
+    return str(fallupVer) if ver < fallupVer else hostdata["agent_version"]

--- a/natlas-server/app/host/routes.py
+++ b/natlas-server/app/host/routes.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import (
     Response,
@@ -168,16 +168,13 @@ def rescan_host(ip):  # type: ignore[no-untyped-def]
         return redirect(url_for("host.host", ip=ip))
 
     incompleteScans = current_app.ScopeManager.get_incomplete_scans()  # type: ignore[attr-defined]
-    scan_dispatched = {}
-    for scan in incompleteScans:
-        scan_dispatched[scan.target] = scan
-
+    scan_dispatched = {scan.target: scan for scan in incompleteScans}
     if ip in scan_dispatched:
         scan = scan_dispatched[ip]
         scan_window = current_app.agentConfig["scanTimeout"] * 2  # type: ignore[attr-defined]
         if (
             scan.dispatched
-            and (datetime.utcnow() - scan.date_dispatched).seconds > scan_window
+            and (datetime.now(UTC) - scan.date_dispatched).seconds > scan_window
         ):
             # It should never take this long so mark it as not dispatched
             scan.dispatched = False

--- a/natlas-server/app/host/summarizers.py
+++ b/natlas-server/app/host/summarizers.py
@@ -2,11 +2,10 @@ from flask import abort, current_app
 
 
 def hostinfo(ip):  # type: ignore[no-untyped-def]
-    hostinfo = {}
     count, context = current_app.elastic.get_host(ip)  # type: ignore[attr-defined]
     if count == 0:
         return abort(404)
-    hostinfo["history"] = count
+    hostinfo = {"history": count}
     screenshot_count = current_app.elastic.count_host_screenshots(ip)  # type: ignore[attr-defined]
     hostinfo["screenshot_count"] = screenshot_count
     screenshots = 0

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -86,7 +86,7 @@ def search():  # type: ignore[no-untyped-def]
     if query == "":
         return redirect(url_for("main.browse"))
     page = int(request.args.get("page", 1))
-    format = request.args.get("format", "")
+    _format = request.args.get("format", "")
     scan_ids = request.args.get("includeScanIDs", "")
     includeHistory = request.args.get("includeHistory", False)
 
@@ -113,7 +113,7 @@ def search():  # type: ignore[no-untyped-def]
         )
 
     # what kind of output are we looking for?
-    if format == "hostlist":
+    if _format == "hostlist":
         hostlist = []
         for host in context:
             if scan_ids:
@@ -121,7 +121,7 @@ def search():  # type: ignore[no-untyped-def]
             else:
                 hostlist.append(str(host["ip"]))
         return Response("\n".join(hostlist), mimetype="text/plain")
-    if format == "json":
+    if _format == "json":
         return jsonify(list(context))
     return render_template(
         "main/search.html",

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from app import db
 from app.models.dict_serializable import DictSerializable
@@ -22,12 +22,12 @@ class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined
 
     def dispatchTask(self):  # type: ignore[no-untyped-def]
         self.dispatched = True
-        self.date_dispatched = datetime.utcnow()
+        self.date_dispatched = datetime.now(UTC)
 
     def completeTask(self, scan_id):  # type: ignore[no-untyped-def]
         self.scan_id = scan_id
         self.complete = True
-        self.date_completed = datetime.utcnow()
+        self.date_completed = datetime.now(UTC)
 
     @staticmethod
     def getPendingTasks():  # type: ignore[no-untyped-def]

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -168,10 +168,11 @@ class ScopeItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
             result["success"] += ins_result.rowcount
         result["exist"] = len(address_list) - len(result["fail"]) - result["success"]  # type: ignore[arg-type, operator]
         all_scope = {item.target: item.id for item in ScopeItem.query.all()}
-        tags_to_import = []
+        tags_to_import = []  # type: ignore[var-annotated]
         for k, v in scope_tag_import.items():
             tags_to_import.extend(
-                {"scope_id": all_scope[k], "tag_id": tag.id} for tag in v
+                {"scope_id": all_scope[k], "tag_id": tag.id}  # type: ignore[attr-defined]
+                for tag in v
             )
         import_chunks = [
             tags_to_import[i : i + chunk_size]

--- a/natlas-server/app/scope/scan_group.py
+++ b/natlas-server/app/scope/scan_group.py
@@ -57,7 +57,7 @@ class ScanGroup:
                 current_app.config["CONSISTENT_SCAN_CYCLE"],
             )
         except Exception as e:
-            if self.scan_manager is not None and self.scan_manager.get_total() != 0:
+            if self.scan_manager is not None:
                 raise e
             errmsg = "Scan manager could not be instantiated because there was no scope configured."
             current_app.logger.warning(f"{datetime.now(UTC)!s} - {errmsg}\n")

--- a/natlas-server/app/scope/scan_group.py
+++ b/natlas-server/app/scope/scan_group.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 
@@ -57,8 +57,7 @@ class ScanGroup:
                 current_app.config["CONSISTENT_SCAN_CYCLE"],
             )
         except Exception as e:
-            if self.scan_manager is None or self.scan_manager.get_total() == 0:  # type: ignore[unreachable]
-                errmsg = "Scan manager could not be instantiated because there was no scope configured."
-                current_app.logger.warning(f"{datetime.utcnow()!s} - {errmsg}\n")
-            else:
+            if self.scan_manager is not None and self.scan_manager.get_total() != 0:
                 raise e
+            errmsg = "Scan manager could not be instantiated because there was no scope configured."
+            current_app.logger.warning(f"{datetime.now(UTC)!s} - {errmsg}\n")

--- a/natlas-server/app/scope/scan_manager.py
+++ b/natlas-server/app/scope/scan_manager.py
@@ -55,7 +55,7 @@ class IPScanManager:
         self.networks.sort(key=blockcomp)
 
         start = 1
-        for i in range(0, len(self.networks)):
+        for i in range(len(self.networks)):
             self.networks[i]["index"] = start
             start += self.networks[i]["size"]
 

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from flask import current_app
 from netaddr import IPAddress
@@ -29,7 +29,7 @@ class ScopeManager:
                     blacklist=ScopeManager.default_group,
                 )
             }
-        self.init_time = datetime.utcnow()
+        self.init_time = datetime.now(UTC)
 
     def load_all_groups(self):  # type: ignore[no-untyped-def]
         """
@@ -64,7 +64,7 @@ class ScopeManager:
 
     def update(self, group: str = default_group):  # type: ignore[no-untyped-def]
         self.scopes.get(group).update()  # type: ignore[union-attr]
-        current_app.logger.info(f"{datetime.utcnow()!s} - ScopeManager Updated\n")
+        current_app.logger.info(f"{datetime.now(UTC)!s} - ScopeManager Updated\n")
 
     def is_acceptable_target(self, target: str, group: str = default_group) -> bool:
         try:

--- a/natlas-server/app/util.py
+++ b/natlas-server/app/util.py
@@ -19,8 +19,8 @@ def generate_hex_32():  # type: ignore[no-untyped-def]
 def pretty_time_delta(delta):  # type: ignore[no-untyped-def]
     hours, seconds = divmod(delta.seconds, 3600)
     minutes, seconds = divmod(seconds, 60)
-    daystr = (str(delta.days) + "d, ") if delta.days else ""
-    hourstr = (str(hours) + "h, ") if hours else ""
-    minstr = (str(minutes) + "m, ") if minutes else ""
-    secstr = str(seconds) + "s"
+    daystr = f"{delta.days!s}d, " if delta.days else ""
+    hourstr = f"{hours!s}h, " if hours else ""
+    minstr = f"{minutes!s}m, " if minutes else ""
+    secstr = f"{seconds!s}s"
     return daystr + hourstr + minstr + secstr


### PR DESCRIPTION
As I'm starting to dig back into the code base, there are some patterns I found that I don't really like. For instance, due to the much more streamlined deployment model and modernized python requirements, we can use assignment expressions to simplify a bunch of code blocks. Additionally, there were a lot of chained `x if x else y` type things that could be simplified into `x or y`. 

There were also a bunch of places I was using timezone naive datetimes, or places where I was using `utcnow()` which is both a deprecated pattern and produces timezone naive datetimes. So that's been updated.