### PR TITLE
Add tablename consistently across models

### DIFF
--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -15,6 +15,8 @@ from app.util import generate_hex_16
 # Users can have many agents, each agent has an ID and a secret (token)
 # Friendly name is purely for identification of agents in the management page
 class Agent(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+    __tablename__ = "agent"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
     agentid: Mapped[str] = mapped_column(String(128), index=True, unique=True)

--- a/natlas-server/app/models/agent_config.py
+++ b/natlas-server/app/models/agent_config.py
@@ -5,6 +5,8 @@ from app.models.dict_serializable import DictSerializable
 
 
 class AgentConfig(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+    __tablename__ = "agent_config"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     versionDetection: Mapped[bool | None] = mapped_column(
         default=True

--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -11,6 +11,8 @@ from app.models.dict_serializable import DictSerializable
 # auth, broadcast, default, discovery, dos, exploit, external, fuzzer, intrusive, malware, safe, version, vuln
 # https://nmap.org/book/nse-usage.html#nse-categories
 class AgentScript(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+    __tablename__ = "agent_script"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str | None] = mapped_column(String(128), index=True, unique=True)
 

--- a/natlas-server/app/models/config_item.py
+++ b/natlas-server/app/models/config_item.py
@@ -9,6 +9,8 @@ from app.models.dict_serializable import DictSerializable
 # This uses a generic key,value style schema so that we can avoid changing the model for every new feature
 # Default config options are defined in natlas-server/config.py
 class ConfigItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+    __tablename__ = "config_item"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str | None] = mapped_column(String(256), unique=True)
     type: Mapped[str | None] = mapped_column(String(256))

--- a/natlas-server/app/models/natlas_services.py
+++ b/natlas-server/app/models/natlas_services.py
@@ -10,6 +10,8 @@ from app import db
 # While generally I prefer to use a singular model name, each record here is going to be storing a set of services
 # Each record in this table is a complete nmap-services db
 class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
+    __tablename__ = "natlas_services"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     sha256: Mapped[str | None] = mapped_column(String(64))
     services: Mapped[str | None] = mapped_column(Text)

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 # Each record represents a user-requested rescan of a given target.
 # Tracks when it was dispatched, when it was completed, and the scan id of the complete scan.
 class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+    __tablename__ = "rescan_task"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     date_added: Mapped[datetime] = mapped_column(index=True, default=datetime.utcnow())
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), nullable=False)

--- a/natlas-server/app/models/scope_item.py
+++ b/natlas-server/app/models/scope_item.py
@@ -20,6 +20,7 @@ scopetags = db.Table(
 
 class ScopeItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     __tablename__ = "scope_item"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     target: Mapped[str | None] = mapped_column(String(128), index=True, unique=True)
     blacklist: Mapped[bool | None] = mapped_column(index=True)


### PR DESCRIPTION
I forgot to explicitly declare the tablename everywhere. This is important because (1) implicit tablenames make it harder to rename a model, (2) flask-sqlalchemy-lite will no longer generate the tablenames for me when I eventually switch to that.