### PR TITLE
Change elastic interface calling convention

### DIFF
--- a/natlas-server/app/__init__.py
+++ b/natlas-server/app/__init__.py
@@ -38,6 +38,7 @@ db = SQLAlchemy(model_class=NatlasBase)
 migrate = Migrate()
 csrf = CSRFProtect()
 scope_manager = ScopeManager()
+elastic = ElasticInterface()
 
 
 @login.unauthorized_handler  # type: ignore[misc]
@@ -74,13 +75,7 @@ def create_app(config_class=config.Config, migrating=False):  # type: ignore[no-
         )
 
     app.jinja_env.add_extension("jinja2.ext.do")
-    app.elastic = ElasticInterface(  # type: ignore[attr-defined]
-        app.config["ELASTICSEARCH_URL"],
-        app.config["ELASTIC_AUTH_ENABLE"],
-        app.config["ELASTIC_USER"],
-        app.config["ELASTIC_PASSWORD"],
-    )
-
+    elastic.init_app(app)
     login.init_app(app)
     mail.init_app(app)
     csrf.init_app(app)

--- a/natlas-server/app/admin/routes.py
+++ b/natlas-server/app/admin/routes.py
@@ -14,7 +14,7 @@ from flask_login import current_user, login_required
 from sqlalchemy import select
 from werkzeug.wrappers.response import Response as wzResponse
 
