### PR TITLE
Switch conftest to the new way to use Config

### DIFF
--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -60,6 +60,7 @@ class Config(BaseSettings):
     otel_collector: str = Field(default="127.0.0.1:4317")
 
     version_override: str | None = Field(default=None)
+    TESTING: bool = Field(default=False)
 
     @model_validator(mode="after")
     def override_version(self) -> Self:

--- a/natlas-server/tests/config.py
+++ b/natlas-server/tests/config.py
@@ -1,25 +1,13 @@
 from config import Config
 
-
-class TestConfig(Config):
-    # MAIL_FROM and MAIL_SERVER are required checks for delivering mail
-    MAIL_FROM = "Test Mail <noreply@example.com>"
-    MAIL_SERVER = "localhost"
-
-    # Tell Flask that it's in testing mode
-    TESTING = True
-
-    # This uses an in-memory database.
-    # It will not work with database migrations.
-    # But will work if you just want an app instance with
-    # an empty database via db.create_all()
-    SQLALCHEMY_DATABASE_URI = "sqlite://"
-
-    # By enabling this, we can test migrations automatically whenever the app is used
-    DB_AUTO_UPGRADE = True
-
-    # Assume that the test environment has access to elastic via localhost:9200
-    ELASTICSEARCH_URL = "http://elastic:9200"
-    ELASTIC_AUTH_ENABLE = True
-    ELASTIC_USER = "elastic"
-    ELASTIC_PASSWORD = "natlas-dev-password-do-not-use"
+test_config = Config(
+    MAIL_FROM="Test Mail <noreply@example.com>",
+    MAIL_SERVER="localhost",
+    TESTING=True,
+    SQLALCHEMY_DATABASE_URI="sqlite://",
+    DB_AUTO_UPGRADE=True,
+    ELASTICSEARCH_URL="http://elastic:9200",
+    ELASTIC_AUTH_ENABLE=True,
+    ELASTIC_USER="elastic",
+    ELASTIC_PASSWORD="natlas-dev-password-do-not-use",
+)

--- a/natlas-server/tests/conftest.py
+++ b/natlas-server/tests/conftest.py
@@ -4,15 +4,14 @@ import tempfile
 import pytest
 from app import create_app
 
-from tests.config import TestConfig
+from tests.config import test_config
 
 
 @pytest.fixture
 def app():  # type: ignore[no-untyped-def]
-    conf = TestConfig()
     db_fd, db_name = tempfile.mkstemp()
-    conf.SQLALCHEMY_DATABASE_URI = "sqlite:///" + db_name
-    app = create_app(conf)
+    test_config.SQLALCHEMY_DATABASE_URI = "sqlite:///" + db_name
+    app = create_app(test_config)
     with app.app_context():
         yield app
     os.close(db_fd)

--- a/natlas-server/tests/elastic/conftest.py
+++ b/natlas-server/tests/elastic/conftest.py
@@ -1,8 +1,6 @@
 import pytest
 from app.elastic import ElasticInterface
-from tests.config import TestConfig
-
-conf = TestConfig()
+from tests.config import test_config
 
 
 def reset_indices(indices):  # type: ignore[no-untyped-def]
@@ -13,7 +11,7 @@ def reset_indices(indices):  # type: ignore[no-untyped-def]
 @pytest.fixture(scope="module")
 def esinterface():  # type: ignore[no-untyped-def]
     esi = ElasticInterface(
-        conf.ELASTICSEARCH_URL,
+        test_config.ELASTICSEARCH_URL,
         True,
         "elastic",
         "natlas-dev-password-do-not-use",


### PR DESCRIPTION
The new server config can have specific overrides declared at instantiation, rather than maintaining a separate subclass. In fact the separate subclass doesn't work anymore.

We don't have automated tests running right now after I ripped circleci out, and tests locally are a bit of a mess due to the fact that I didn't bother to mock out any external dependencies or use fixtures, so running tests fails unless you have elastic running, and running tests in the container doesn't really work because we don't have a test target.

But that'll all come later. This just fixes it so that pytest _can_ launch correctly.