### PR TITLE
Access scope_manager instance rather than current_app.scope_manager

### DIFF
--- a/natlas-server/app/api/rescan_handler.py
+++ b/natlas-server/app/api/rescan_handler.py
@@ -1,8 +1,6 @@
 from typing import TYPE_CHECKING
 
-from flask import current_app
-
-from app import db
+from app import db, scope_manager
 
 if TYPE_CHECKING:
     from app.models.rescan_task import RescanTask
@@ -17,17 +15,17 @@ def mark_scan_dispatched(rescan: "RescanTask") -> None:
     rescan.dispatchTask()
     db.session.add(rescan)
     db.session.commit()
-    current_app.scope_manager.update_pending_rescans()  # type: ignore[attr-defined]
-    current_app.scope_manager.update_dispatched_rescans()  # type: ignore[attr-defined]
+    scope_manager.update_pending_rescans()
+    scope_manager.update_dispatched_rescans()
 
 
 def mark_scan_completed(ip, scan_id) -> bool:  # type: ignore[no-untyped-def]
-    dispatched = current_app.scope_manager.get_dispatched_rescans()  # type: ignore[attr-defined]
+    dispatched = scope_manager.get_dispatched_rescans()
     for scan in dispatched:
         if scan.target == ip:
             scan.completeTask(scan_id)
             db.session.add(scan)
             db.session.commit()
-            current_app.scope_manager.update_dispatched_rescans()  # type: ignore[attr-defined]
+            scope_manager.update_dispatched_rescans()
             return True
     return False

--- a/natlas-server/app/api/rescan_handler.py
+++ b/natlas-server/app/api/rescan_handler.py
@@ -19,7 +19,6 @@ def mark_scan_dispatched(rescan: "RescanTask") -> None:
     scope_manager.update_dispatched_rescans()
 
 
-
 def mark_scan_completed(ip: str, scan_id: str) -> bool:
     dispatched = scope_manager.get_dispatched_rescans()
     for scan in dispatched:

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -6,6 +6,7 @@ import dateutil.parser
 from flask import Response, current_app, jsonify, request
 from libnmap.parser import NmapParser, NmapParserException
 
+from app import scope_manager
 from app.api import bp
 from app.api.prepare_work import prepare_work
 from app.api.processing.screenshot import process_screenshots
@@ -34,7 +35,7 @@ def getwork() -> Response:
     work = {}
 
     if manual:
-        canTarget = current_app.scope_manager.is_acceptable_target(manual)  # type: ignore[attr-defined]
+        canTarget = scope_manager.is_acceptable_target(manual)
         if canTarget:
             work["scan_reason"] = "manual"
             work["target"] = manual
@@ -52,15 +53,15 @@ def getwork() -> Response:
             )
         return response
 
-    rescans = current_app.scope_manager.get_pending_rescans()  # type: ignore[attr-defined]
+    rescans = scope_manager.get_pending_rescans()
     if (
         len(rescans) == 0
     ):  # If there aren't any rescans, update the Rescan Queue and get it again, because of lazy loading
-        current_app.scope_manager.update_pending_rescans()  # type: ignore[attr-defined]
-        rescans = current_app.scope_manager.get_pending_rescans()  # type: ignore[attr-defined]
+        scope_manager.update_pending_rescans()
+        rescans = scope_manager.get_pending_rescans()
 
     if len(rescans) == 0:  # if we don't have rescans, use the ScanManager
-        scanmanager = current_app.scope_manager.get_scan_manager()  # type: ignore[attr-defined]
+        scanmanager = scope_manager.get_scan_manager()
 
         if not scanmanager:
             response_body = json.dumps(
@@ -113,9 +114,7 @@ def submit() -> Response:
             )
 
         # If it's not an acceptable target, tell the agent it's out of scope
