### PR TITLE
Revamp the work API internals

### DIFF
--- a/natlas-server/app/models/agent_script.py
+++ b/natlas-server/app/models/agent_script.py
@@ -4,12 +4,16 @@ from sqlalchemy.orm import Mapped, mapped_column
 from app import NatlasBase, db
 from app.models.dict_serializable import DictSerializable
 
+# TODO: This whole table can be replaced with an array field on the AgentConfig table
+
 
 # Scripts for agents to run
 # These will be named according to the command line value that gets passed to nmap
 # groups of scripts are also accepted, such as "safe" and "default"
 # auth, broadcast, default, discovery, dos, exploit, external, fuzzer, intrusive, malware, safe, version, vuln
 # https://nmap.org/book/nse-usage.html#nse-categories
+
+
 class AgentScript(NatlasBase, DictSerializable):
     __tablename__ = "agent_script"
 


### PR DESCRIPTION
The `getwork` API currently does some annoying dict building to determine what to return. This replaces that process with a pydantic model that we dump to json at the moment we return the response, ensuring type information is available for as long as possible within the server.

This also switches from using the `current_app` in-memory values to just querying the database for a specific record for the services and agent config. While not my favorite, it's not that big a deal and it means that it's one less thing in the web worker memory to get out of sync when we have multiple workers running.

There's definitely some improvements to be made, in part in the underlying database models, in part using enums instead of magic values everywhere, and in part improving the ability to just automatically serialize my models without having to do this weird `**Model.as_dict()` pattern into a serializer constructor.

But as of right now, `/api/getwork` returns the exact same content as before this PR, just in a less annoying way.

