### PR TITLE
Typing improvements for natlas-server

### DIFF
--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -28,9 +28,9 @@ from app.models import (
 
 
 @bp.route("/", methods=["GET", "POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def admin():  # type: ignore[no-untyped-def]
+def admin() -> str:
     configForm = forms.ConfigForm()
     configItems = current_app.config
     if configForm.validate_on_submit():
@@ -49,9 +49,9 @@ def admin():  # type: ignore[no-untyped-def]
 
 
 @bp.route("/users", methods=["GET", "POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def users():  # type: ignore[no-untyped-def]
+def users() -> Response | str:
     users = User.query.all()
     inviteForm = forms.InviteUserForm()
     if inviteForm.validate_on_submit():
@@ -59,7 +59,7 @@ def users():  # type: ignore[no-untyped-def]
         msg = UserInvitation.deliver_invite(invitation)
         flash(msg, "success")
         db.session.commit()
-        return redirect(url_for("admin.users"))
+        return redirect(url_for("admin.users"))  # type: ignore[return-value]
     return render_template(
         "admin/users.html",
         users=users,
@@ -70,14 +70,14 @@ def users():  # type: ignore[no-untyped-def]
 
 
 @bp.route("/users/<int:id>/delete", methods=["POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def delete_user(id):  # type: ignore[no-untyped-def]
+def delete_user(id: int) -> Response:
     delForm = forms.UserDeleteForm()
     if delForm.validate_on_submit():
         if current_user.id == id:
             flash("You can't delete yourself!", "danger")
-            return redirect(url_for("admin.users"))
+            return redirect(url_for("admin.users"))  # type: ignore[return-value]
         user = User.query.filter_by(id=id).first()
         User.query.filter_by(id=id).delete()
         db.session.commit()
@@ -85,32 +85,32 @@ def delete_user(id):  # type: ignore[no-untyped-def]
     else:
         flash("Form couldn't validate!", "danger")
 
-    return redirect(url_for("admin.users"))
+    return redirect(url_for("admin.users"))  # type: ignore[return-value]
 
 
 @bp.route("/users/<int:id>/toggle", methods=["POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def toggle_user(id):  # type: ignore[no-untyped-def]
+def toggle_user(id: int) -> Response:
     editForm = forms.UserEditForm()
     if editForm.validate_on_submit():
         user = User.query.filter_by(id=id).first()
         if user.id == current_user.id:
             flash("Can't demote yourself!", "danger")
-            return redirect(url_for("admin.users"))
+            return redirect(url_for("admin.users"))  # type: ignore[return-value]
         user.is_admin = not user.is_admin
         db.session.commit()
         flash("User status toggled.", "success")
     else:
         flash("Form couldn't validate!", "danger")
 
-    return redirect(url_for("admin.users"))
+    return redirect(url_for("admin.users"))  # type: ignore[return-value]
 
 
 @bp.route("/scope", methods=["GET", "POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def scope():  # type: ignore[no-untyped-def]
+def scope() -> Response | str:
     render = {
         "scope": ScopeItem.getScope(),
         "scopeSize": current_app.ScopeManager.get_scope_size(),  # type: ignore[attr-defined]
@@ -132,14 +132,14 @@ def scope():  # type: ignore[no-untyped-def]
         db.session.commit()
         current_app.ScopeManager.update()  # type: ignore[attr-defined]
         flash(f"{newTarget.target} added.", "success")
-        return redirect(url_for("admin.scope"))
+        return redirect(url_for("admin.scope"))  # type: ignore[return-value]
     return render_template("admin/scope.html", **render)
 
 
 @bp.route("/blacklist", methods=["GET", "POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def blacklist():  # type: ignore[no-untyped-def]
+def blacklist() -> Response | str:
     render = {
         "scope": ScopeItem.getBlacklist(),
         "blacklistSize": current_app.ScopeManager.get_blacklist_size(),  # type: ignore[attr-defined]
@@ -160,14 +160,14 @@ def blacklist():  # type: ignore[no-untyped-def]
         db.session.commit()
         current_app.ScopeManager.update()  # type: ignore[attr-defined]
         flash(f"{newTarget.target} blacklisted.", "success")
-        return redirect(url_for("admin.blacklist"))
+        return redirect(url_for("admin.blacklist"))  # type: ignore[return-value]
     return render_template("admin/blacklist.html", **render)
 
 
 @bp.route("/import/<string:scopetype>", methods=["POST"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def import_scope(scopetype=""):  # type: ignore[no-untyped-def]
+def import_scope(scopetype: str = "") -> Response:
     if scopetype == "blacklist":
         importBlacklist = True
         importForm = forms.ImportBlacklistForm()
@@ -175,7 +175,7 @@ def import_scope(scopetype=""):  # type: ignore[no-untyped-def]
         importBlacklist = False
         importForm = forms.ImportScopeForm()
     else:
-        return abort(404)
+        abort(404)
     if importForm.validate_on_submit():
         newScopeItems = importForm.scope.data.split("\n")
         result = ScopeItem.import_scope_list(newScopeItems, importBlacklist)
@@ -193,7 +193,7 @@ def import_scope(scopetype=""):  # type: ignore[no-untyped-def]
         for _field, errors in importForm.errors.items():
             for error in errors:
                 flash(error, "danger")
-    return redirect(url_for(f"admin.{scopetype}"))
+    return redirect(url_for(f"admin.{scopetype}"))  # type: ignore[return-value]
 
 
 @bp.route("/export/<string:scopetype>", methods=["GET"])
@@ -483,8 +483,8 @@ def tags():  # type: ignore[no-untyped-def]
 
 
 @bp.route("/logs", methods=["GET"])
-@login_required
+@login_required  # type: ignore[misc]
 @is_admin
-def logs():  # type: ignore[no-untyped-def]
+def logs() -> str:
     scope_logs = ScopeLog.query.order_by(ScopeLog.created_at.desc()).all()
     return render_template("admin/logs.html", scope_logs=scope_logs)

--- a/natlas-server/app/api/prepare_work.py
+++ b/natlas-server/app/api/prepare_work.py
@@ -5,7 +5,7 @@ from flask import current_app
 from app.models import ScopeItem
 
 
-def get_target_tags(target: str) -> list:  # type: ignore[type-arg]
+def get_target_tags(target: str) -> list[str]:
     overlap = ScopeItem.get_overlapping_ranges(target)
     tags = []
     for scope in overlap:

--- a/natlas-server/app/api/rescan_handler.py
+++ b/natlas-server/app/api/rescan_handler.py
@@ -1,9 +1,14 @@
+from typing import TYPE_CHECKING
+
 from flask import current_app
 
 from app import db
 
+if TYPE_CHECKING:
+    from app.models.rescan_task import RescanTask
 
-def mark_scan_dispatched(rescan):  # type: ignore[no-untyped-def]
+
+def mark_scan_dispatched(rescan: "RescanTask") -> None:
     rescan.dispatchTask()
     db.session.add(rescan)
     db.session.commit()
@@ -11,7 +16,7 @@ def mark_scan_dispatched(rescan):  # type: ignore[no-untyped-def]
     current_app.ScopeManager.update_dispatched_rescans()  # type: ignore[attr-defined]
 
 
-def mark_scan_completed(ip, scan_id):  # type: ignore[no-untyped-def]
+def mark_scan_completed(ip, scan_id) -> bool:  # type: ignore[no-untyped-def]
     dispatched = current_app.ScopeManager.get_dispatched_rescans()  # type: ignore[attr-defined]
     for scan in dispatched:
         if scan.target == ip:

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -19,7 +19,7 @@ json_content = "application/json"
 
 @bp.route("/getwork", methods=["GET"])
 @is_agent_authenticated
-def getwork():  # type: ignore[no-untyped-def]
+def getwork() -> Response:
     manual = request.args.get("target", "")
     if "natlas-agent" in request.headers["user-agent"]:
         verstr = request.headers["user-agent"].split("/")[1]
@@ -89,7 +89,7 @@ def getwork():  # type: ignore[no-untyped-def]
 
 @bp.route("/submit", methods=["POST"])
 @is_agent_authenticated
-def submit():  # type: ignore[no-untyped-def]
+def submit() -> Response:
     status_code = None
     response_body = None
     data = request.get_json()
@@ -215,7 +215,7 @@ def submit():  # type: ignore[no-untyped-def]
 
 @bp.route("/natlas-services", methods=["GET"])
 @is_agent_authenticated
-def natlasServices():  # type: ignore[no-untyped-def]
+def natlasServices() -> Response:
     if current_app.current_services["id"] != "None":  # type: ignore[attr-defined]
         tmpdict = (
             current_app.current_services.copy()  # type: ignore[attr-defined]
@@ -235,7 +235,7 @@ def natlasServices():  # type: ignore[no-untyped-def]
 
 @bp.route("/status", methods=["GET"])
 @is_authenticated
-def status():  # type: ignore[no-untyped-def]
+def status() -> Response:
     last_cycle_start = current_app.ScopeManager.get_last_cycle_start()  # type: ignore[attr-defined]
     completed_cycles = current_app.ScopeManager.get_completed_cycle_count()  # type: ignore[attr-defined]
     avg_cycle_time = None

--- a/natlas-server/app/auth/email.py
+++ b/natlas-server/app/auth/email.py
@@ -29,7 +29,7 @@ def validate_email(addr):  # type: ignore[no-untyped-def]
     return validemail
 
 
-def build_email_url(token, token_type):  # type: ignore[no-untyped-def]
+def build_email_url(token: str, token_type: str) -> str:
     return url_for(
         token_types[token_type]["route"],
         token=token,

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 
 from flask import current_app, flash, redirect, render_template, request, url_for
 from flask_login import login_user, logout_user
+from werkzeug.wrappers.response import Response
 
 from app import db
 from app.auth import bp
@@ -119,8 +120,11 @@ def reset_password():  # type: ignore[no-untyped-def]
 
 @bp.route("/invite", methods=["GET", "POST"])
 @is_not_authenticated
-def invite_user():  # type: ignore[no-untyped-def]
+def invite_user() -> Response:
     url_token = request.args.get("token", None)
+    if not url_token:
+        flash("No token found")
+        return redirect(url_for("auth.login"))
     invite = UserInvitation.get_invite(url_token)
     if not invite:
         flash("Invite token is invalid or has expired", "danger")
@@ -140,7 +144,7 @@ def invite_user():  # type: ignore[no-untyped-def]
         login_user(new_user)
         flash("Your password has been set.", "success")
         return redirect(url_for("main.browse"))
-    return render_template(
+    return render_template(  # type: ignore[return-value]
         supported_forms[form_type]["template"],  # type: ignore[arg-type]
         title="Accept Invitation",
         form=form,

--- a/natlas-server/app/auth/wrappers.py
+++ b/natlas-server/app/auth/wrappers.py
@@ -1,51 +1,56 @@
 import json
+from collections.abc import Callable
 from functools import wraps
+from typing import ParamSpec, TypeVar
 
-from flask import Response, current_app, flash, redirect, request, url_for
+from flask import Response, abort, current_app, flash, redirect, request, url_for
 from flask_login import current_user
 
 from app import login as lm
 from app.models import Agent
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 # This can be used in lieu of @login_required for pages that don't require a user account
-def is_authenticated(f):  # type: ignore[no-untyped-def]
+def is_authenticated(f: Callable[P, R]) -> Callable[P, R]:
     @wraps(f)
-    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def decorated_function(*args: P.args, **kwargs: P.kwargs) -> R:
         if current_app.config["LOGIN_REQUIRED"] and not current_user.is_authenticated:
-            return lm.unauthorized()
+            return lm.unauthorized()  # type: ignore[no-any-return]
         return f(*args, **kwargs)
 
     return decorated_function
 
 
 # An explicit wrapper to make a route only available if a request is not authenticated
-def is_not_authenticated(f):  # type: ignore[no-untyped-def]
+def is_not_authenticated(f: Callable[P, R]) -> Callable[P, R]:
     @wraps(f)
-    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def decorated_function(*args: P.args, **kwargs: P.kwargs) -> R:
         if current_user.is_authenticated:
             flash("You're already logged in!", "warning")
-            return redirect(url_for("main.browse"))
+            return redirect(url_for("main.browse"))  # type: ignore[return-value]
         return f(*args, **kwargs)
 
     return decorated_function
 
 
 # Ensure current user is an admin
-def is_admin(f):  # type: ignore[no-untyped-def]
+def is_admin(f: Callable[P, R]) -> Callable[P, R]:
     @wraps(f)
-    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def decorated_function(*args: P.args, **kwargs: P.kwargs) -> R:
         if current_user.is_anonymous or not current_user.is_admin:
-            return lm.unauthorized()
+            return lm.unauthorized()  # type: ignore[no-any-return]
         return f(*args, **kwargs)
 
     return decorated_function
 
 
 # Validate agent authentication if required
-def is_agent_authenticated(f):  # type: ignore[no-untyped-def]
+def is_agent_authenticated(f: Callable[P, R]) -> Callable[P, R]:
     @wraps(f)
-    def decorated_function(*args, **kwargs):  # type: ignore[no-untyped-def]
+    def decorated_function(*args: P.args, **kwargs: P.kwargs) -> R:
         # if we don't require agent authentication then don't bother
         if not current_app.config["AGENT_AUTHENTICATION"]:
             return f(*args, **kwargs)
@@ -61,10 +66,12 @@ def is_agent_authenticated(f):  # type: ignore[no-untyped-def]
                     "retry": False,
                 }
             )
-            return Response(
-                response=response_body,
-                status=status_code,
-                content_type="application/json",
+            abort(
+                Response(
+                    response=response_body,
+                    status=status_code,
+                    content_type="application/json",
+                )
             )
         return f(*args, **kwargs)
 

--- a/natlas-server/app/elastic/indices.py
+++ b/natlas-server/app/elastic/indices.py
@@ -7,8 +7,8 @@ from app.elastic.client import ElasticClient
 
 
 class ElasticIndices:
-    basename = None  # type: ignore[var-annotated]
-    indices = None  # type: ignore[var-annotated]
+    basename: str
+    indices: dict[str, str]
     logger = logging.getLogger("elasticsearch")
     logger.setLevel("ERROR")
 
@@ -18,7 +18,7 @@ class ElasticIndices:
         self.indices = {"latest": basename, "history": f"{basename}_history"}
         self._initialize_indices()
 
-    def _initialize_indices(self):  # type: ignore[no-untyped-def]
+    def _initialize_indices(self) -> None:
         """
         Ensure each index in this context is initalized
         """
@@ -28,7 +28,7 @@ class ElasticIndices:
             self.client.initialize_index(index, mapping)
         self.logger.info(f"Initialized Elasticsearch {self.basename} indices")
 
-    def _delete_indices(self):  # type: ignore[no-untyped-def]
+    def _delete_indices(self) -> None:
         """
         Delete all indices in this context
         """
@@ -36,19 +36,19 @@ class ElasticIndices:
             self.client.delete_index(index=index)
         self.logger.info(f"Deleted Elasticsearch {self.basename} indices")
 
-    def name(self, alias: str):  # type: ignore[no-untyped-def]
+    def name(self, alias: str) -> str:
         """
         Get the name of an index based on the current context
         """
-        return self.indices[alias]  # type: ignore[index]
+        return self.indices[alias]
 
-    def all_indices(self):  # type: ignore[no-untyped-def]
+    def all_indices(self) -> list[str]:
         """
         Return a list of indices in the current context
         """
-        return [v for _, v in self.indices.items()]  # type: ignore[union-attr]
+        return [v for _, v in self.indices.items()]
 
-    def str_indices(self):  # type: ignore[no-untyped-def]
+    def str_indices(self) -> str:
         """
         Return a comma-separated string of indices in the current context
         """

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -7,8 +7,8 @@ from app.elastic.indices import ElasticIndices
 
 
 class ElasticInterface:
-    client = None  # type: ignore[var-annotated]
-    indices = None  # type: ignore[var-annotated]
+    client: ElasticClient
+    indices: ElasticIndices
 
     def __init__(
         self,
@@ -49,8 +49,8 @@ class ElasticInterface:
         }
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_collection(  # type: ignore[union-attr]
-            index=self.indices.name(searchIndex),  # type: ignore[union-attr]
+        return self.client.get_collection(
+            index=self.indices.name(searchIndex),
             query=query,
             sort=sort,
             from_=offset,
@@ -60,7 +60,7 @@ class ElasticInterface:
         """
         Count the number of documents in nmap and return the count
         """
-        result = self.client.execute_count(index=self.indices.name("latest"))  # type: ignore[union-attr]
+        result = self.client.execute_count(index=self.indices.name("latest"))
         return result["count"]
 
     def new_result(self, host: dict):  # type: ignore[no-untyped-def, type-arg]
@@ -69,9 +69,9 @@ class ElasticInterface:
         """
         ip = str(host["ip"])
 
-        self.client.execute_index(index=self.indices.name("history"), document=host)  # type: ignore[union-attr]
-        self.client.execute_index(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),  # type: ignore[union-attr]
+        self.client.execute_index(index=self.indices.name("history"), document=host)
+        self.client.execute_index(
+            index=self.indices.name("latest"),
             id=ip,
             document=host,
         )
@@ -86,8 +86,8 @@ class ElasticInterface:
         query = {"term": {"ip": ip}}
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("history"),  # type: ignore[union-attr]
+        return self.client.get_single_host(
+            index=self.indices.name("history"),
             size=size,
             query=query,
             sort=sort,
@@ -100,8 +100,8 @@ class ElasticInterface:
         query = {"term": {"ip": ip}}
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_collection(  # type: ignore[union-attr]
-            index=self.indices.name("history"),  # type: ignore[union-attr]
+        return self.client.get_collection(
+            index=self.indices.name("history"),
             size=limit,
             from_=offset,
             query=query,
@@ -133,8 +133,8 @@ class ElasticInterface:
         }
         sort = {"ctime": {"order": "desc"}}
         source_fields = ["screenshots", "ctime", "scan_id"]
-        return self.client.get_collection(  # type: ignore[union-attr]
-            index=self.indices.name("history"),  # type: ignore[union-attr]
+        return self.client.get_collection(
+            index=self.indices.name("history"),
             query=query,
             size=limit,
             from_=offset,
@@ -158,8 +158,8 @@ class ElasticInterface:
         }
         sort = {"ctime": {"order": "desc"}}
 
-        return self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("history"),  # type: ignore[union-attr]
+        return self.client.get_single_host(
+            index=self.indices.name("history"),
             size=size,
             query=query,
             sort=sort,
@@ -173,8 +173,8 @@ class ElasticInterface:
         size = 1
         query = {"query_string": {"query": scan_id, "fields": ["scan_id"]}}
         sort = {"ctime": {"order": "desc"}}
-        count, host = self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),  # type: ignore[union-attr]
+        count, host = self.client.get_single_host(
+            index=self.indices.name("latest"),
             size=size,
             query=query,
             sort=sort,
@@ -182,13 +182,13 @@ class ElasticInterface:
         if count != 0:
             # we're deleting the most recent scan result and need to pull the next most recent into the nmap index
             # otherwise you won't find the host when doing searches or browsing
-            ipaddr = host["ip"]
+            ipaddr = host["ip"]  # type: ignore[index]
             size = 2
             query = {"query_string": {"query": ipaddr, "fields": ["ip"]}}
             sort = {"ctime": {"order": "desc"}}
 
-            count, twoscans = self.client.get_collection(  # type: ignore[union-attr]
-                index=self.indices.name("history"),  # type: ignore[union-attr]
+            count, twoscans = self.client.get_collection(
+                index=self.indices.name("history"),
                 size=size,
                 query=query,
                 sort=sort,
@@ -206,13 +206,13 @@ class ElasticInterface:
                 }
             }
         }
-        result = self.client.execute_delete_by_query(  # type: ignore[union-attr]
-            index=self.indices.str_indices(),  # type: ignore[union-attr]
+        result = self.client.execute_delete_by_query(
+            index=self.indices.str_indices(),
             body=deleteBody,
         )
         if migrate:
-            self.client.execute_index(  # type: ignore[union-attr]
-                index=self.indices.name("latest"),  # type: ignore[union-attr]
+            self.client.execute_index(
+                index=self.indices.name("latest"),
                 id=ipaddr,  # type: ignore[possibly-undefined]
                 document=twoscans[1],  # type: ignore[possibly-undefined]
             )
@@ -232,8 +232,8 @@ class ElasticInterface:
             }
         }
 
-        deleted = self.client.execute_delete_by_query(  # type: ignore[union-attr]
-            index=self.indices.str_indices(),  # type: ignore[union-attr]
+        deleted = self.client.execute_delete_by_query(
+            index=self.indices.str_indices(),
             body=deleteBody,
         )
         return deleted["deleted"]
@@ -259,8 +259,8 @@ class ElasticInterface:
             }
         }
 
-        count, host = self.client.get_single_host(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),  # type: ignore[union-attr]
+        count, host = self.client.get_single_host(
+            index=self.indices.name("latest"),
             size=size,
             from_=offset,
             query=query,
@@ -276,8 +276,8 @@ class ElasticInterface:
         sort = {"ctime": {"order": "desc"}}
         source_fields = ["screenshots", "ctime", "scan_id", "ip"]
         # We need to execute_search instead of get_collection here because we also need the aggregation information
-        result = self.client.execute_search(  # type: ignore[union-attr]
-            index=self.indices.name("latest"),  # type: ignore[union-attr]
+        result = self.client.execute_search(
+            index=self.indices.name("latest"),
             query=query,
             size=limit,
             from_=offset,
@@ -287,7 +287,7 @@ class ElasticInterface:
             track_scores=False,
         )
         num_screenshots = int(result["aggregations"]["screenshot_count"]["value"])
-        results = self.client.collate_source(result["hits"]["hits"])  # type: ignore[union-attr]
+        results = self.client.collate_source(result["hits"]["hits"])
 
         return result["hits"]["total"], num_screenshots, results
 
@@ -302,8 +302,8 @@ class ElasticInterface:
         """
         Count the number of scans that match an arbitrary search body
         """
-        return self.client.execute_search(  # type: ignore[union-attr]
-            index=self.indices.name(index),  # type: ignore[union-attr]
+        return self.client.execute_search(
+            index=self.indices.name(index),
             size=0,
             track_scores=False,
             **kwargs,

--- a/natlas-server/app/email.py
+++ b/natlas-server/app/email.py
@@ -1,18 +1,20 @@
 from threading import Thread
 
-from flask import current_app
+from flask import Flask, current_app
 from flask_mail import Message
 
 from app import mail
 
 
-def send_async_email(app, msg):  # type: ignore[no-untyped-def]
+def send_async_email(app: Flask, msg: Message) -> None:
     with app.app_context():
         mail.send(msg)
 
 
-def send_email(subject, sender, recipients, text_body):  # type: ignore[no-untyped-def]
-    msg = Message(subject, sender=sender, recipients=recipients)
+def send_email(
+    subject: str, sender: str, recipients: list[str], text_body: str
+) -> None:
+    msg = Message(subject, sender=sender, recipients=recipients)  # type: ignore[arg-type]
     msg.body = text_body
     Thread(
         target=send_async_email,

--- a/natlas-server/app/errors/errors.py
+++ b/natlas-server/app/errors/errors.py
@@ -7,13 +7,13 @@ class NatlasServiceError(Exception):
         self.message = message
         self.template = template if template else f"errors/{self.status_code}.html"
 
-    def __str__(self):  # type: ignore[no-untyped-def]
+    def __str__(self) -> str:
         return f"{self.status_code}: {self.message}"
 
-    def get_dict(self):  # type: ignore[no-untyped-def]
+    def get_dict(self) -> dict[str, int | str]:
         return {"status": self.status_code, "message": self.message}
 
-    def get_json(self):  # type: ignore[no-untyped-def]
+    def get_json(self) -> str:
         return json.dumps(self.get_dict(), sort_keys=True, indent=4)
 
 

--- a/natlas-server/app/errors/handlers.py
+++ b/natlas-server/app/errors/handlers.py
@@ -1,6 +1,6 @@
 import elasticsearch
 import sentry_sdk
-from flask import request
+from flask import Response, request
 
 from app import db
 from app.errors import bp
@@ -8,7 +8,7 @@ from app.errors.errors import NatlasSearchError, NatlasServiceError
 from app.errors.responses import get_response, get_supported_formats
 
 
-def build_response(err: NatlasServiceError):  # type: ignore[no-untyped-def]
+def build_response(err: NatlasServiceError) -> Response:
     selected_format = request.accept_mimetypes.best_match(
         get_supported_formats(), default="application/json"
     )

--- a/natlas-server/app/errors/responses.py
+++ b/natlas-server/app/errors/responses.py
@@ -21,5 +21,5 @@ def get_response(requested_format: str, err: NatlasServiceError) -> Response:
     return supported_formats.get(requested_format)(err)  # type: ignore[misc]
 
 
-def get_supported_formats() -> list:  # type: ignore[type-arg]
+def get_supported_formats() -> list[str]:
     return supported_formats.keys()  # type: ignore[return-value]

--- a/natlas-server/app/filters.py
+++ b/natlas-server/app/filters.py
@@ -5,14 +5,14 @@ bp = Blueprint("filters", __name__)
 
 
 @bp.app_template_filter("ctime")
-def ctime(s, human=False):  # type: ignore[no-untyped-def]
+def ctime(s: str, human: bool = False) -> str:
     if human:
-        return parser.parse(s).strftime("%Y-%m-%d %H:%M:%S %Z")
-    return parser.parse(s).strftime("%Y-%m-%d %H:%M")
+        return parser.parse(s).strftime("%Y-%m-%d %H:%M:%S %Z")  # type: ignore[no-any-return]
+    return parser.parse(s).strftime("%Y-%m-%d %H:%M")  # type: ignore[no-any-return]
 
 
 @bp.app_template_filter("get_screenshot_path")
-def get_screenshot_path(inhash: str, service: str = "HTTP"):  # type: ignore[no-untyped-def]
+def get_screenshot_path(inhash: str, service: str = "HTTP") -> str:
     ext_map = {"HTTP": ".png", "HTTPS": ".png", "VNC": ".jpg"}
 
     return f"{inhash[0:2]}/{inhash[2:4]}/{inhash}{ext_map[service]}"

--- a/natlas-server/app/host/migrators.py
+++ b/natlas-server/app/host/migrators.py
@@ -2,15 +2,13 @@ import semver
 
 
 def determine_data_version(hostdata):  # type: ignore[no-untyped-def]
+    # 0.6.3 is our oldest host template set
+    fallupVer = semver.VersionInfo.parse("0.6.3")
     if "agent_version" in hostdata:
         ver = semver.VersionInfo.parse(hostdata["agent_version"])
-
-        # 0.6.3 is our oldest host template set
-        fallupVer = semver.VersionInfo.parse("0.6.3")
-
         # If agent_version is present and older than 0.6.3, "fall up" to 0.6.3 templates
         version = str(fallupVer) if ver < fallupVer else hostdata["agent_version"]
     else:
-        version = str(fallupVer)  # type: ignore[used-before-def]
+        version = str(fallupVer)
 
     return version

--- a/natlas-server/app/host/routes.py
+++ b/natlas-server/app/host/routes.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import werkzeug
 from flask import (
     Response,
     abort,
@@ -25,7 +26,7 @@ from app.models import RescanTask
 
 @bp.route("/<ip:ip>")
 @is_authenticated
-def host(ip):  # type: ignore[no-untyped-def]
+def host(ip: str) -> str:
     info, context = hostinfo(ip)
     delForm = DeleteForm()
     delHostForm = DeleteForm()
@@ -46,7 +47,7 @@ def host(ip):  # type: ignore[no-untyped-def]
 
 @bp.route("/<ip:ip>/history")
 @is_authenticated
-def host_history(ip):  # type: ignore[no-untyped-def]
+def host_history(ip: str) -> str:
     info, context = hostinfo(ip)
     page = int(request.args.get("p", 1))
     searchOffset = current_user.results_per_page * (page - 1)
@@ -83,7 +84,7 @@ def host_history(ip):  # type: ignore[no-untyped-def]
 
 @bp.route("/<ip:ip>/<scan_id>")
 @is_authenticated
-def host_historical_result(ip, scan_id):  # type: ignore[no-untyped-def]
+def host_historical_result(ip: str, scan_id: str) -> str:
     delForm = DeleteForm()
     delHostForm = DeleteForm()
     rescanForm = RescanForm()
@@ -105,9 +106,9 @@ def host_historical_result(ip, scan_id):  # type: ignore[no-untyped-def]
 
 @bp.route("/<ip:ip>/<scan_id>.<ext>")
 @is_authenticated
-def export_scan(ip, scan_id, ext):  # type: ignore[no-untyped-def]
+def export_scan(ip: str, scan_id: str, ext: str) -> Response:
     if ext not in ["xml", "nmap", "gnmap", "json"]:
-        return abort(404)
+        abort(404)
 
     export_field = f"{ext}_data"
 
@@ -117,12 +118,14 @@ def export_scan(ip, scan_id, ext):  # type: ignore[no-untyped-def]
         return jsonify(context)
     if count > 0 and export_field in context:
         return Response(context[export_field], mimetype=mime)
-    return abort(404)
+    abort(404)
+    # This return is unreachable but the RET503 linter doesn't understand that abort is a NoReturn apparently?
+    return None  # type: ignore[unreachable]
 
 
 @bp.route("/<ip:ip>/screenshots")
 @is_authenticated
-def host_screenshots(ip):  # type: ignore[no-untyped-def]
+def host_screenshots(ip: str) -> str:
     page = int(request.args.get("p", 1))
     searchOffset = current_user.results_per_page * (page - 1)
 
@@ -156,8 +159,8 @@ def host_screenshots(ip):  # type: ignore[no-untyped-def]
 
 
 @bp.route("/<ip:ip>/rescan", methods=["POST"])
-@login_required
-def rescan_host(ip):  # type: ignore[no-untyped-def]
+@login_required  # type: ignore[misc]
+def rescan_host(ip: str) -> werkzeug.wrappers.response.Response:
     rescanForm = RescanForm()
 
     if not (
@@ -200,7 +203,7 @@ def rescan_host(ip):  # type: ignore[no-untyped-def]
 
 @bp.route("/random")
 @is_authenticated
-def random_host():  # type: ignore[no-untyped-def]
+def random_host() -> str:
     random_host = current_app.elastic.random_host()  # type: ignore[attr-defined]
     # This would most likely occur when there are no hosts up in the index, so just throw a 404
     if not random_host:

--- a/natlas-server/app/host/summarizers.py
+++ b/natlas-server/app/host/summarizers.py
@@ -1,7 +1,7 @@
 from flask import abort, current_app
 
 
-def hostinfo(ip):  # type: ignore[no-untyped-def]
+def hostinfo(ip: str):  # type: ignore[no-untyped-def]
     hostinfo = {}
     count, context = current_app.elastic.get_host(ip)  # type: ignore[attr-defined]
     if count == 0:

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 import flask
 import sentry_sdk
+from config import Config
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
@@ -16,19 +17,19 @@ SERVICE_NAME = "natlas-server"
 template_span = threading.local()
 
 
-def render_template_end(*kargs, **kwargs):  # type: ignore[no-untyped-def]
+def render_template_end(*args: object, **kwargs: object) -> None:
     span = template_span.x
     template_span.x = None
     span.end()
 
 
-def render_template_start(app, template, context):  # type: ignore[no-untyped-def]
+def render_template_start(app: flask.Flask, template, context):  # type: ignore[no-untyped-def]
     tracer = trace.get_tracer(__name__)
     template_span.x = tracer.start_span(name="render_template")
     template_span.x.set_attribute("flask.template", template.name)
 
 
-def initialize_opentelemetry(config, flask_app):  # type: ignore[no-untyped-def]
+def initialize_opentelemetry(config: Config, flask_app: flask.Flask) -> None:
     if config.otel_enable:
         collector = config.otel_collector
         print(f"OpenTelemetry enabled and reporting to {collector} using gRPC")
@@ -39,13 +40,13 @@ def initialize_opentelemetry(config, flask_app):  # type: ignore[no-untyped-def]
         processor = BatchSpanProcessor(exporter)
         provider.add_span_processor(processor)
         trace.set_tracer_provider(provider)
-        flask_app.wsgi_app = SentryIoContextMiddleware(flask_app.wsgi_app)
+        flask_app.wsgi_app = SentryIoContextMiddleware(flask_app.wsgi_app)  # type: ignore[method-assign]
         FlaskInstrumentor().instrument_app(flask_app)
         flask.before_render_template.connect(render_template_start, flask_app)
         flask.template_rendered.connect(render_template_end, flask_app)
 
 
-def initialize_sentryio(config):  # type: ignore[no-untyped-def]
+def initialize_sentryio(config: Config) -> None:
     if config.sentry_dsn:
         url = urlparse(config.sentry_dsn)
         print(

--- a/natlas-server/app/main/pagination.py
+++ b/natlas-server/app/main/pagination.py
@@ -1,18 +1,22 @@
+from typing import Any
+
 from flask import url_for
 from flask_login import current_user
 
 
-def build_pagination_urls(route, page, count, **kargs):  # type: ignore[no-untyped-def]
+def build_pagination_urls(
+    route: str, page: int, count: int, **kwargs: Any
+) -> tuple[str | None, str | None]:
     next_url = (
-        url_for(route, page=page + 1, **kargs)
+        url_for(route, page=page + 1, **kwargs)
         if count > page * current_user.results_per_page
         else None
     )
-    prev_url = url_for(route, page=page - 1, **kargs) if page > 1 else None
+    prev_url = url_for(route, page=page - 1, **kwargs) if page > 1 else None
     return next_url, prev_url
 
 
-def results_offset(page):  # type: ignore[no-untyped-def]
-    results_per_page = current_user.results_per_page
+def results_offset(page: int) -> tuple[int, int]:
+    results_per_page: int = current_user.results_per_page
     search_offset = results_per_page * (page - 1)
     return results_per_page, search_offset

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -19,7 +19,7 @@ from app.main.pagination import build_pagination_urls, results_offset
 
 
 @bp.route("/")
-def index():  # type: ignore[no-untyped-def]
+def index() -> str:
     login_form = None
     reg_form = None
     if current_user.is_anonymous:
@@ -33,7 +33,7 @@ def index():  # type: ignore[no-untyped-def]
 # Serve media files in case the front-end proxy doesn't do it
 @bp.route("/media/<path:filename>")
 @is_authenticated
-def send_media(filename):  # type: ignore[no-untyped-def]
+def send_media(filename: str) -> Response:
     # If you're looking at this function, wondering why your files aren't sending...
     # It's probably because current_app.config['MEDIA_DIRECTORY'] isn't pointing to an absolute file path
     return send_from_directory(current_app.config["MEDIA_DIRECTORY"], filename)
@@ -41,7 +41,7 @@ def send_media(filename):  # type: ignore[no-untyped-def]
 
 @bp.route("/browse")
 @is_authenticated
-def browse():  # type: ignore[no-untyped-def]
+def browse() -> str:
     """
     A simple browser that doesn't deal with queries at all
     """
@@ -78,13 +78,13 @@ def browse():  # type: ignore[no-untyped-def]
 
 @bp.route("/search")
 @is_authenticated
-def search():  # type: ignore[no-untyped-def]
+def search() -> Response | str:
     """
     Return search results for a given query
     """
     query = request.args.get("query", "")
     if query == "":
-        return redirect(url_for("main.browse"))
+        return redirect(url_for("main.browse"))  # type: ignore[return-value]
     page = int(request.args.get("page", 1))
     format = request.args.get("format", "")
     scan_ids = request.args.get("includeScanIDs", "")
@@ -137,13 +137,13 @@ def search():  # type: ignore[no-untyped-def]
 
 @bp.route("/searchmodal")
 @is_authenticated
-def search_modal():  # type: ignore[no-untyped-def]
+def search_modal() -> str:
     return render_template("includes/search_modal_content.html")
 
 
 @bp.route("/screenshots")
 @is_authenticated
-def screenshots():  # type: ignore[no-untyped-def]
+def screenshots() -> str:
     page = int(request.args.get("page", 1))
 
     results_per_page, search_offset = results_offset(page)
@@ -166,7 +166,7 @@ def screenshots():  # type: ignore[no-untyped-def]
 
 @bp.route("/status")
 @is_authenticated
-def status():  # type: ignore[no-untyped-def]
+def status() -> str:
     """
     Simple html representation of the status api
     """

--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -1,6 +1,7 @@
 import secrets
 import string
 from datetime import datetime
+from typing import Optional
 
 from app import db
 from app.models.dict_serializable import DictSerializable
@@ -21,27 +22,27 @@ class Agent(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     # optional friendly name for viewing on user page
     friendly_name = db.Column(db.String(128), default="")
 
-    def verify_secret(self, secret):  # type: ignore[no-untyped-def]
+    def verify_secret(self, secret: str) -> bool:
         return secrets.compare_digest(secret, self.token)
 
     @staticmethod
-    def verify_agent(auth_header):  # type: ignore[no-untyped-def]
+    def verify_agent(auth_header: str) -> bool:
         auth_list = auth_header.split()
         if auth_list[0].lower() != "bearer":
             return False
         agent_id, agent_token = auth_list[1].split(":", 1)
         agent = Agent.load_agent(agent_id)
-        return bool(agent and agent.verify_secret(agent_token))
+        return bool(agent is not None and agent.verify_secret(agent_token))
 
     @staticmethod
-    def load_agent(agentid):  # type: ignore[no-untyped-def]
-        return Agent.query.filter_by(agentid=agentid).first()
+    def load_agent(agentid: str) -> Optional["Agent"]:
+        return Agent.query.filter_by(agentid=agentid).first()  # type: ignore[no-any-return]
 
     @staticmethod
-    def generate_token():  # type: ignore[no-untyped-def]
+    def generate_token() -> str:
         tokencharset = string.ascii_uppercase + string.ascii_lowercase + string.digits
         return "".join(secrets.choice(tokencharset) for _ in range(32))
 
     @staticmethod
-    def generate_agentid():  # type: ignore[no-untyped-def]
+    def generate_agentid() -> str:
         return generate_hex_16()

--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -12,5 +12,5 @@ class AgentScript(db.Model, DictSerializable):  # type: ignore[misc, name-define
     name = db.Column(db.String(128), index=True, unique=True)
 
     @staticmethod
-    def get_scripts_string():  # type: ignore[no-untyped-def]
+    def get_scripts_string() -> str:
         return ",".join(s.name for s in AgentScript.query.all())

--- a/natlas-server/app/models/dict_serializable.py
+++ b/natlas-server/app/models/dict_serializable.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class DictSerializable:
-    def as_dict(self):  # type: ignore[no-untyped-def]
+    def as_dict(self) -> dict[str, Any]:
         return {c.name: getattr(self, c.name) for c in self.__table__.columns}  # type: ignore[attr-defined]

--- a/natlas-server/app/models/natlas_services.py
+++ b/natlas-server/app/models/natlas_services.py
@@ -1,4 +1,5 @@
 import hashlib
+from typing import Any
 
 from app import db
 
@@ -15,11 +16,11 @@ class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
         self.sha256 = hashlib.sha256(self.services.encode()).hexdigest()
 
     @staticmethod
-    def get_latest_services():  # type: ignore[no-untyped-def]
-        return NatlasServices.query.order_by(NatlasServices.id.desc()).first().as_dict()
+    def get_latest_services() -> dict[str, str]:
+        return NatlasServices.query.order_by(NatlasServices.id.desc()).first().as_dict()  # type: ignore[no-any-return]
 
-    def hash_equals(self, hash):  # type: ignore[no-untyped-def]
-        return self.sha256 == hash
+    def hash_equals(self, hash: str) -> bool:
+        return self.sha256 == hash  # type: ignore[no-any-return]
 
     def services_as_list(self):  # type: ignore[no-untyped-def]
         servlist = []
@@ -36,7 +37,7 @@ class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
             idx += 1
         return servlist
 
-    def as_dict(self):  # type: ignore[no-untyped-def]
+    def as_dict(self) -> dict[str, Any]:
         servdict = {c.name: getattr(self, c.name) for c in self.__table__.columns}
         servdict["as_list"] = self.services_as_list()
         return servdict

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -20,34 +20,34 @@ class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined
     date_completed = db.Column(db.DateTime, index=True)
     scan_id = db.Column(db.String(256), index=True, unique=True)
 
-    def dispatchTask(self):  # type: ignore[no-untyped-def]
+    def dispatchTask(self) -> None:
         self.dispatched = True
         self.date_dispatched = datetime.utcnow()
 
-    def completeTask(self, scan_id):  # type: ignore[no-untyped-def]
+    def completeTask(self, scan_id: str) -> None:
         self.scan_id = scan_id
         self.complete = True
         self.date_completed = datetime.utcnow()
 
     @staticmethod
-    def getPendingTasks():  # type: ignore[no-untyped-def]
+    def getPendingTasks() -> list["RescanTask"]:
         # Tasks that haven't been completed and haven't been dispatched
-        return (
+        return (  # type: ignore[no-any-return]
             RescanTask.query.filter_by(complete=False).filter_by(dispatched=False).all()
         )
 
     @staticmethod
-    def getDispatchedTasks():  # type: ignore[no-untyped-def]
+    def getDispatchedTasks() -> list["RescanTask"]:
         # Tasks that have been dispatched but haven't been completed
-        return (
+        return (  # type: ignore[no-any-return]
             RescanTask.query.filter_by(dispatched=True).filter_by(complete=False).all()
         )
 
     @staticmethod
-    def getIncompleteTasks():  # type: ignore[no-untyped-def]
+    def getIncompleteTasks() -> list["RescanTask"]:
         # All tasks that haven't been marked as complete
-        return RescanTask.query.filter_by(complete=False).all()
+        return RescanTask.query.filter_by(complete=False).all()  # type: ignore[no-any-return]
 
     @staticmethod
-    def getIncompleteTaskForTarget(ip):  # type: ignore[no-untyped-def]
-        return RescanTask.query.filter_by(target=ip).filter_by(complete=False).all()
+    def getIncompleteTaskForTarget(ip: str) -> list["RescanTask"]:
+        return RescanTask.query.filter_by(target=ip).filter_by(complete=False).all()  # type: ignore[no-any-return]

--- a/natlas-server/app/models/scope_log.py
+++ b/natlas-server/app/models/scope_log.py
@@ -10,9 +10,9 @@ class ScopeLog(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     msg = db.Column(db.String(256))
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
-    def __init__(self, msg=None):  # type: ignore[no-untyped-def]
+    def __init__(self, msg: str | None = None) -> None:
         self.msg = msg
 
-    def __repr__(self):  # type: ignore[no-untyped-def]
+    def __repr__(self) -> str:
         timerepr = self.created_at.strftime("%Y-%m-%d-%H:%M:%S")
         return f"<Log: {timerepr} - {self.msg[:50]}>"

--- a/natlas-server/app/models/tag.py
+++ b/natlas-server/app/models/tag.py
@@ -8,7 +8,7 @@ class Tag(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     name = db.Column(db.String(128), index=True, unique=True, nullable=False)
 
     @staticmethod
-    def create_if_none(tag):  # type: ignore[no-untyped-def]
+    def create_if_none(tag: str) -> "Tag":
         """If tag exists, return it. If not, create it and return it."""
         tag = tag.strip()
         existingTag = Tag.query.filter_by(name=tag).first()
@@ -16,4 +16,4 @@ class Tag(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
             newTag = Tag(name=tag)
             db.session.add(newTag)
             return newTag
-        return existingTag
+        return existingTag  # type: ignore[no-any-return]

--- a/natlas-server/app/models/token_validation.py
+++ b/natlas-server/app/models/token_validation.py
@@ -1,14 +1,23 @@
 import secrets
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
-def default_validator():  # type: ignore[no-untyped-def]
+def default_validator() -> bool:
     # if no custom validator is supplied then just pass
     return True
 
 
-def validate_token(record, provided_token, stored_token, validator=default_validator):  # type: ignore[no-untyped-def]
+def validate_token(
+    record: T,
+    provided_token: str,
+    stored_token: str,
+    validator: Callable[[], bool] = default_validator,
+) -> T | None:
     if record and secrets.compare_digest(provided_token, stored_token) and validator():
         return record
     # still do a digest compare of equal sizes to resist timing attacks
     secrets.compare_digest(provided_token, "a" * len(provided_token))
-    return False
+    return None

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -1,13 +1,17 @@
 import secrets
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Literal, Optional
 
-from email_validator import EmailNotValidError, validate_email
+from email_validator import EmailNotValidError, ValidatedEmail, validate_email
 from flask_login import UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from app import db, login
 from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
+
+if TYPE_CHECKING:
+    from app.models.user_invitation import UserInvitation
 
 
 class User(UserMixin, db.Model, DictSerializable):  # type: ignore[misc, name-defined]
@@ -29,67 +33,71 @@ class User(UserMixin, db.Model, DictSerializable):  # type: ignore[misc, name-de
     expiration_duration = 60 * 60 * 24 * 2
     token_length = 32
 
-    def __repr__(self):  # type: ignore[no-untyped-def]
+    def __repr__(self) -> str:
         return f"<User {self.email}>"
 
     @staticmethod
-    def exists(email):  # type: ignore[no-untyped-def]
+    def exists(email: str) -> bool:
         return User.query.filter_by(email=email).first() is not None
 
     # https://github.com/JoshData/python-email-validator
     @staticmethod
-    def validate_email(email):  # type: ignore[no-untyped-def]
+    def validate_email(email: str) -> ValidatedEmail | Literal[False]:
         try:
             valid = validate_email(email)
             return valid["email"]
         except EmailNotValidError:
             return False
 
-    def set_password(self, password):  # type: ignore[no-untyped-def]
+    def set_password(self, password: str) -> None:
         self.password_hash = generate_password_hash(password)
 
-    def check_password(self, password):  # type: ignore[no-untyped-def]
+    def check_password(self, password: str) -> bool:
         return check_password_hash(self.password_hash, password)
 
-    @login.user_loader
-    def load_user(id):  # type: ignore[no-untyped-def]
-        return User.query.get(id)
+    @login.user_loader  # type: ignore[misc]
+    def load_user(id: int) -> "User":
+        return User.query.get(id)  # type: ignore[no-any-return]
 
-    def new_reset_token(self):  # type: ignore[no-untyped-def]
+    def new_reset_token(self) -> None:
         self.password_reset_token = secrets.token_urlsafe(User.token_length)
         self.password_reset_expiration = datetime.utcnow() + timedelta(
             seconds=User.expiration_duration
         )
 
-    def expire_reset_token(self):  # type: ignore[no-untyped-def]
+    def expire_reset_token(self) -> None:
         self.password_reset_token = None
         self.password_reset_expiration = None
 
-    def validate_reset_token(self):  # type: ignore[no-untyped-def]
+    def validate_reset_token(self) -> bool:
         if not (self.password_reset_token and self.password_reset_expiration):
             return False
-        return self.password_reset_expiration > datetime.utcnow()
+        return self.password_reset_expiration > datetime.utcnow()  # type: ignore[no-any-return]
 
     @staticmethod
-    def get_reset_token(email):  # type: ignore[no-untyped-def]
+    def get_reset_token(email: str) -> Optional["User"]:
         user = User.query.filter_by(email=email).first()
         if not user:
             return None
         if not user.validate_reset_token():
             user.new_reset_token()
-        return user
+        return user  # type: ignore[no-any-return]
 
     @staticmethod
-    def get_user_by_token(url_token):  # type: ignore[no-untyped-def]
-        record = User.query.filter_by(password_reset_token=url_token).first()
+    def get_user_by_token(url_token: str) -> Optional["User"]:
+        record: User | None = User.query.filter_by(
+            password_reset_token=url_token
+        ).first()
         if not record:
-            return False
+            return None
         return validate_token(
             record, url_token, record.password_reset_token, record.validate_reset_token
         )
 
     @staticmethod
-    def new_user_from_invite(invite, password, email=None):  # type: ignore[no-untyped-def]
+    def new_user_from_invite(
+        invite: "UserInvitation", password: str, email: str | None = None
+    ) -> "User":
         user_email = email if email else invite.email
         new_user = User(email=user_email, is_admin=invite.is_admin, is_active=True)
         new_user.set_password(password)

--- a/natlas-server/app/scope/scan_group.py
+++ b/natlas-server/app/scope/scan_group.py
@@ -43,13 +43,13 @@ class ScanGroup:
             return 0
         return self.scan_manager.rng.completed_cycle_count  # type: ignore[unreachable]
 
-    def update(self):  # type: ignore[no-untyped-def]
+    def update(self) -> None:
         self.scope.update()
         self.blacklist.update()
         self.update_scan_manager()
         self.effective_size = (self.scope.set - self.blacklist.set).size
 
-    def update_scan_manager(self):  # type: ignore[no-untyped-def]
+    def update_scan_manager(self) -> None:
         try:
             self.scan_manager = IPScanManager(  # type: ignore[assignment]
                 self.scope.set,

--- a/natlas-server/app/scope/scan_manager.py
+++ b/natlas-server/app/scope/scan_manager.py
@@ -5,8 +5,8 @@ from netaddr import IPSet
 class IPScanManager:
     networks = None  # type: ignore[var-annotated]
     total = 0
-    rng = None  # type: ignore[var-annotated]
-    consistent = None  # type: ignore[var-annotated]
+    rng: CyclicPRNG | None = None
+    consistent: bool = False
 
     def __init__(self, whitelist: IPSet, blacklist: IPSet, consistent: bool):
         self.networks = []
@@ -17,7 +17,7 @@ class IPScanManager:
         self.blacklist = blacklist
         self.initialize_manager()
 
-    def log_to_db(self, message: str):  # type: ignore[no-untyped-def]
+    def log_to_db(self, message: str) -> None:
         from app import db
         from app.models import ScopeLog
 
@@ -30,7 +30,7 @@ class IPScanManager:
         db.session.add(db_log)
         db.session.commit()
 
-    def initialize_manager(self):  # type: ignore[no-untyped-def]
+    def initialize_manager(self) -> None:
         self.networks = []
         self.ipset = self.whitelist - self.blacklist
 
@@ -49,10 +49,7 @@ class IPScanManager:
             self.total, consistent=self.consistent, event_handler=self.log_to_db
         )
 
-        def blockcomp(b):  # type: ignore[no-untyped-def]
-            return b["start"]
-
-        self.networks.sort(key=blockcomp)
+        self.networks.sort(key=lambda b: b["start"])
 
         start = 1
         for i in range(0, len(self.networks)):
@@ -61,11 +58,11 @@ class IPScanManager:
 
         self.initialized = True
 
-    def get_total(self):  # type: ignore[no-untyped-def]
+    def get_total(self) -> int:
         return self.total
 
-    def get_ready(self):  # type: ignore[no-untyped-def]
-        return self.rng and self.total > 0 and self.initialized
+    def get_ready(self) -> bool:
+        return bool(self.rng and self.total > 0 and self.initialized)
 
     def get_next_ip(self):  # type: ignore[no-untyped-def]
         if self.rng:
@@ -73,7 +70,7 @@ class IPScanManager:
             return self.get_ip(index)
         return None
 
-    def get_ip(self, index):  # type: ignore[no-untyped-def]
+    def get_ip(self, index: int):  # type: ignore[no-untyped-def]
         def binarysearch(networks, i):  # type: ignore[no-untyped-def]
             middle = int(len(networks) / 2)
             network = networks[middle]

--- a/natlas-server/app/scope/scope_collection.py
+++ b/natlas-server/app/scope/scope_collection.py
@@ -10,10 +10,10 @@ class ScopeCollection:
         scope_source: A callable that returns a collection of ScopeItem
         """
         self.scope_source = scope_source
-        self.list = []  # type: ignore[var-annotated]
+        self.list: list[IPNetwork] = []
         self.set = IPSet()
 
-    def update(self):  # type: ignore[no-untyped-def]
+    def update(self) -> None:
         self.list = [IPNetwork(item.target, False) for item in self.scope_source()]  # type: ignore[misc]
         self.set = IPSet(self.list)
         self.size = self.set.size

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from flask import current_app
 from netaddr import IPAddress
@@ -6,6 +7,9 @@ from netaddr.core import AddrFormatError
 
 from app.scope.scan_group import ScanGroup
 from app.scope.scan_manager import IPScanManager
+
+if TYPE_CHECKING:
+    from app.models.rescan_task import RescanTask
 
 
 class ScopeManager:
@@ -15,9 +19,9 @@ class ScopeManager:
     effective_size = 0
     default_group = "all"
 
-    def __init__(self):  # type: ignore[no-untyped-def]
-        self.pendingRescans = []
-        self.dispatchedRescans = []
+    def __init__(self) -> None:
+        self.pendingRescans: list[RescanTask] = []
+        self.dispatchedRescans: list[RescanTask] = []
 
     def init_app(self, app):  # type: ignore[no-untyped-def]
         app.ScopeManager = self
@@ -31,7 +35,7 @@ class ScopeManager:
             }
         self.init_time = datetime.utcnow()
 
-    def load_all_groups(self):  # type: ignore[no-untyped-def]
+    def load_all_groups(self) -> None:
         """
         Used at initialization to update all scan groups with their database values
         """
@@ -62,7 +66,7 @@ class ScopeManager:
     def get_completed_cycle_count(self, group: str = default_group) -> int:
         return self.scopes[group].get_completed_cycle_count()  # type: ignore[index, no-any-return]
 
-    def update(self, group: str = default_group):  # type: ignore[no-untyped-def]
+    def update(self, group: str = default_group) -> None:
         self.scopes.get(group).update()  # type: ignore[union-attr]
         current_app.logger.info(f"{datetime.utcnow()!s} - ScopeManager Updated\n")
 
@@ -81,13 +85,13 @@ class ScopeManager:
             and target in self.scopes[group].scope.set  # type: ignore[index]
         )
 
-    def get_pending_rescans(self) -> list:  # type: ignore[type-arg]
+    def get_pending_rescans(self) -> list["RescanTask"]:
         return self.pendingRescans
 
-    def get_dispatched_rescans(self) -> list:  # type: ignore[type-arg]
+    def get_dispatched_rescans(self) -> list["RescanTask"]:
         return self.dispatchedRescans
 
-    def get_incomplete_scans(self) -> list:  # type: ignore[type-arg]
+    def get_incomplete_scans(self) -> list["RescanTask"]:
         if self.pendingRescans == [] or self.dispatchedRescans == []:
             from app.models import RescanTask
 
@@ -95,12 +99,12 @@ class ScopeManager:
             self.dispatchedRescans = RescanTask.getDispatchedTasks()
         return self.pendingRescans + self.dispatchedRescans
 
-    def update_dispatched_rescans(self):  # type: ignore[no-untyped-def]
+    def update_dispatched_rescans(self) -> None:
         from app.models import RescanTask
 
         self.dispatchedRescans = RescanTask.getDispatchedTasks()
 
-    def update_pending_rescans(self):  # type: ignore[no-untyped-def]
+    def update_pending_rescans(self) -> None:
         from app.models import RescanTask
 
         self.pendingRescans = RescanTask.getPendingTasks()

--- a/natlas-server/app/url_converters.py
+++ b/natlas-server/app/url_converters.py
@@ -11,13 +11,13 @@ class NatlasConverter(BaseConverter):
 class IPConverter(NatlasConverter):
     name = "ip"
 
-    def to_python(self, value):  # type: ignore[no-untyped-def]
+    def to_python(self, value: object) -> str:
         try:
             return str(IPAddress(value))
         except AddrFormatError as e:
             raise ValidationError from e
 
 
-def register_converters(app: Flask) -> dict:  # type: ignore[return, type-arg]
+def register_converters(app: Flask) -> None:
     for converter in NatlasConverter.__subclasses__():
         app.url_map.converters[converter.name] = converter  # type: ignore[attr-defined]

--- a/natlas-server/app/user/forms.py
+++ b/natlas-server/app/user/forms.py
@@ -14,7 +14,7 @@ class ChangePasswordForm(FlaskForm):  # type: ignore[misc]
     )
     changePassword = SubmitField("Change Password")
 
-    def validate_old_password(self, old_password):  # type: ignore[no-untyped-def]
+    def validate_old_password(self, old_password: PasswordField) -> None:
         user = User.query.get(current_user.id)
         if user is None:
             raise ValidationError("You're not logged in!")
@@ -39,6 +39,6 @@ class AgentNameForm(FlaskForm):  # type: ignore[misc]
     agent_name = StringField("New Agent Name", validators=[DataRequired()])
     change_name = SubmitField("Change Name")
 
-    def validate_agent_name(self, agent_name):  # type: ignore[no-untyped-def]
+    def validate_agent_name(self, agent_name: StringField) -> None:
         if len(agent_name.data) > 32:
             raise ValidationError("Name must be less than 32 characters")

--- a/natlas-server/app/user/routes.py
+++ b/natlas-server/app/user/routes.py
@@ -76,9 +76,9 @@ def generate_new_token(agent_id):  # type: ignore[no-untyped-def]
 
     if generateTokenForm.validate_on_submit():
         myAgent = Agent.load_agent(agent_id)
-        myAgent.token = Agent.generate_token()
+        myAgent.token = Agent.generate_token()  # type: ignore[union-attr]
         db.session.commit()
-        flash(f"Agent {myAgent.agentid} has a new key of: {myAgent.token}", "success")
+        flash(f"Agent {myAgent.agentid} has a new key of: {myAgent.token}", "success")  # type: ignore[union-attr]
     else:
         flash("Couldn't generate new token", "danger")
     return redirect(url_for("user.profile"))
@@ -91,11 +91,12 @@ def change_agent_name(agent_id):  # type: ignore[no-untyped-def]
 
     if agentNameForm.validate_on_submit():
         myAgent = Agent.load_agent(agent_id)
-        oldname = myAgent.friendly_name
-        myAgent.friendly_name = agentNameForm.agent_name.data
+        oldname = myAgent.friendly_name  # type: ignore[union-attr]
+        myAgent.friendly_name = agentNameForm.agent_name.data  # type: ignore[union-attr]
         db.session.commit()
         flash(
-            f"Agent name changed from {oldname} to {myAgent.friendly_name}", "success"
+            f"Agent name changed from {oldname} to {myAgent.friendly_name}",  # type: ignore[union-attr]
+            "success",
         )
     else:
         flash("Couldn't change agent name", "danger")

--- a/natlas-server/app/util.py
+++ b/natlas-server/app/util.py
@@ -1,22 +1,22 @@
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 
-def utcnow_tz():  # type: ignore[no-untyped-def]
+def utcnow_tz() -> datetime:
     return datetime.now(UTC)
 
 
-def generate_hex_16():  # type: ignore[no-untyped-def]
+def generate_hex_16() -> str:
     # 8 bytes converted to two hex digits each
     return secrets.token_hex(8)
 
 
-def generate_hex_32():  # type: ignore[no-untyped-def]
+def generate_hex_32() -> str:
     # 16 bytes converted to two hex digits each
     return secrets.token_hex(16)
 
 
-def pretty_time_delta(delta):  # type: ignore[no-untyped-def]
+def pretty_time_delta(delta: timedelta) -> str:
     hours, seconds = divmod(delta.seconds, 3600)
     minutes, seconds = divmod(seconds, 60)
     daystr = (str(delta.days) + "d, ") if delta.days else ""


### PR DESCRIPTION
Now that I have mypy hooked up (its not in CI yet, but I promise I'll get there), it's time to start tackling some of the type ignores, starting with my favorite - `no-untyped-def` - and expanding out from there.

Count of type ignores in `natlas-server` before this change, broken down by type:

```
➜ mypy-count
    296 no-untyped-def
    112 attr-defined
     48 union-attr
     31 misc
     19 type-arg
     15 var-annotated
     11 name-defined
     10 no-any-return
      8 operator
      7 arg-type
      4 index
      3 unreachable
      3 possibly-undefined
      3 assignment
      2 valid-type
      2 call-arg
      1 used-before-def
      1 truthy-bool
      1 return-value
➜ mypy-summary
577
```

Count of type ignores in `natlas-server` after this change, broken down by type:

```
➜ mypy-count 
    163 no-untyped-def
    112 attr-defined
     41 misc
     29 no-any-return
     21 union-attr
     12 return-value
     11 name-defined
      9 type-arg
      8 operator
      8 arg-type
      4 var-annotated
      4 unreachable
      4 index
      3 possibly-undefined
      2 valid-type
      2 call-arg
      2 assignment
      1 truthy-bool
      1 method-assign
➜ mypy-summary
437
```


This felt like a lot more work than 140 fixes. But alas, such is the game of mypy whack-a-mole.