### PR TITLE
Use more reasonable dependency declarations for agent

### DIFF
--- a/natlas-agent/Pipfile
+++ b/natlas-agent/Pipfile
@@ -2,8 +2,8 @@
 mypy = "~=1.14"
 
 [packages]
-natlas-libnmap = "*"
-pillow = "*"
+natlas-libnmap = "~=0.7"
+pillow = "~=11.0"
 pydantic-settings = "~=2.7"
 python-dotenv = "~=1.0.1"
 requests = "~=2.31.0"

--- a/natlas-agent/Pipfile.lock
+++ b/natlas-agent/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7b8dd78815fdb18dd33ad012945ab76d81d4e6891b10d040a95ae933aefb56ff"
+            "sha256": "361b9ef94bb8fb4a6c7443ac0dfddf640e625e6ba54a2996e5868732c9bafa12"
         },
         "pipfile-spec": 6,
         "requires": {


### PR DESCRIPTION
I've learned a lot over the years, and one of the things I've learned is that if you want to build and run a stable application and minimize future surprises, you probably don't want to use `*` version specifiers.

This replaces the existing * specifiers with ones that are more narrow but without requiring manual intervention for every version update.