### PR TITLE
No more legacy query interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.12
 
 default_stages:
   - pre-commit

--- a/natlas-server/app/api/rescan_handler.py
+++ b/natlas-server/app/api/rescan_handler.py
@@ -7,6 +7,11 @@ from app import db
 if TYPE_CHECKING:
     from app.models.rescan_task import RescanTask
 
+"""
+TODO: Yeah this whole thing is probably broken. I'm amazed it ever worked.
+I think previously it would automatically rebind objects to the current session.
+"""
+
 
 def mark_scan_dispatched(rescan: "RescanTask") -> None:
     rescan.dispatchTask()

--- a/natlas-server/app/auth/forms.py
+++ b/natlas-server/app/auth/forms.py
@@ -1,7 +1,9 @@
 from flask_wtf import FlaskForm
+from sqlalchemy import select
 from wtforms import BooleanField, PasswordField, StringField, SubmitField
 from wtforms.validators import DataRequired, Email, EqualTo, Length, ValidationError
 
+from app import db
 from app.models import User
 
 
@@ -21,7 +23,9 @@ class RegistrationForm(FlaskForm):  # type: ignore[misc]
     submit = SubmitField("Register")
 
     def validate_email(self, email):  # type: ignore[no-untyped-def]
-        user = User.query.filter_by(email=email.data.lower()).first()
+        user = db.session.scalars(
+            select(User).where(User.email == email.data.lower())
+        ).first()
         if user is not None:
             raise ValidationError("Email already exists!")
 

--- a/natlas-server/app/auth/routes.py
+++ b/natlas-server/app/auth/routes.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 
 from flask import current_app, flash, redirect, render_template, request, url_for
 from flask_login import login_user, logout_user
+from sqlalchemy import select
 from werkzeug.wrappers.response import Response
 
 from app import db
@@ -23,7 +24,9 @@ from app.models import User, UserInvitation
 def login():  # type: ignore[no-untyped-def]
     form = LoginForm(prefix="login")
     if form.validate_on_submit():
-        user = User.query.filter_by(email=User.validate_email(form.email.data)).first()
+        user = db.session.scalars(
+            select(User).where(User.email == User.validate_email(form.email.data))
+        ).first()
         if user is None or not user.check_password(form.password.data):
             flash("Invalid email or password", "danger")
             return redirect(url_for("auth.login"))

--- a/natlas-server/app/cli/user.py
+++ b/natlas-server/app/cli/user.py
@@ -1,6 +1,7 @@
 import click
 from flask import current_app
 from flask.cli import AppGroup
+from sqlalchemy import select
 
 from app import db
 from app.auth.email import deliver_auth_link
