### PR TITLE
Complete migration to new sqlalchemy syntax

### DIFF
--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -3,6 +3,9 @@ import string
 from datetime import datetime
 from typing import Optional
 
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models.dict_serializable import DictSerializable
 from app.util import generate_hex_16
@@ -12,18 +15,15 @@ from app.util import generate_hex_16
 # Users can have many agents, each agent has an ID and a secret (token)
 # Friendly name is purely for identification of agents in the management page
 class Agent(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    # agent identification string for storing in reports
-    agentid = db.Column(db.String(128), index=True, unique=True, nullable=False)
-    date_created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    # auth token
-    token = db.Column(db.String(128), index=True, unique=True)
-    # optional friendly name for viewing on user page
-    friendly_name = db.Column(db.String(128), default="")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
+    agentid: Mapped[str] = mapped_column(String(128), index=True, unique=True)
+    date_created: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    token: Mapped[str | None] = mapped_column(String(128), index=True, unique=True)
+    friendly_name: Mapped[str | None] = mapped_column(String(128), default="")
 
     def verify_secret(self, secret: str) -> bool:
-        return secrets.compare_digest(secret, self.token)
+        return secrets.compare_digest(secret, self.token)  # type: ignore[type-var]
 
     @staticmethod
     def verify_agent(auth_header: str) -> bool:

--- a/natlas-server/app/models/agent_config.py
+++ b/natlas-server/app/models/agent_config.py
@@ -1,35 +1,42 @@
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models.dict_serializable import DictSerializable
 
 
 class AgentConfig(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    versionDetection = db.Column(
-        db.Boolean, default=True
+    id: Mapped[int] = mapped_column(primary_key=True)
+    versionDetection: Mapped[bool | None] = mapped_column(
+        default=True
     )  # Enable Version Detection (-sV)
-    osDetection = db.Column(db.Boolean, default=True)  # Enable OS Detection (-O)
-    enableScripts = db.Column(
-        db.Boolean, default=True
+    osDetection: Mapped[bool | None] = mapped_column(
+        default=True
+    )  # Enable OS Detection (-O)
+    enableScripts: Mapped[bool | None] = mapped_column(
+        default=True
     )  # Enable Nmap Scripting Engine (loads all AgentScripts)
-    onlyOpens = db.Column(db.Boolean, default=True)  # Only report open ports (--open)
-    scanTimeout = db.Column(
-        db.Integer, default=660
+    onlyOpens: Mapped[bool | None] = mapped_column(
+        default=True
+    )  # Only report open ports (--open)
+    scanTimeout: Mapped[int | None] = mapped_column(
+        default=60
     )  # SIGKILL nmap if it's running longer than this
-    webScreenshots = db.Column(
-        db.Boolean, default=True
+    webScreenshots: Mapped[bool | None] = mapped_column(
+        default=True
     )  # Attempt to take web screenshots (aquatone)
-    vncScreenshots = db.Column(
-        db.Boolean, default=True
+    vncScreenshots: Mapped[bool | None] = mapped_column(
+        default=True
     )  # Attempt to take VNC screenshots (xvfb+vncsnapshot)
-    webScreenshotTimeout = db.Column(
-        db.Integer, default=60
+    webScreenshotTimeout: Mapped[int | None] = mapped_column(
+        default=60
     )  # aquatone process timeout in seconds
-    vncScreenshotTimeout = db.Column(
-        db.Integer, default=60
+    vncScreenshotTimeout: Mapped[int | None] = mapped_column(
+        default=60
     )  # vnc process timeout in seconds
-
-    scriptTimeout = db.Column(db.Integer, default=60)  # --script-timeout (s)
-    hostTimeout = db.Column(db.Integer, default=600)  # --host-timeout (s)
-    osScanLimit = db.Column(db.Boolean, default=True)  # --osscan-limit
-    noPing = db.Column(db.Boolean, default=False)  # -Pn
-    udpScan = db.Column(db.Boolean, default=False)  # -sSU
+    scriptTimeout: Mapped[int | None] = mapped_column(
+        default=60
+    )  # --script-timeout (s)
+    hostTimeout: Mapped[int | None] = mapped_column(default=600)  # --host-timeout (s)
+    osScanLimit: Mapped[bool | None] = mapped_column(default=True)  # --osscan-limit
+    noPing: Mapped[bool | None] = mapped_column(default=False)  # -Pn
+    udpScan: Mapped[bool | None] = mapped_column(default=False)  # -sSU

--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -1,3 +1,6 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models.dict_serializable import DictSerializable
 
@@ -8,8 +11,8 @@ from app.models.dict_serializable import DictSerializable
 # auth, broadcast, default, discovery, dos, exploit, external, fuzzer, intrusive, malware, safe, version, vuln
 # https://nmap.org/book/nse-usage.html#nse-categories
 class AgentScript(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(128), index=True, unique=True)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str | None] = mapped_column(String(128), index=True, unique=True)
 
     @staticmethod
     def get_scripts_string() -> str:

--- a/natlas-server/app/models/config_item.py
+++ b/natlas-server/app/models/config_item.py
@@ -1,3 +1,6 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models.dict_serializable import DictSerializable
 
@@ -6,7 +9,7 @@ from app.models.dict_serializable import DictSerializable
 # This uses a generic key,value style schema so that we can avoid changing the model for every new feature
 # Default config options are defined in natlas-server/config.py
 class ConfigItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(256), unique=True)
-    type = db.Column(db.String(256))
-    value = db.Column(db.String(256))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str | None] = mapped_column(String(256), unique=True)
+    type: Mapped[str | None] = mapped_column(String(256))
+    value: Mapped[str | None] = mapped_column(String(256))

--- a/natlas-server/app/models/natlas_services.py
+++ b/natlas-server/app/models/natlas_services.py
@@ -1,31 +1,34 @@
 import hashlib
 from typing import Any
 
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 
 
 # While generally I prefer to use a singular model name, each record here is going to be storing a set of services
 # Each record in this table is a complete nmap-services db
 class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    sha256 = db.Column(db.String(64))
-    services = db.Column(db.Text)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    sha256: Mapped[str | None] = mapped_column(String(64))
+    services: Mapped[str | None] = mapped_column(Text)
 
     def __init__(self, services):  # type: ignore[no-untyped-def]
         self.services = services
-        self.sha256 = hashlib.sha256(self.services.encode()).hexdigest()
+        self.sha256 = hashlib.sha256(self.services.encode()).hexdigest()  # type: ignore[union-attr]
 
     @staticmethod
     def get_latest_services() -> dict[str, str]:
         return NatlasServices.query.order_by(NatlasServices.id.desc()).first().as_dict()  # type: ignore[no-any-return]
 
     def hash_equals(self, hash: str) -> bool:
-        return self.sha256 == hash  # type: ignore[no-any-return]
+        return self.sha256 == hash
 
     def services_as_list(self):  # type: ignore[no-untyped-def]
         servlist = []
         idx = 1
-        for line in self.services.splitlines():
+        for line in self.services.splitlines():  # type: ignore[union-attr]
             # any empty newlines will be skipped, or comment lines (for uploaded files)
             if line == "" or line.startswith("#"):
                 continue

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -1,24 +1,29 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app import db
 from app.models.dict_serializable import DictSerializable
+
+if TYPE_CHECKING:
+    pass
 
 
 # Rescan Queue
 # Each record represents a user-requested rescan of a given target.
 # Tracks when it was dispatched, when it was completed, and the scan id of the complete scan.
 class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    date_added = db.Column(
-        db.DateTime, index=True, default=datetime.utcnow, nullable=False
-    )
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
-    target = db.Column(db.String(128), index=True, nullable=False)
-    dispatched = db.Column(db.Boolean, default=False, index=True)
-    date_dispatched = db.Column(db.DateTime, index=True)
-    complete = db.Column(db.Boolean, default=False, index=True)
-    date_completed = db.Column(db.DateTime, index=True)
-    scan_id = db.Column(db.String(128), index=True, unique=True)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    date_added: Mapped[datetime] = mapped_column(index=True, default=datetime.utcnow())
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), nullable=False)
+    target: Mapped[str] = mapped_column(String(128), index=True)
+    dispatched: Mapped[bool | None] = mapped_column(default=False, index=True)
+    date_dispatched: Mapped[datetime | None] = mapped_column(index=True)
+    complete: Mapped[bool | None] = mapped_column(default=False, index=True)
+    date_completed: Mapped[datetime | None] = mapped_column(index=True)
+    scan_id: Mapped[str | None] = mapped_column(String(128), index=True, unique=True)
 
     def dispatchTask(self) -> None:
         self.dispatched = True

--- a/natlas-server/app/models/scope_log.py
+++ b/natlas-server/app/models/scope_log.py
@@ -1,18 +1,23 @@
 from datetime import datetime
 
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models.dict_serializable import DictSerializable
 
 
 # Basic Logging for Scope related events
 class ScopeLog(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    msg = db.Column(db.String(256))
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    __tablename__ = "scope_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    msg: Mapped[str | None] = mapped_column(String(256))
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
 
     def __init__(self, msg: str | None = None) -> None:
         self.msg = msg
 
     def __repr__(self) -> str:
         timerepr = self.created_at.strftime("%Y-%m-%d-%H:%M:%S")
-        return f"<Log: {timerepr} - {self.msg[:50]}>"
+        return f"<Log: {timerepr} - {self.msg[:50]}>"  # type: ignore[index]

--- a/natlas-server/app/models/tag.py
+++ b/natlas-server/app/models/tag.py
@@ -1,11 +1,14 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models.dict_serializable import DictSerializable
 
 
 # Simple tags that can be added to scope items for automatic tagging
 class Tag(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(128), index=True, unique=True, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), index=True, unique=True)
 
     @staticmethod
     def create_if_none(tag: str) -> "Tag":

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -101,8 +101,8 @@ class User(UserMixin, NatlasBase, DictSerializable):  # type: ignore[misc]
         return validate_token(
             record,
             url_token,
-            record.password_reset_token,
-            record.validate_reset_token,  # type: ignore[arg-type]
+            record.password_reset_token,  # type: ignore[arg-type]
+            record.validate_reset_token,
         )
 
     @staticmethod

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -2,6 +2,9 @@ import secrets
 from datetime import datetime, timedelta
 from typing import Optional
 
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
 from app import db
 from app.models import User
 from app.models.dict_serializable import DictSerializable
@@ -9,15 +12,18 @@ from app.models.token_validation import validate_token
 
 
 class UserInvitation(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
-    id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(254), unique=True)
-    token = db.Column(db.String(256), unique=True, nullable=False)
-    creation_date = db.Column(db.DateTime, default=datetime.utcnow)
-    expiration_date = db.Column(db.DateTime, nullable=False)
-    accepted_date = db.Column(db.DateTime)
-    is_expired = db.Column(db.Boolean, default=False)
-    # is_admin should really only be used for bootstrapping users with add-user.py
-    is_admin = db.Column(db.Boolean, default=False)
+    __tablename__ = "user_invitation"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str | None] = mapped_column(String(254), unique=True)
+    token: Mapped[str] = mapped_column(String(256), unique=True)
+    creation_date: Mapped[datetime | None] = mapped_column(
+        DateTime, default=datetime.utcnow
+    )
+    expiration_date: Mapped[datetime]
+    accepted_date: Mapped[datetime | None]
+    is_expired: Mapped[bool | None] = mapped_column(default=False)
+    is_admin: Mapped[bool | None] = mapped_column(default=False)
 
     # Tokens expire after 48 hours or upon use
     expiration_duration = 60 * 60 * 24 * 2

--- a/natlas-server/tests/models/test_scope.py
+++ b/natlas-server/tests/models/test_scope.py
@@ -19,7 +19,7 @@ def test_add_tags(app):  # type: ignore[no-untyped-def]
     test_scope = ScopeItem(target="127.0.0.1/8", blacklist=False)
     db.session.add(test_scope)
     ScopeItem.addTags(test_scope, tags)
-    for tag in test_scope.tags:  # type: ignore[attr-defined]
+    for tag in test_scope.tags:
         assert test_scope.is_tagged(tag)
 
 
@@ -28,9 +28,9 @@ def test_del_tags(app):  # type: ignore[no-untyped-def]
     test_scope = ScopeItem(target="127.0.0.1/8", blacklist=False)
     db.session.add(test_scope)
     ScopeItem.addTags(test_scope, tags)
-    assert len([t.name for t in test_scope.tags]) == 3  # type: ignore[attr-defined]
-    test_scope.delTag(test_scope.tags[2])  # type: ignore[index]
-    assert len([t.name for t in test_scope.tags]) == 2  # type: ignore[attr-defined]
+    assert len([t.name for t in test_scope.tags]) == 3
+    test_scope.delTag(test_scope.tags[2])
+    assert len([t.name for t in test_scope.tags]) == 2
 
 
 def test_get_scope(app):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
This finishes the migration to the sqlalchemy2 Mapped syntax for model definition. It also captures the type ignores needed for mypy to pass (which highlights several theoretical bugs), as well as removes some unused ignores now that more types are in place.