### PR TITLE
Begin migrating to new sqlalchemy syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,6 @@ services:
       - OTEL_ENABLE=True
       - OTEL_COLLECTOR=otel:4317
       - DB_AUTO_UPGRADE=True
-      - SQLALCHEMY_DATABASE_URI=postgresql+psycopg://natlas:natlas-dev-password-do-not-use@postgres:5432/natlas
     volumes:
       - ns-data:/data
       - ./natlas-server:/opt/natlas/natlas-server

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -82,7 +82,7 @@ def reset_password_request():  # type: ignore[no-untyped-def]
             return redirect(url_for("auth.reset_password_request"))
         user = User.get_reset_token(validemail)
         if user:
-            deliver_auth_link(user.email, user.password_reset_token, "reset")
+            deliver_auth_link(user.email, user.password_reset_token, "reset")  # type: ignore[arg-type]
         db.session.commit()
         flash("Check your email for the instructions to reset your password", "info")
         return redirect(url_for("auth.login"))

--- a/natlas-server/app/cli/user.py
+++ b/natlas-server/app/cli/user.py
@@ -72,6 +72,6 @@ def reset_password(email):  # type: ignore[no-untyped-def]
     user = User.get_reset_token(email)
     if not user:
         raise click.BadParameter(err_msgs["no_such_user"].format(email))
-    msg = deliver_auth_link(user.email, user.password_reset_token, "reset")
+    msg = deliver_auth_link(user.email, user.password_reset_token, "reset")  # type: ignore[arg-type]
     db.session.commit()
     print(msg)

--- a/natlas-server/app/config_loader.py
+++ b/natlas-server/app/config_loader.py
@@ -9,7 +9,7 @@ def load_natlas_config(app, db):  # type: ignore[no-untyped-def]
 
     from app.models import ConfigItem
 
-    for item in ConfigItem.query.all():
+    for item in db.session.execute(db.select(ConfigItem)).scalars().all():
         app.config[item.name] = config.casted_value(item.type, item.value)
 
 

--- a/natlas-server/app/instrumentation/__init__.py
+++ b/natlas-server/app/instrumentation/__init__.py
@@ -30,8 +30,8 @@ def render_template_start(app: flask.Flask, template, context):  # type: ignore[
 
 
 def initialize_opentelemetry(config: Config, flask_app: flask.Flask) -> None:
-    if config.otel_enable:
-        collector = config.otel_collector
+    if config.OTEL_ENABLE:
+        collector = config.OTEL_COLLECTOR
         print(f"OpenTelemetry enabled and reporting to {collector} using gRPC")
         exporter = OTLPSpanExporter(endpoint=collector, insecure=True)
         provider = TracerProvider(
@@ -47,15 +47,15 @@ def initialize_opentelemetry(config: Config, flask_app: flask.Flask) -> None:
 
 
 def initialize_sentryio(config: Config) -> None:
-    if config.sentry_dsn:
-        url = urlparse(config.sentry_dsn)
+    if config.SENTRY_DSN:
+        url = urlparse(config.SENTRY_DSN)
         print(
             f"Sentry.io enabled and reporting errors to {url.scheme}://{url.hostname}"
         )
         from sentry_sdk.integrations.flask import FlaskIntegration
 
         sentry_sdk.init(
-            dsn=config.sentry_dsn,
+            dsn=config.SENTRY_DSN,
             release=config.NATLAS_VERSION,
             integrations=[FlaskIntegration()],
         )

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -18,7 +18,7 @@ class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined
     date_dispatched = db.Column(db.DateTime, index=True)
     complete = db.Column(db.Boolean, default=False, index=True)
     date_completed = db.Column(db.DateTime, index=True)
-    scan_id = db.Column(db.String(256), index=True, unique=True)
+    scan_id = db.Column(db.String(128), index=True, unique=True)
 
     def dispatchTask(self) -> None:
         self.dispatched = True

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -28,8 +28,8 @@ class ScopeItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
         lazy=True,
     )
     addr_family = db.Column(db.Integer)
-    start_addr = db.Column(db.VARBINARY(16))
-    stop_addr = db.Column(db.VARBINARY(16))
+    start_addr = db.Column(db.LargeBinary(16))
+    stop_addr = db.Column(db.LargeBinary(16))
 
     def __init__(self, target: str, blacklist: bool) -> None:
         self.target = target

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -54,10 +54,10 @@ class Config(BaseSettings):
 
     CONSISTENT_SCAN_CYCLE: bool = Field(default=False)
 
-    sentry_dsn: str | None = Field(default=None)
+    SENTRY_DSN: str | None = Field(default=None)
     SENTRY_JS_DSN: str | None = Field(default=None)
-    otel_enable: bool = Field(default=False)
-    otel_collector: str = Field(default="127.0.0.1:4317")
+    OTEL_ENABLE: bool = Field(default=False)
+    OTEL_COLLECTOR: str = Field(default="127.0.0.1:4317")
 
     version_override: str | None = Field(default=None)
     TESTING: bool = Field(default=False)

--- a/natlas-server/tests/models/test_user.py
+++ b/natlas-server/tests/models/test_user.py
@@ -35,7 +35,7 @@ def test_reset_token():  # type: ignore[no-untyped-def]
     assert not user.validate_reset_token()
     assert User.get_reset_token(email)
     assert user.validate_reset_token()
-    assert User.get_user_by_token(user.password_reset_token)
+    assert User.get_user_by_token(user.password_reset_token)  # type: ignore[arg-type]
     user.expire_reset_token()
     assert not user.validate_reset_token()
     assert not User.get_reset_token("notoken@example.com")


### PR DESCRIPTION
1. Postgres is giving me some problems, in part because old migrations use VARBINARY which postgres doesn't support. Turns out I should have been using LargeBinary not VARBINARY.
2. I want to start migrating towards better type-hinted models, which means using the newer Sqlalchemy 2.0 syntax. The User file changes result in no migration for the User table, which means that it's identical. This also highlights an important thing I noticed, which is that almost every column on almost every table is nullable, which wasn't really intended. But I'll tackle that another time, this is meant to be functionally equivalent.
3. The nullable-ness of nearly every database field is going to lead to a lot of arg-type ignores for a while, as seen here.