### PR TITLE
Fix the User model

### DIFF
--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -8,7 +8,7 @@ from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from app import NatlasBase, db, login
+from app import db, login
 from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from app.models.user_invitation import UserInvitation
 
 
-class User(UserMixin, NatlasBase, DictSerializable):  # type: ignore[misc]
+class User(UserMixin, db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     __tablename__ = "user"
 
     id: Mapped[int] = mapped_column(primary_key=True)


### PR DESCRIPTION
Idk how I didn't notice this, but switching to NatlasBase doesn't work until after I update all the query syntax, since the whole app relies on `Model.query` syntax, which isn't available once a model moves off of `db.Model` as the base class.