### PR TITLE
Update all models to NatlasBase instead of the dynamic db.Model

### DIFF
--- a/natlas-server/app/models/agent.py
+++ b/natlas-server/app/models/agent.py
@@ -6,7 +6,7 @@ from typing import Optional
 from sqlalchemy import ForeignKey, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase, db
 from app.models.dict_serializable import DictSerializable
 from app.util import generate_hex_16
 
@@ -14,7 +14,7 @@ from app.util import generate_hex_16
 # Agent registration
 # Users can have many agents, each agent has an ID and a secret (token)
 # Friendly name is purely for identification of agents in the management page
-class Agent(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class Agent(NatlasBase, DictSerializable):
     __tablename__ = "agent"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/agent_config.py
+++ b/natlas-server/app/models/agent_config.py
@@ -1,10 +1,10 @@
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase
 from app.models.dict_serializable import DictSerializable
 
 
-class AgentConfig(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class AgentConfig(NatlasBase, DictSerializable):
     __tablename__ = "agent_config"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -1,7 +1,7 @@
 from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase, db
 from app.models.dict_serializable import DictSerializable
 
 
@@ -10,7 +10,7 @@ from app.models.dict_serializable import DictSerializable
 # groups of scripts are also accepted, such as "safe" and "default"
 # auth, broadcast, default, discovery, dos, exploit, external, fuzzer, intrusive, malware, safe, version, vuln
 # https://nmap.org/book/nse-usage.html#nse-categories
-class AgentScript(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class AgentScript(NatlasBase, DictSerializable):
     __tablename__ = "agent_script"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/config_item.py
+++ b/natlas-server/app/models/config_item.py
@@ -1,14 +1,14 @@
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase
 from app.models.dict_serializable import DictSerializable
 
 
 # Server configuration options
 # This uses a generic key,value style schema so that we can avoid changing the model for every new feature
 # Default config options are defined in natlas-server/config.py
-class ConfigItem(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class ConfigItem(NatlasBase, DictSerializable):
     __tablename__ = "config_item"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/natlas_services.py
+++ b/natlas-server/app/models/natlas_services.py
@@ -4,12 +4,12 @@ from typing import Any
 from sqlalchemy import String, Text, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase, db
 
 
 # While generally I prefer to use a singular model name, each record here is going to be storing a set of services
 # Each record in this table is a complete nmap-services db
-class NatlasServices(db.Model):  # type: ignore[misc, name-defined]
+class NatlasServices(NatlasBase):
     __tablename__ = "natlas_services"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/rescan_task.py
+++ b/natlas-server/app/models/rescan_task.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import ForeignKey, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase, db
 from app.models.dict_serializable import DictSerializable
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 # Rescan Queue
 # Each record represents a user-requested rescan of a given target.
 # Tracks when it was dispatched, when it was completed, and the scan id of the complete scan.
-class RescanTask(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class RescanTask(NatlasBase, DictSerializable):
     __tablename__ = "rescan_task"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/scope_log.py
+++ b/natlas-server/app/models/scope_log.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase
 from app.models.dict_serializable import DictSerializable
 
 
 # Basic Logging for Scope related events
-class ScopeLog(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class ScopeLog(NatlasBase, DictSerializable):
     __tablename__ = "scope_log"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/tag.py
+++ b/natlas-server/app/models/tag.py
@@ -1,12 +1,14 @@
 from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase, db
 from app.models.dict_serializable import DictSerializable
 
 
 # Simple tags that can be added to scope items for automatic tagging
-class Tag(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class Tag(NatlasBase, DictSerializable):
+    __tablename__ = "tag"
+
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(128), index=True, unique=True)
 

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -8,7 +8,7 @@ from sqlalchemy import String, select
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from app import db, login
+from app import NatlasBase, db, login
 from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from app.models.user_invitation import UserInvitation
 
 
-class User(UserMixin, db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class User(UserMixin, NatlasBase, DictSerializable):  # type: ignore[misc]
     __tablename__ = "user"
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/natlas-server/app/models/user_invitation.py
+++ b/natlas-server/app/models/user_invitation.py
@@ -5,13 +5,13 @@ from typing import Optional
 from sqlalchemy import DateTime, String, select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app import db
+from app import NatlasBase, db
 from app.models import User
 from app.models.dict_serializable import DictSerializable
 from app.models.token_validation import validate_token
 
 
-class UserInvitation(db.Model, DictSerializable):  # type: ignore[misc, name-defined]
+class UserInvitation(NatlasBase, DictSerializable):
     __tablename__ = "user_invitation"
 
     id: Mapped[int] = mapped_column(primary_key=True)


### PR DESCRIPTION
This replaces all the existing `db.Model` occurrences with NatlasBase, the base for all models in Natlas.

It also removes a bunch of associated type ignores and creates a TypedDict for the ScopeItem import results, since that was also getting in my way now that I had replaced the `db.Model` base class.