### PR TITLE
Improve docker compose, mypy config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,11 @@ services:
       POSTGRES_DB: "natlas"
     networks:
       - backend
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   zipkin:
     image: openzipkin/zipkin-slim:3.1.0
@@ -118,7 +123,6 @@ services:
       - DB_AUTO_UPGRADE=True
     env_file: .env
     volumes:
-      - ns-data:/data
       - ./natlas-server:/opt/natlas/natlas-server
       - html_assets:/opt/natlas/natlas-server/static/dist
     links:
@@ -131,7 +135,7 @@ services:
       elastic:
         condition: service_healthy
       postgres:
-        condition: service_started
+        condition: service_healthy
 
 
   agent:
@@ -154,7 +158,6 @@ networks:
   backend:
 
 volumes:
-  ns-data:
   elastic:
   node_modules:
   html_assets:

--- a/natlas-server/config.py
+++ b/natlas-server/config.py
@@ -83,8 +83,7 @@ class Config(BaseSettings):
     # By capitalizing this, we can technically access this object from flask's app.config
     # I'm not certain I want to keep using flask's app.config or just move to using this config directly
     # But for now I'll maintain the pattern. `app.config['s3']` yields an S3Settings object.
-    # Additionally, the settings load from environment, but mypy doesn't understand that.
-    S3: S3Settings = S3Settings()  # type: ignore[call-arg]
+    S3: S3Settings = S3Settings()
 
     @model_validator(mode="after")
     def override_version(self) -> Self:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,17 @@ exclude = [
 files = "."
 local_partial_types = true
 mypy_path = "mypy_stubs"
-no_implicit_reexport = false
+no_implicit_reexport = true
+plugins = ["pydantic.mypy"]
 pretty = false
 strict = true
 strict_optional = true
 warn_unreachable = true
-warn_unused_configs = true
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
 
 [tool.ruff]
 


### PR DESCRIPTION
This adds the healthcheck for postgres, removes the unused data volume for natlas server, and adds some mypy config changes to better support pydantic.

One of the configs I added for pydantic seems like it might be slowing mypy down quite a bit, though. If it becomes too painful I'll have to revisit to figure out what's going on.