-        elif len(
-            nmap.hosts
-        ) == 1 and not current_app.scope_manager.is_acceptable_target(  # type: ignore[attr-defined]
+        elif len(nmap.hosts) == 1 and not scope_manager.is_acceptable_target(
             nmap.hosts[0].address
         ):
             status_code = 400
@@ -238,24 +237,22 @@ def natlasServices() -> Response:
 @bp.route("/status", methods=["GET"])
 @is_authenticated
 def status() -> Response:
-    last_cycle_start = current_app.scope_manager.get_last_cycle_start()  # type: ignore[attr-defined]
-    completed_cycles = current_app.scope_manager.get_completed_cycle_count()  # type: ignore[attr-defined]
+    last_cycle_start = scope_manager.get_last_cycle_start()
+    completed_cycles = scope_manager.get_completed_cycle_count()
     avg_cycle_time = None
     if last_cycle_start:
         scans_this_cycle = current_app.elastic.count_scans_since(last_cycle_start)  # type: ignore[attr-defined]
-        if completed_cycles > 0:
-            delta = (
-                last_cycle_start - current_app.scope_manager.init_time  # type: ignore[attr-defined]
-            ) / completed_cycles
+        if completed_cycles > 0 and scope_manager.init_time is not None:
+            delta = (last_cycle_start - scope_manager.init_time) / completed_cycles
             avg_cycle_time = pretty_time_delta(delta)
     else:
         scans_this_cycle = 0
     payload = {
-        "natlas_start_time": current_app.scope_manager.init_time,  # type: ignore[attr-defined]
+        "natlas_start_time": scope_manager.init_time,
         "cycle_start_time": last_cycle_start,
         "completed_cycles": completed_cycles,
         "scans_this_cycle": scans_this_cycle,
-        "effective_scope_size": current_app.scope_manager.get_effective_scope_size(),  # type: ignore[attr-defined]
+        "effective_scope_size": scope_manager.get_effective_scope_size(),
         "avg_cycle_duration": avg_cycle_time,
     }
     return jsonify(payload)

--- a/natlas-server/app/scope/scope_manager.py
+++ b/natlas-server/app/scope/scope_manager.py
@@ -60,10 +60,10 @@ class ScopeManager:
     def get_blacklist(self, group: str = default_group) -> list:  # type: ignore[type-arg]
         return self.scopes[group].blacklist.list  # type: ignore[index, no-any-return]
 
-    def get_scan_manager(self, group: str = default_group) -> IPScanManager:
+    def get_scan_manager(self, group: str = default_group) -> IPScanManager | None:
         return self.scopes.get(group).get_scan_manager()  # type: ignore[no-any-return, union-attr]
 
-    def get_last_cycle_start(self, group: str = default_group) -> datetime:
+    def get_last_cycle_start(self, group: str = default_group) -> datetime | None:
         return self.scopes[group].get_last_cycle_start()  # type: ignore[index, no-any-return]
 
     def get_completed_cycle_count(self, group: str = default_group) -> int:

--- a/natlas-server/tests/scope/test_scope_manager.py
+++ b/natlas-server/tests/scope/test_scope_manager.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 
-from app import db
+from app import db, scope_manager
 from app.models import RescanTask, ScopeItem, User
 from app.scope import ScopeManager
-from flask import current_app
 
 network_lengths = {"/0": 4294967296, "/8": 16777216, "/16": 65536, "/24": 256, "/32": 1}
 
@@ -22,9 +21,9 @@ def test_scope_update(app):  # type: ignore[no-untyped-def]
     for s in scope_items:
         item = ScopeItem(target=s, blacklist=False)
         db.session.add(item)
-    current_app.scope_manager.update()  # type: ignore[attr-defined]
-    assert current_app.scope_manager.get_scope_size() == network_lengths["/8"]  # type: ignore[attr-defined]
-    assert current_app.scope_manager.is_acceptable_target("10.1.2.3")  # type: ignore[attr-defined]
+    scope_manager.update()
+    assert scope_manager.get_scope_size() == network_lengths["/8"]
+    assert scope_manager.is_acceptable_target("10.1.2.3")
 
 
 def test_blacklist_update(app):  # type: ignore[no-untyped-def]
@@ -36,15 +35,15 @@ def test_blacklist_update(app):  # type: ignore[no-untyped-def]
     for s in blacklist_items:
         item = ScopeItem(target=s, blacklist=True)
         db.session.add(item)
-    current_app.scope_manager.update()  # type: ignore[attr-defined]
-    assert current_app.scope_manager.get_blacklist_size() == network_lengths["/24"]  # type: ignore[attr-defined]
-    assert current_app.scope_manager.get_scope_size() == network_lengths["/8"]  # type: ignore[attr-defined]
+    scope_manager.update()
+    assert scope_manager.get_blacklist_size() == network_lengths["/24"]
+    assert scope_manager.get_scope_size() == network_lengths["/8"]
     assert (
-        current_app.scope_manager.get_effective_scope_size()  # type: ignore[attr-defined]
+        scope_manager.get_effective_scope_size()
         == network_lengths["/8"] - network_lengths["/24"]
     )
-    assert current_app.scope_manager.is_acceptable_target("10.10.11.1")  # type: ignore[attr-defined]
-    assert not current_app.scope_manager.is_acceptable_target("10.10.10.10")  # type: ignore[attr-defined]
+    assert scope_manager.is_acceptable_target("10.10.11.1")
+    assert not scope_manager.is_acceptable_target("10.10.10.10")
 
 
 def test_acceptable_targets(app):  # type: ignore[no-untyped-def]
@@ -56,13 +55,13 @@ def test_acceptable_targets(app):  # type: ignore[no-untyped-def]
     for s in blacklist_items:
         item = ScopeItem(target=s, blacklist=True)
         db.session.add(item)
-    current_app.scope_manager.update()  # type: ignore[attr-defined]
-    assert current_app.scope_manager.is_acceptable_target("192.168.0.123")  # type: ignore[attr-defined]
-    assert current_app.scope_manager.is_acceptable_target("192.168.2.2")  # type: ignore[attr-defined]
-    assert not current_app.scope_manager.is_acceptable_target("192.168.1.234")  # type: ignore[attr-defined]
-    assert not current_app.scope_manager.is_acceptable_target("192.168.2.1")  # type: ignore[attr-defined]
-    assert not current_app.scope_manager.is_acceptable_target("192.0.2.34")  # type: ignore[attr-defined]
-    assert not current_app.scope_manager.is_acceptable_target("example.com")  # type: ignore[attr-defined]
+    scope_manager.update()
+    assert scope_manager.is_acceptable_target("192.168.0.123")
+    assert scope_manager.is_acceptable_target("192.168.2.2")
+    assert not scope_manager.is_acceptable_target("192.168.1.234")
+    assert not scope_manager.is_acceptable_target("192.168.2.1")
+    assert not scope_manager.is_acceptable_target("192.0.2.34")
+    assert not scope_manager.is_acceptable_target("example.com")
 
 
 def test_rescan_lifecycle(app):  # type: ignore[no-untyped-def]
@@ -72,26 +71,26 @@ def test_rescan_lifecycle(app):  # type: ignore[no-untyped-def]
     for s in scope_items:
         item = ScopeItem(target=s, blacklist=False)
         db.session.add(item)
-    current_app.scope_manager.update()  # type: ignore[attr-defined]
-    assert current_app.scope_manager.get_pending_rescans() == []  # type: ignore[attr-defined]
-    assert current_app.scope_manager.get_dispatched_rescans() == []  # type: ignore[attr-defined]
-    assert current_app.scope_manager.get_incomplete_scans() == []  # type: ignore[attr-defined]
+    scope_manager.update()
+    assert scope_manager.get_pending_rescans() == []
+    assert scope_manager.get_dispatched_rescans() == []
+    assert scope_manager.get_incomplete_scans() == []
     r = RescanTask(target="192.168.123.45", user_id=user.id)
     db.session.add(r)
-    current_app.scope_manager.update_pending_rescans()  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_pending_rescans()) == 1  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_incomplete_scans()) == 1  # type: ignore[attr-defined]
+    scope_manager.update_pending_rescans()
+    assert len(scope_manager.get_pending_rescans()) == 1
+    assert len(scope_manager.get_incomplete_scans()) == 1
     r.dispatchTask()
     db.session.add(r)
