### PR TITLE
Cache images we send from s3

### DIFF
--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -47,7 +47,12 @@ def send_media(filename: str) -> Response:
         response = storage.get_object(
             bucket_name=s3_config.bucket, object_name=filename
         )
-        return Response(response.read(), status=200, mimetype=mime, content_type=mime)
+        flask_response = Response(
+            response.read(), status=200, mimetype=mime, content_type=mime
+        )
+        # 86400 == 1 day. This should balance reducing server load and overloading the browser cache with images
+        flask_response.headers["Cache-Control"] = "public, max-age=86400, immutable"
+        return flask_response
     finally:
         response.close()
         response.release_conn()


### PR DESCRIPTION
Since all images are going to be served via the flask application now, we should set up some caching so that the browser doesn't download duplicates. We set the timeout to one day, which should be somewhat reasonable to balance the cache size and the server load. In most use cases, you probably won't need to reload the same images more than a day later, or if you do, it'll be in smaller views rather than the homepage that shows potentially hundreds of images in one page load.