@@ -17,7 +18,7 @@ err_msgs = {
 
 
 def get_user(email):  # type: ignore[no-untyped-def]
-    user = User.query.filter_by(email=email).first()
+    user = db.session.scalars(select(User).where(User.email == email)).first()
     if not user:
         raise click.BadParameter(err_msgs["no_such_user"].format(email))
     return user

--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -3,7 +3,7 @@ import string
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import ForeignKey, String
+from sqlalchemy import ForeignKey, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app import db
@@ -38,7 +38,7 @@ class Agent(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
 
     @staticmethod
     def load_agent(agentid: str) -> Optional["Agent"]:
-        return Agent.query.filter_by(agentid=agentid).first()  # type: ignore[no-any-return]
+        return db.session.scalars(select(Agent).where(Agent.agentid == agentid)).first()
 
     @staticmethod
     def generate_token() -> str:

--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String
+from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app import db
@@ -18,4 +18,4 @@ class AgentScript(db.Model, DictSerializable):  # type: ignore[misc, name-define
 
     @staticmethod
     def get_scripts_string() -> str:
-        return ",".join(s.name for s in AgentScript.query.all())
+        return ",".join(s.name for s in db.session.scalars(select(AgentScript)).all())  # type: ignore[misc]

--- a/natlas-server/app/models/natlas_services.py
+++ b/natlas-server/app/models/natlas_services.py
@@ -1,7 +1,7 @@
 import hashlib
 from typing import Any
 
-from sqlalchemy import String, Text
+from sqlalchemy import String, Text, select
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app import db
@@ -22,7 +22,13 @@ class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
 
     @staticmethod
     def get_latest_services() -> dict[str, str]:
-        return NatlasServices.query.order_by(NatlasServices.id.desc()).first().as_dict()  # type: ignore[no-any-return]
+        return (
+            db.session.scalars(  # type: ignore[union-attr]
+                select(NatlasServices).order_by(NatlasServices.id.desc())
+            )
+            .first()
+            .as_dict()
+        )
 
     def hash_equals(self, hash: str) -> bool:
         return self.sha256 == hash

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -20,6 +20,9 @@ class ScopeManager:
     default_group = "all"
 
     def __init__(self) -> None:
+        # TODO: This is currently broken, its storing references to models that are bound in other sessions
+        # I think it was designed to avoid having to constantly the database when handing out work
+        # This won't work with multi-node deployments anyways so this needs to be revisited. But it's borked.
         self.pendingRescans: list[RescanTask] = []
         self.dispatchedRescans: list[RescanTask] = []
 

--- a/natlas-server/app/user/forms.py
+++ b/natlas-server/app/user/forms.py
@@ -3,6 +3,7 @@ from flask_wtf import FlaskForm
 from wtforms import PasswordField, SelectField, StringField, SubmitField
 from wtforms.validators import DataRequired, EqualTo, Length, ValidationError
 
+from app import db
 from app.models import User
 
 
@@ -15,7 +16,7 @@ class ChangePasswordForm(FlaskForm):  # type: ignore[misc]
     changePassword = SubmitField("Change Password")
 
     def validate_old_password(self, old_password: PasswordField) -> None:
-        user = User.query.get(current_user.id)
+        user = db.session.get(User, current_user.id)
         if user is None:
             raise ValidationError("You're not logged in!")
         if not user.check_password(old_password.data):

--- a/natlas-server/app/user/routes.py
+++ b/natlas-server/app/user/routes.py
@@ -44,18 +44,18 @@ def profile():  # type: ignore[no-untyped-def]
         changePasswordForm.changePassword.data
         and changePasswordForm.validate_on_submit()
     ):
-        user = User.query.get(current_user.id)
-        user.set_password(changePasswordForm.password.data)
+        user = db.session.get(User, current_user.id)
+        user.set_password(changePasswordForm.password.data)  # type: ignore[union-attr]
         db.session.commit()
         flash("Your password has been changed.", "success")
     elif (
         displaySettingsForm.updateDisplaySettings.data
         and displaySettingsForm.validate_on_submit()
     ):
-        user = User.query.get(current_user.id)
-        user.results_per_page = displaySettingsForm.results_per_page.data
-        user.preview_length = displaySettingsForm.preview_length.data
-        user.result_format = displaySettingsForm.result_format.data
+        user = db.session.get(User, current_user.id)
+        user.results_per_page = displaySettingsForm.results_per_page.data  # type: ignore[union-attr]
+        user.preview_length = displaySettingsForm.preview_length.data  # type: ignore[union-attr]
+        user.result_format = displaySettingsForm.result_format.data  # type: ignore[union-attr]
         db.session.commit()
         flash("Display settings updated.", "success")
 

--- a/natlas-server/tests/models/test_scope.py
+++ b/natlas-server/tests/models/test_scope.py
@@ -1,5 +1,6 @@
 from app import db
 from app.models import ScopeItem
+from sqlalchemy import select
 
 
 def test_new_scope(app):  # type: ignore[no-untyped-def]
@@ -58,10 +59,14 @@ def test_import_scope(app):  # type: ignore[no-untyped-def]
     assert len(result["fail"]) == 1
     assert result["exist"] == 1
     assert result["success"] == 5
-    item = ScopeItem.query.filter_by(target="127.0.0.1/32").first()
-    tags = [t.name for t in item.tags]
+    item = db.session.scalars(
+        select(ScopeItem).where(ScopeItem.target == "127.0.0.1/32")
+    ).first()
+    tags = [t.name for t in item.tags]  # type: ignore[union-attr]
     assert len(tags) == 3
     assert "one" in tags
     assert "four" not in tags
-    item = ScopeItem.query.filter_by(target="10.12.13.14/32").first()
-    assert len(item.tags) == 0
+    item = db.session.scalars(
+        select(ScopeItem).where(ScopeItem.target == "10.12.13.14/32")
+    ).first()
+    assert len(item.tags) == 0  # type: ignore[union-attr]


### PR DESCRIPTION
This removes all the remaining legacy query interface call sites. Every query to the database is now done via the 2.0 ORM query syntax.

This has either led to or uncovered a bug with rescan task references being stored in a list in the ScopeManager, then later trying to modify those references and commit them in a session different than the one that they are bound to. This means that rescans are broken right now.

It also uncovered a ton of new `union-attr` issues, places where something could be None and I didn't know. This is related to nearly every column being nullable in the database. I've mostly just marked these as ignored for now, since the best solution will likely be to make the columns not nullable if they weren't meant to be nullable in the first placec.