### PR TITLE
BREAKING: Postgres only going forward

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,11 +108,12 @@ services:
       - ELASTIC_AUTH_ENABLE=True
       - ELASTIC_USER=elastic
       - ELASTIC_PASSWORD=natlas-dev-password-do-not-use
+      - SQLALCHEMY_DATABASE_URI=postgresql+psycopg://natlas:natlas-dev-password-do-not-use@postgres/natlas
       - S3_ENDPOINT=minio:9000
       - S3_USE_TLS=0
       - S3_BUCKET=natlas-screenshots
       - FLASK_ENV=development
-      - OTEL_ENABLE=True
+      - OTEL_ENABLE=False
       - OTEL_COLLECTOR=otel:4317
       - DB_AUTO_UPGRADE=True
     env_file: .env
@@ -129,6 +130,8 @@ services:
         condition: service_healthy
       elastic:
         condition: service_healthy
+      postgres:
+        condition: service_started
 
 
   agent:

--- a/natlas-server/Dockerfile
+++ b/natlas-server/Dockerfile
@@ -10,8 +10,7 @@ RUN yarn run webpack --mode production
 
 FROM python:3.12 AS build
 
-COPY Pipfile .
-COPY Pipfile.lock .
+COPY Pipfile Pipfile.lock ./
 
 RUN pip install pipenv
 RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy \
