### PR TITLE
Switch a few model queries, add more type hinting

### DIFF
--- a/natlas-server/app/admin/redirects.py
+++ b/natlas-server/app/admin/redirects.py
@@ -1,7 +1,8 @@
 from flask import redirect, url_for
+from werkzeug.wrappers.response import Response
 
 
-def get_scope_redirect(type):  # type: ignore[no-untyped-def]
+def get_scope_redirect(type: str) -> Response:
     redirects = {
         "scope": url_for("admin.scope"),
         "blacklist": url_for("admin.blacklist"),

--- a/natlas-server/app/models/tag.py
+++ b/natlas-server/app/models/tag.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String
+from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app import db
@@ -14,9 +14,9 @@ class Tag(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
     def create_if_none(tag: str) -> "Tag":
         """If tag exists, return it. If not, create it and return it."""
         tag = tag.strip()
-        existingTag = Tag.query.filter_by(name=tag).first()
+        existingTag = db.session.scalars(select(Tag).filter_by(name=tag)).first()
         if not existingTag:
             newTag = Tag(name=tag)
             db.session.add(newTag)
             return newTag
-        return existingTag  # type: ignore[no-any-return]
+        return existingTag


### PR DESCRIPTION
This change conflates two processes, but it was hard to do just one or the other.

1. Starts to update query building syntax to the new SQLAlchemy 2.0 syntax. This enables type information for anything that relies on database models, which is most of the application, so it's going to be super helpful.
2. Because of the new type information available, I have to add a bunch of ignores anyways (technically I have to fix a bunch of bugs, but right now it's add a bunch of ignores). So when I was updating call sites for the models, I went ahead and also updated a bunch of type ignores in those files.