### PR TITLE
Update otel collector to send to zipkin correctly

### DIFF
--- a/.otel-collector-dev.yml
+++ b/.otel-collector-dev.yml
@@ -13,7 +13,7 @@ processors:
 
 exporters:
   zipkin:
-    endpoint: 'http://zipkin-server:9411/api/v2/spans'
+    endpoint: 'http://zipkin:9411/api/v2/spans'
   logging:
     loglevel: debug
 


### PR DESCRIPTION
I renamed zipkin-server to zipkin when I renamed a bunch of other things to simpler names, but missed this, which is necessary for the otel collector to send spans off to Zipkin.

As a side note, I kinda think Zipkin's interface is... bad.