@@ -28,21 +27,19 @@ RUN python3 -m compileall .
 # Build final image
 FROM python:3.12-slim
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends libmariadb3 \
-    && rm -rf /var/cache/* /root /var/lib/apt/info/* /var/lib/apt/lists/* /var/lib/ghc /var/lib/dpkg /var/lib/log/*
+RUN rm -rf /var/cache/* /root /var/lib/apt/info/* /var/lib/apt/lists/* /var/lib/ghc /var/lib/dpkg /var/lib/log/* \
+    && adduser --disabled-password --no-create-home --gecos "" --disabled-login docker
 
 COPY --from=build /.venv /.venv
 COPY --from=build /opt/natlas /opt/natlas
 
 WORKDIR /opt/natlas/natlas-server/
-VOLUME ["/data"]
-ENV FLASK_APP=./natlas-server.py
-ENV FLASK_ENV=production
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-ENV PATH="/.venv/bin:$PATH"
+ENV FLASK_APP=./natlas-server.py \
+    FLASK_ENV=production \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PATH="/.venv/bin:$PATH"
 EXPOSE 5000
-ENTRYPOINT ["/bin/bash", "entrypoint.sh"]
+USER docker
 
 CMD ["gunicorn", "-b", "0.0.0.0:5000", "natlas-server:app"]

--- a/natlas-server/README.md
+++ b/natlas-server/README.md
@@ -110,8 +110,7 @@ Environment configs are loaded from the environment or a `.env` file and require
 | Variable | Default | Explanation |
 |---|---|---|
 | `SECRET_KEY` | Randomly generated | Used for CSRF tokens and sessions. You should generate a unique value for this in `.env`, otherwise sessions will be invalidated whenever the app restarts. |
-| `DATA_DIR` | `/data` | Path to store any data that should be persisted. Sqlite database, any log files, and media files all go in subdirectories of this directory. |
-| `SQLALCHEMY_DATABASE_URI` | `sqlite:///$DATA_DIR/db/metadata.db` | A [SQLALCHEMY URI](https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/) that points to the database to store natlas metadata in. Supported types by natlas-server are: `sqlite:`, `mysql:` |
+| `SQLALCHEMY_DATABASE_URI` | `postgres+psycopg://user:pass@host/db` | A [SQLALCHEMY URI](https://flask-sqlalchemy.palletsprojects.com/en/2.x/config/) that points to the Postgres database to store natlas metadata in. Supported types by natlas-server are: `postgres+psycopg://` |
 | `DB_AUTO_UPGRADE` | `False` | Automatically perform necessary data migrations when upgrading to a new version of natlas. Not recommended for multi-node deployments. |
 | `ELASTICSEARCH_URL` | `http://localhost:9200` | A URL that points to the elasticsearch cluster to store natlas scan data in |
 | `ELASTIC_AUTH_ENABLE` | `False` | Whether authentication is enabled on the elasticsearch cluster |

--- a/natlas-server/app/models/user.py
+++ b/natlas-server/app/models/user.py
@@ -23,7 +23,7 @@ class User(UserMixin, NatlasBase, DictSerializable):  # type: ignore[misc]
 
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str | None] = mapped_column(String(254), index=True, unique=True)
-    password_hash: Mapped[str | None] = mapped_column(String(128))
+    password_hash: Mapped[str | None] = mapped_column(String(256))
     is_admin: Mapped[bool | None] = mapped_column(default=False)
     results_per_page: Mapped[int | None] = mapped_column(default=100)
     preview_length: Mapped[int | None] = mapped_column(default=100)

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -47,13 +47,14 @@ class S3Settings(BaseSettings):
 class Config(BaseSettings):
     NATLAS_VERSION: str = "0.6.12"
     BASEDIR: str = os.path.abspath(os.path.dirname(__file__))
-    DATA_DIR: str = "/data"
     SERVER_NAME: str = Field(default="localhost:5000")
     SECRET_KEY: str = Field(default=secrets.token_urlsafe(64))
     PREFERRED_URL_SCHEME: str = Field(default="https")
-    SQLALCHEMY_DATABASE_URI: str = Field(
-        default=f"sqlite:///{os.path.join(DATA_DIR, 'db', 'metadata.db')}"
-    )
+
+    # We should replace SQLALCHEMY_DATABASE_URI with specific params for the database configuration
+    # The URI is kinda clunky and requires exposing the password in the same variable as the host and database name
+    # Flask-SQLAlchemy also doesn't understand the PostgresDsn type from Pydantic.
+    SQLALCHEMY_DATABASE_URI: str = Field()
     SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
     DB_AUTO_UPGRADE: bool = Field(default=False)
     ELASTICSEARCH_URL: str = Field(default="http://localhost:9200")

--- a/natlas-server/migrations/versions/7099debf8cda_store_start_addr_and_stop_addr_as_.py
+++ b/natlas-server/migrations/versions/7099debf8cda_store_start_addr_and_stop_addr_as_.py
@@ -26,8 +26,8 @@ class ScopeItem(Base):
     id = sa.Column(sa.Integer, primary_key=True)
     target = sa.Column(sa.String(length=128))
     addr_family = sa.Column(sa.Integer)
-    start_addr = sa.Column(sa.VARBINARY(length=16))
-    stop_addr = sa.Column(sa.VARBINARY(length=16))
+    start_addr = sa.Column(sa.LargeBinary(length=16))
+    stop_addr = sa.Column(sa.LargeBinary(length=16))
 
     def parse_network_range(self, network: str):
         net = IPNetwork(network)
@@ -42,10 +42,10 @@ def upgrade():
     with op.batch_alter_table("scope_item", schema=None) as batch_op:
         batch_op.add_column(sa.Column("addr_family", sa.Integer(), nullable=True))
         batch_op.add_column(
-            sa.Column("start_addr", sa.VARBINARY(length=16), nullable=True)
+            sa.Column("start_addr", sa.LargeBinary(length=16), nullable=True)
         )
         batch_op.add_column(
-            sa.Column("stop_addr", sa.VARBINARY(length=16), nullable=True)
+            sa.Column("stop_addr", sa.LargeBinary(length=16), nullable=True)
         )
 
     bind = op.get_bind()

--- a/natlas-server/migrations/versions/ed2f92f790d3_users_table.py
+++ b/natlas-server/migrations/versions/ed2f92f790d3_users_table.py
@@ -22,7 +22,7 @@ def upgrade():
         "user",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("email", sa.String(length=254), nullable=True),
-        sa.Column("password_hash", sa.String(length=128), nullable=True),
+        sa.Column("password_hash", sa.String(length=256), nullable=True),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_index(op.f("ix_user_email"), "user", ["email"], unique=True)


### PR DESCRIPTION
**THIS CHANGE IS NOT BACKWARDS COMPATIBLE**

This change sets up Postgres to be the only supported database for Natlas going forward. In order to do this, I had to modify some old migrations. This isn't ideal, and realistically I'm probably going to tear down all the migrations and create a new set of migrations from scratch before I do another "release."

This furthers the total backwards incompatibility between the current tagged version and the next release, but enables a bunch of useful features and simplifies the application to not require having a volume mounted.

## Upgrading

If you have an existing Natlas installation, you can _mostly_ export the data from your tables and then import them into a postgres database after running migrations. The only changes that were needed at this time were to change VARBINARY to LargeBinary, and to change the password_hash length to 256, because postgres will not do string truncation and the hash is ~163 characters long.