### PR TITLE
Ignore code workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ natlas-agent/logs
 natlas-server/node_modules
 .DS_Store
 .vscode
+*.code-workspace
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
VS Code Workspace configurations are cool and they _could_ go in a repo, but they don't need to, and I don't want to accidentally commit it in the future.