-from app import db, scope_manager
+from app import db, elastic, scope_manager
 from app.admin import bp, forms, redirects
 from app.auth.wrappers import is_admin
 from app.models import (
@@ -438,7 +438,7 @@ def delete_scan(scan_id: str) -> wzResponse:
     redirectLoc = url_for("main.browse")
 
     if delForm.validate_on_submit():
-        deleted = current_app.elastic.delete_scan(scan_id)  # type: ignore[attr-defined]
+        deleted = elastic.delete_scan(scan_id)
         if deleted not in [1, 2]:
             flash(f"Couldn't delete scan {scan_id}!", "danger")
         else:
@@ -457,7 +457,7 @@ def delete_host(ip: str) -> wzResponse | None:
     redirectLoc = url_for("main.browse")
 
     if delForm.validate_on_submit():
-        deleted = current_app.elastic.delete_host(ip)  # type: ignore[attr-defined]
+        deleted = elastic.delete_host(ip)
         if deleted > 0:
             flash(
                 f"Successfully deleted {deleted - 1 if deleted > 1 else deleted} scans for {ip}.",

--- a/natlas-server/app/api/prepare_work.py
+++ b/natlas-server/app/api/prepare_work.py
@@ -1,9 +1,8 @@
 import secrets
 
-from flask import current_app
 from pydantic import BaseModel
 
-from app import db
+from app import db, elastic
 from app.models import AgentConfig, NatlasServices, ScopeItem
 from app.models.agent_script import AgentScript
 
@@ -22,7 +21,7 @@ def get_unique_scan_id() -> str:
     scan_id = ""
     while scan_id == "":
         rand = secrets.token_hex(16)
-        count, context = current_app.elastic.get_host_by_scan_id(rand)  # type: ignore[attr-defined]
+        count, context = elastic.get_host_by_scan_id(rand)
         if count == 0:
             scan_id = rand
     return scan_id

--- a/natlas-server/app/api/prepare_work.py
+++ b/natlas-server/app/api/prepare_work.py
@@ -47,7 +47,7 @@ class AgentConfigSerializer(BaseModel):
 
 
 class AgentWork(BaseModel):
-    reason: str
+    scan_reason: str
     target: str
     tags: list[str]
     type: str = "nmap"
@@ -67,7 +67,7 @@ def prepare_work(reason: str, target: str) -> AgentWork:
         raise RuntimeError("We have no agent config! What happened?!")
 
     return AgentWork(
-        reason=reason,
+        scan_reason=reason,
         target=target,
         tags=get_target_tags(target),
         type="nmap",

--- a/natlas-server/app/api/routes.py
+++ b/natlas-server/app/api/routes.py
@@ -6,7 +6,7 @@ import dateutil.parser
 from flask import Response, current_app, jsonify, request
 from libnmap.parser import NmapParser, NmapParserException
 
-from app import scope_manager
+from app import elastic, scope_manager
 from app.api import bp
 from app.api.prepare_work import prepare_work
 from app.api.processing.screenshot import process_screenshots
@@ -120,7 +120,7 @@ def submit() -> Response:
 
         # If there's no further processing to do, store the host and prepare the response
         elif not newhost["is_up"] or (newhost["is_up"] and newhost["port_count"] == 0):
-            current_app.elastic.new_result(newhost)  # type: ignore[attr-defined]
+            elastic.new_result(newhost)
             status_code = 200
             response_body = json.dumps(
                 {"status": status_code, "message": "Received: " + newhost["ip"]}
@@ -193,7 +193,7 @@ def submit() -> Response:
         )
     else:
         status_code = 200
-        current_app.elastic.new_result(newhost)  # type: ignore[attr-defined]
+        elastic.new_result(newhost)
         response_body = json.dumps(
             {
                 "status": status_code,
@@ -233,7 +233,7 @@ def status() -> Response:
     completed_cycles = scope_manager.get_completed_cycle_count()
     avg_cycle_time = None
     if last_cycle_start:
-        scans_this_cycle = current_app.elastic.count_scans_since(last_cycle_start)  # type: ignore[attr-defined]
+        scans_this_cycle = elastic.count_scans_since(last_cycle_start)
         if completed_cycles > 0 and scope_manager.init_time is not None:
             delta = (last_cycle_start - scope_manager.init_time) / completed_cycles
             avg_cycle_time = pretty_time_delta(delta)

--- a/natlas-server/app/elastic/interface.py
+++ b/natlas-server/app/elastic/interface.py
@@ -2,6 +2,8 @@ import random
 import sys
 from datetime import datetime
 
+from flask import Flask
+
 from app.elastic.client import ElasticClient
 from app.elastic.indices import ElasticIndices
 
@@ -10,21 +12,14 @@ class ElasticInterface:
     client: ElasticClient
     indices: ElasticIndices
 
-    def __init__(
-        self,
-        elasticUrl: str,
-        authEnabled: bool,
-        elasticUser: str,
-        elasticPassword: str,
-        basename: str = "nmap",
-    ):
+    def init_app(self, app: Flask) -> None:
         self.client = ElasticClient(
-            elasticUrl,
-            authEnabled=authEnabled,
-            elasticUser=elasticUser,
-            elasticPassword=elasticPassword,
+            elasticURL=app.config["ELASTICSEARCH_URL"],
+            authEnabled=app.config["ELASTIC_AUTH_ENABLE"],
+            elasticUser=app.config["ELASTIC_USER"],
+            elasticPassword=app.config["ELASTIC_PASSWORD"],
         )
-        self.indices = ElasticIndices(self.client, basename)
+        self.indices = ElasticIndices(self.client, "nmap")
 
     def search(  # type: ignore[no-untyped-def]
         self, limit: int, offset: int, query: str = "nmap", searchIndex: str = "latest"

--- a/natlas-server/app/host/routes.py
+++ b/natlas-server/app/host/routes.py
@@ -14,7 +14,7 @@ from flask import (
 )
 from flask_login import current_user, login_required
 
-from app import db, scope_manager
+from app import db, elastic, scope_manager
 from app.admin.forms import DeleteForm
 from app.auth.wrappers import is_authenticated
 from app.host import bp
@@ -55,7 +55,7 @@ def host_history(ip: str) -> str:
     delHostForm = DeleteForm()
     rescanForm = RescanForm()
 
-    count, context = current_app.elastic.get_host_history(  # type: ignore[attr-defined]
+    count, context = elastic.get_host_history(
         ip, current_user.results_per_page, searchOffset
     )
     if count == 0:
@@ -89,7 +89,7 @@ def host_historical_result(ip: str, scan_id: str) -> str:
     delHostForm = DeleteForm()
     rescanForm = RescanForm()
     info, context = hostinfo(ip)
-    count, context = current_app.elastic.get_host_by_scan_id(scan_id)  # type: ignore[attr-defined]
+    count, context = elastic.get_host_by_scan_id(scan_id)
 
     version = determine_data_version(context)
     template_str = f"host/versions/{version}/summary.html"
@@ -113,7 +113,7 @@ def export_scan(ip: str, scan_id: str, ext: str) -> Response:
     export_field = f"{ext}_data"
 
     mime = "application/json" if ext == "json" else "text/plain"
-    count, context = current_app.elastic.get_host_by_scan_id(scan_id)  # type: ignore[attr-defined]
+    count, context = elastic.get_host_by_scan_id(scan_id)
     if ext == "json" and count > 0:
         return jsonify(context)
     if count > 0 and export_field in context:
@@ -132,7 +132,7 @@ def host_screenshots(ip: str) -> str:
     delHostForm = DeleteForm()
     rescanForm = RescanForm()
     info, context = hostinfo(ip)
-    total_entries, screenshots = current_app.elastic.get_host_screenshots(  # type: ignore[attr-defined]
+    total_entries, screenshots = elastic.get_host_screenshots(
         ip, current_user.results_per_page, searchOffset
     )
 
@@ -201,7 +201,7 @@ def rescan_host(ip: str) -> werkzeug.wrappers.response.Response:
 @bp.route("/random")
 @is_authenticated
 def random_host() -> str:
-    random_host = current_app.elastic.random_host()  # type: ignore[attr-defined]
+    random_host = elastic.random_host()
     # This would most likely occur when there are no hosts up in the index, so just throw a 404
     if not random_host:
         return abort(404)

--- a/natlas-server/app/host/summarizers.py
+++ b/natlas-server/app/host/summarizers.py
@@ -1,13 +1,15 @@
-from flask import abort, current_app
+from flask import abort
+
+from app import elastic
 
 
 def hostinfo(ip: str):  # type: ignore[no-untyped-def]
     hostinfo = {}
-    count, context = current_app.elastic.get_host(ip)  # type: ignore[attr-defined]
+    count, context = elastic.get_host(ip)  # type: ignore[attr-defined]
     if count == 0:
         return abort(404)
     hostinfo["history"] = count
-    screenshot_count = current_app.elastic.count_host_screenshots(ip)  # type: ignore[attr-defined]
+    screenshot_count = elastic.count_host_screenshots(ip)  # type: ignore[attr-defined]
     hostinfo["screenshot_count"] = screenshot_count
     screenshots = 0
     screenshotTypes = [

--- a/natlas-server/app/main/routes.py
+++ b/natlas-server/app/main/routes.py
@@ -12,6 +12,7 @@ from flask import (
 from flask_login import current_user
 from minio import Minio
 
+from app import elastic
 from app.auth.forms import LoginForm, RegistrationForm
 from app.auth.wrappers import is_authenticated
 from app.errors import NatlasSearchError
@@ -71,10 +72,10 @@ def browse() -> str:
 
     searchIndex = "history" if includeHistory else "latest"
 
-    count, hostdata = current_app.elastic.search(  # type: ignore[attr-defined]
+    count, hostdata = elastic.search(
         results_per_page, search_offset, searchIndex=searchIndex
     )
-    totalHosts = current_app.elastic.total_hosts()  # type: ignore[attr-defined]
+    totalHosts = elastic.total_hosts()
 
     if includeHistory:
         next_url, prev_url = build_pagination_urls(
@@ -114,13 +115,13 @@ def search() -> Response | str:
     searchIndex = "history" if includeHistory else "latest"
 
     try:
-        count, context = current_app.elastic.search(  # type: ignore[attr-defined]
+        count, context = elastic.search(
             results_per_page, search_offset, query=query, searchIndex=searchIndex
         )
     except elasticsearch.RequestError as e:
         raise NatlasSearchError(e) from e
 
-    totalHosts = current_app.elastic.total_hosts()  # type: ignore[attr-defined]
+    totalHosts = elastic.total_hosts()
 
     if includeHistory:
         next_url, prev_url = build_pagination_urls(
@@ -167,7 +168,7 @@ def screenshots() -> str:
 
     results_per_page, search_offset = results_offset(page)
 
-    total_hosts, total_screenshots, hosts = current_app.elastic.get_current_screenshots(  # type: ignore[attr-defined]
+    total_hosts, total_screenshots, hosts = elastic.get_current_screenshots(
         results_per_page, search_offset
     )
 

--- a/natlas-server/tests/elastic/conftest.py
+++ b/natlas-server/tests/elastic/conftest.py
@@ -1,26 +1,23 @@
 import pytest
 from app.elastic import ElasticInterface
-from tests.config import test_config
+from app.elastic.client import ElasticClient
+from app.elastic.indices import ElasticIndices
+from flask import current_app
 
 
-def reset_indices(indices):  # type: ignore[no-untyped-def]
+def reset_indices(indices: ElasticIndices) -> None:
     indices._delete_indices()
     indices._initialize_indices()
 
 
 @pytest.fixture(scope="module")
 def esinterface():  # type: ignore[no-untyped-def]
-    esi = ElasticInterface(
-        test_config.ELASTICSEARCH_URL,
-        True,
-        "elastic",
-        "natlas-dev-password-do-not-use",
-        "natlas_test",
-    )
+    esi = ElasticInterface()
+    esi.init_app(current_app)
     yield esi
     reset_indices(esi.indices)
 
 
 @pytest.fixture(scope="module")
-def esclient(esinterface):  # type: ignore[no-untyped-def]
+def esclient(esinterface: ElasticInterface) -> ElasticClient:
     return esinterface.client


### PR DESCRIPTION
Attaching things to the app instance makes mypy mad, and makes the DX bad.

Instead, treat the elastic interface similar to how we treat db, scope manager, login, etc. Which is that the process gets one instance that just gets imported everywhere. This is functionally no different, I think, than attaching one instance to app and then only accessing it through `current_app`. 

The elastic types themselves are still messy because I am dealing with a lot of dicts. But we'll get there.