-    current_app.scope_manager.update_pending_rescans()  # type: ignore[attr-defined]
-    current_app.scope_manager.update_dispatched_rescans()  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_pending_rescans()) == 0  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_dispatched_rescans()) == 1  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_incomplete_scans()) == 1  # type: ignore[attr-defined]
+    scope_manager.update_pending_rescans()
+    scope_manager.update_dispatched_rescans()
+    assert len(scope_manager.get_pending_rescans()) == 0
+    assert len(scope_manager.get_dispatched_rescans()) == 1
+    assert len(scope_manager.get_incomplete_scans()) == 1
     r.completeTask("testscanid")
     db.session.add(r)
-    current_app.scope_manager.update_pending_rescans()  # type: ignore[attr-defined]
-    current_app.scope_manager.update_dispatched_rescans()  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_pending_rescans()) == 0  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_dispatched_rescans()) == 0  # type: ignore[attr-defined]
-    assert len(current_app.scope_manager.get_incomplete_scans()) == 0  # type: ignore[attr-defined]
+    scope_manager.update_pending_rescans()
+    scope_manager.update_dispatched_rescans()
+    assert len(scope_manager.get_pending_rescans()) == 0
+    assert len(scope_manager.get_dispatched_rescans()) == 0
+    assert len(scope_manager.get_incomplete_scans()) == 0


### PR DESCRIPTION
Replace scope_manager access pattern with the db, mail, login, etc access patterns.